### PR TITLE
host_window: add REIMS_VGPU_FULLSCREEN presentation preference

### DIFF
--- a/crates/reims-vgpu/examples/host_window_smoke.rs
+++ b/crates/reims-vgpu/examples/host_window_smoke.rs
@@ -50,6 +50,9 @@ fn main() {
             title: "reims_vgpu host-window smoke".to_string(),
             width: w,
             height: h,
+            // A smoke test stays windowed: it is a present-path check, and a
+            // fullscreen mode change would only add a window-system interaction.
+            fullscreen: false,
         },
         on_input,
         frames,

--- a/crates/reims-vgpu/src/device/window_publish.rs
+++ b/crates/reims-vgpu/src/device/window_publish.rs
@@ -164,6 +164,7 @@ pub fn device_window_start(id: u64, width: u32, height: u32) -> bool {
         } else {
             height
         },
+        fullscreen: crate::env::switch(crate::env::FULLSCREEN) == crate::env::Switch::On,
     };
     let stop: crate::host_window::present::StopFlag =
         Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/reims-vgpu/src/env.rs
+++ b/crates/reims-vgpu/src/env.rs
@@ -859,6 +859,25 @@ pub const PASS_CHURN: &str = "REIMS_VGPU_PASS_CHURN";
 /// settle it, and the arm and its `bext_*` census stay so that they can.
 pub const EXTENT_NARROW: &str = "REIMS_VGPU_EXTENT_NARROW";
 
+/// `on` opens the host presentation window borderless fullscreen instead of
+/// windowed, on the monitor winit picks.
+///
+/// A host-side presentation preference and nothing else. It changes the
+/// geometry of the window the device presents into — never the frames it
+/// presents, never a rail the guest observes, never what the device is
+/// capable of. The guest framebuffer, the pointer mapping and the
+/// `WindowConfig` size all stay exactly what they would be in a window; the
+/// window system just places the window over the whole display, without
+/// decorations.
+///
+/// It is read by `host_window::present` at window creation, which is why it
+/// is the only variable here that names a presentation mode rather than a
+/// device rail. Default off, because a windowed window is the state an
+/// operator can inspect and leave alone; `on` is the state a VM is *used*
+/// in. Like every on-switch in this module it adds host-side work (a
+/// fullscreen mode change) and can never grant the device a capability.
+pub const FULLSCREEN: &str = "REIMS_VGPU_FULLSCREEN";
+
 /// What one variable says, including the two ways it says nothing usable.
 ///
 /// Four states rather than a `bool` because "unset", "explicitly on" and
@@ -932,7 +951,7 @@ pub fn switch(name: &str) -> Switch {
 /// Nothing enforces that a new `pub const` above is added to this list; the rule
 /// is stated and honestly unenforced. What keeps it small is that the list is
 /// next to the constants, and [`report_line`] is the only consumer.
-pub const ALL: [&str; 20] = [
+pub const ALL: [&str; 21] = [
     LAZY_WRITEBACK,
     SLAB_RETAIN,
     CLEAR_SEED,
@@ -958,6 +977,7 @@ pub const ALL: [&str; 20] = [
     LAYOUT_CHURN,
     PASS_CHURN,
     EXTENT_NARROW,
+    FULLSCREEN,
 ];
 
 /// The state of every variable in [`ALL`], for the one-shot boot line.

--- a/crates/reims-vgpu/src/host_window/present.rs
+++ b/crates/reims-vgpu/src/host_window/present.rs
@@ -34,7 +34,7 @@ use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::PhysicalKey;
-use winit::window::{Window, WindowId};
+use winit::window::{Fullscreen, Window, WindowId};
 
 use super::input_map;
 use crate::runtime::host::HostAction;
@@ -110,6 +110,11 @@ pub struct WindowConfig {
     pub title: String,
     pub width: u32,
     pub height: u32,
+    /// Ask winit for a borderless fullscreen window (`REIMS_VGPU_FULLSCREEN`).
+    /// A presentation-mode preference only: the window system places the
+    /// window over the display, and nothing about the frames, the guest or
+    /// the pointer mapping changes.
+    pub fullscreen: bool,
 }
 
 impl Default for WindowConfig {
@@ -118,7 +123,22 @@ impl Default for WindowConfig {
             title: "Reims vGPU".to_string(),
             width: 1280,
             height: 800,
+            fullscreen: false,
         }
+    }
+}
+
+/// The fullscreen request this config asks winit for: borderless on the
+/// current monitor when [`WindowConfig::fullscreen`] is set, nothing
+/// otherwise.
+///
+/// Split out from `resumed` so the decision is testable without an event
+/// loop, and so the two spellings (windowed / fullscreen) cannot drift.
+fn fullscreen_request(config: &WindowConfig) -> Option<Fullscreen> {
+    if config.fullscreen {
+        Some(Fullscreen::Borderless(None))
+    } else {
+        None
     }
 }
 
@@ -755,7 +775,8 @@ impl ApplicationHandler<FramePublished> for App {
             .with_inner_size(winit::dpi::PhysicalSize::new(
                 self.config.width,
                 self.config.height,
-            ));
+            ))
+            .with_fullscreen(fullscreen_request(&self.config));
         let window = match event_loop.create_window(attrs) {
             Ok(w) => Arc::new(w),
             Err(e) => {
@@ -1673,5 +1694,29 @@ mod tests {
     #[test]
     fn a_resize_with_nothing_pending_is_not_an_answer() {
         assert_eq!(guest_resize_settled(None, (1920, 1080)), None);
+    }
+
+    /// The fullscreen preference maps to exactly one winit request: borderless
+    /// on the current monitor, or nothing at all. A windowed config that asks
+    /// for a fullscreen mode, or a fullscreen config that asks for none, is
+    /// the branch inverted — and the windowed spelling is the one every
+    /// default boot takes.
+    #[test]
+    fn a_fullscreen_config_requests_borderless_fullscreen_and_only_then() {
+        let mut config = WindowConfig::default();
+        assert!(
+            fullscreen_request(&config).is_none(),
+            "the default window must not request fullscreen"
+        );
+        config.fullscreen = true;
+        assert!(
+            matches!(
+                fullscreen_request(&config),
+                Some(Fullscreen::Borderless(None))
+            ),
+            "a fullscreen config must request borderless on the current monitor"
+        );
+        config.fullscreen = false;
+        assert!(fullscreen_request(&config).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- adds `WindowConfig.fullscreen` and a `REIMS_VGPU_FULLSCREEN` env switch
- `on` requests a borderless fullscreen window from winit on the monitor it picks, at window creation
- default stays windowed (off)

This is a host-side presentation preference only. It changes the geometry of the window the device presents into — it does not touch the frames presented, the guest framebuffer, the pointer mapping, or `WindowConfig` size. Nothing about device capability changes.

## Verification

- `cargo build -p reims-vgpu --no-default-features --features backend-vulkan,host-window`: clean
- `cargo test -p reims-vgpu --no-default-features --features backend-vulkan,host-window --lib host_window::present::tests -- --test-threads=1`: 12 passed (11 existing + 1 new)
- `cargo clippy -p reims-vgpu --no-default-features --features backend-vulkan,host-window --all-targets -- -D warnings`: clean

New test: `a_fullscreen_config_requests_borderless_fullscreen_and_only_then` — checks the config→request mapping is exactly one-to-one (default windowed, `fullscreen: true` → `Fullscreen::Borderless(None)`, and back).