### PR TITLE
Vulkan: declare every descriptor slot shaders read (crash/garbage-pixel fix) + Vulkan12Features + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,22 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 45
     # Advisory, not a merge gate. These three suites execute real Vulkan work.
-    # On a GPU-less runner with no ICD they self-skip (skip_if_no_gpu turns an
-    # init failure into a printed SKIP and returns ok), so they would prove
-    # nothing; with the lavapipe software ICD installed below they run for real,
-    # because caps/device_select.rs ranks PHYSICAL_DEVICE_TYPE_CPU last but does
-    # not reject it, and lavapipe clears the Vulkan 1.2 floor in caps/api_floor.rs.
-    # Whether they pass on llvmpipe has never been established on any host, and
-    # AGENTS.md documents them as order-dependent with a device-recreate ceiling.
-    # Promote this job to blocking (drop continue-on-error) after a green run.
+    # With no ICD they self-skip (skip_if_no_gpu turns an init failure into a
+    # printed SKIP and returns ok) and would prove nothing; with the lavapipe
+    # software ICD installed below they run for real, because
+    # caps/device_select.rs ranks PHYSICAL_DEVICE_TYPE_CPU last but does not
+    # reject it, and lavapipe clears the Vulkan 1.2 floor in caps/api_floor.rs.
+    #
+    # Measured on this runner: zero skip_if_no_gpu skips, so lavapipe executes
+    # the whole suite. vk_engine_batch 6/6 and vk_engine_compute 14/14 pass;
+    # vk_engine_parity is 43 passed / 1 failed. The one failure is
+    # framebuffer_fetch_reads_destination_via_input_attachment, which reads back
+    # (0,0,0,2) where the seeded destination (191,127,64,255) is due -- an
+    # input-attachment read that llvmpipe does not serve the way hardware does.
+    # It is left failing rather than excluded by name: that case is the arm64
+    # MoltenVK GPU-address-fault regression guard, and calling it a software
+    # rasterizer limitation is a claim no run on this runner can settle.
+    # Promote to blocking once it is scored on a hardware GPU runner.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Install Vulkan loader + lavapipe ICD
+      - name: Install Vulkan loader, lavapipe ICD and LLVM
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y mesa-vulkan-drivers libvulkan1
+          # llvm provides llvm-dis, which the MTLB -> AIR -> SPIR-V translate path
+          # shells out to. Without it the first case panics before it reaches
+          # Vulkan at all, and because that panic is taken while the shared
+          # engine lock is held, every later case in the same binary fails with
+          # PoisonError -- one missing tool reported as a whole-suite failure.
+          sudo apt-get install -y mesa-vulkan-drivers libvulkan1 llvm spirv-tools
+          command -v llvm-dis
           # Fail setup early if the loader has nothing to bind, rather than
           # letting every case report a confusing mid-suite init failure.
           shopt -s nullglob

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,209 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [dev]
+
+# Least privilege: nothing here writes to the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Fail the build on any rustc warning (unused imports, dead_code, ...).
+  RUSTFLAGS: -D warnings
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-26.04
+    outputs:
+      full: ${{ steps.classify.outputs.full }}
+      rust: ${{ steps.changes.outputs.rust }}
+      cargo: ${{ steps.changes.outputs.cargo }}
+      efi: ${{ steps.changes.outputs.efi }}
+      ci: ${{ steps.changes.outputs.ci }}
+      docs: ${{ steps.changes.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            rust:
+              - 'crates/**/*.rs'
+              - 'crates/**/build.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'rustfmt.toml'
+              - '.config/**'
+            cargo:
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+            efi:
+              - 'crates/reims-vgpu-efi/**'
+            ci:
+              - '.github/workflows/**'
+            docs:
+              - '**/*.md'
+              - 'assets/**'
+              - 'LICENSE'
+      - id: classify
+        name: Classify changes
+        run: |
+          set -eufo pipefail
+          full=false
+          if [[ "${{ steps.changes.outputs.rust }}" == "true" \
+             || "${{ steps.changes.outputs.ci }}" == "true" ]]; then
+            full=true
+          fi
+          echo "full=$full" >> "$GITHUB_OUTPUT"
+          echo "full=$full"
+
+  fmt:
+    name: fmt
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true'
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # merge-base against origin/master needs the full history of both.
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      # master mirrors upstream verbatim and carries formatting drift this fork
+      # does not own: `cargo fmt --all -- --check` reports 14 files, every one of
+      # them byte-identical to master. Reformatting them would add divergence to
+      # every future upstream merge, so the rule enforced here is the one that is
+      # actually ours — every .rs file this branch has touched is rustfmt-clean.
+      # skip_children keeps rustfmt from following `mod` declarations into
+      # untouched siblings and re-reporting that same upstream drift.
+      - name: Formatting (rustfmt, files this branch touches)
+        run: |
+          set -euo pipefail
+          base="$(git merge-base origin/master HEAD)"
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base" HEAD -- '*.rs')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no Rust files changed against origin/master"
+            exit 0
+          fi
+          printf 'checking %s\n' "${files[@]}"
+          rustfmt --edition 2021 --config skip_children=true --check "${files[@]}"
+
+  clippy:
+    name: clippy
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true'
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Default features select backend-metal, which crates/reims-vgpu/src/lib.rs
+      # rejects off Apple with a compile_error!. Every cargo invocation on Linux
+      # must therefore pass --no-default-features --features backend-vulkan.
+      - name: Clippy (warnings denied)
+        run: cargo clippy --workspace --all-targets --no-default-features --features backend-vulkan -- -D warnings
+
+  test:
+    name: test
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # The unit tests and the three integration suites below are pure CPU
+      # decode/planning work and need no Vulkan driver. AGENTS.md requires the
+      # suite to run serially: GPU-touching tests are not parallel-safe.
+      - name: Test (unit)
+        run: cargo test --workspace --no-default-features --features backend-vulkan --lib -- --test-threads=1
+      - name: Test (host integration suites)
+        run: |
+          cargo test --workspace --no-default-features --features backend-vulkan \
+            --test golden_vectors --test reflection_adoption --test reflection_probe \
+            -- --test-threads=1
+
+  vulkan-suite:
+    name: vulkan-suite
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 45
+    # Advisory, not a merge gate. These three suites execute real Vulkan work.
+    # On a GPU-less runner with no ICD they self-skip (skip_if_no_gpu turns an
+    # init failure into a printed SKIP and returns ok), so they would prove
+    # nothing; with the lavapipe software ICD installed below they run for real,
+    # because caps/device_select.rs ranks PHYSICAL_DEVICE_TYPE_CPU last but does
+    # not reject it, and lavapipe clears the Vulkan 1.2 floor in caps/api_floor.rs.
+    # Whether they pass on llvmpipe has never been established on any host, and
+    # AGENTS.md documents them as order-dependent with a device-recreate ceiling.
+    # Promote this job to blocking (drop continue-on-error) after a green run.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install Vulkan loader + lavapipe ICD
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers libvulkan1
+          # Fail setup early if the loader has nothing to bind, rather than
+          # letting every case report a confusing mid-suite init failure.
+          shopt -s nullglob
+          icds=(/usr/share/vulkan/icd.d/*.json /etc/vulkan/icd.d/*.json)
+          echo "Vulkan ICDs: ${icds[*]:-none}"
+          test "${#icds[@]}" -gt 0
+          # Pin the loader to lavapipe by discovery: the packaged basename is
+          # arch-suffixed (lvp_icd.x86_64.json) and must not be hardcoded.
+          lvp=(/usr/share/vulkan/icd.d/lvp_icd*.json)
+          test "${#lvp[@]}" -gt 0
+          echo "VK_DRIVER_FILES=${lvp[0]}" >> "$GITHUB_ENV"
+      - name: Test (Vulkan engine suites)
+        run: |
+          cargo test --workspace --no-default-features --features backend-vulkan \
+            --test vk_engine_parity --test vk_engine_compute --test vk_engine_batch \
+            -- --test-threads=1 --nocapture
+
+  efi-rom:
+    name: efi-rom
+    needs: [preflight]
+    if: needs.preflight.outputs.full == 'true' || needs.preflight.outputs.efi == 'true'
+    runs-on: ubuntu-26.04
+    # crates/reims-vgpu-efi is excluded from the root workspace, so the jobs
+    # above never compile it. It is a release artifact, so build it here.
+    defaults:
+      run:
+        working-directory: crates/reims-vgpu-efi
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-uefi
+          components: rustfmt
+      - name: Formatting (rustfmt)
+        run: cargo fmt --all -- --check
+      - name: Build UEFI option ROM payload
+        run: cargo build --release --target x86_64-unknown-uefi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,30 +142,42 @@ jobs:
             --test golden_vectors --test reflection_adoption --test reflection_probe \
             -- --test-threads=1
 
-  vulkan-suite:
-    name: vulkan-suite
+  # These suites execute real Vulkan work. With no ICD they self-skip
+  # (skip_if_no_gpu turns an init failure into a printed SKIP and returns ok)
+  # and would prove nothing; with the lavapipe software ICD installed below they
+  # run for real, because caps/device_select.rs ranks PHYSICAL_DEVICE_TYPE_CPU
+  # last but does not reject it, and lavapipe clears the Vulkan 1.2 floor in
+  # caps/api_floor.rs. Measured on this runner and independently reproduced on
+  # the x86 dev host (Mesa 25.2.8 / LLVM 20.1.2): zero skips on either.
+  #
+  # gate   -- vk_engine_batch 6/6 and vk_engine_compute 14/14, identical on both
+  #           hosts, so these block.
+  # parity -- 43 passed / 1 failed on both hosts. The failure is
+  #           framebuffer_fetch_reads_destination_via_input_attachment, reading
+  #           back (0,0,0,2) where the seeded (191,127,64,255) is due: an
+  #           input-attachment read llvmpipe does not serve the way hardware
+  #           does. Deterministic, not flaky. It is left failing rather than
+  #           excluded by name because that case guards the arm64 MoltenVK
+  #           GPU-address-fault class, and "llvmpipe's fault" is a claim two
+  #           lavapipe hosts cannot settle between them. Score it on a hardware
+  #           GPU runner, then drop continue-on-error.
+  vulkan:
+    name: vulkan (${{ matrix.suite }})
     needs: [preflight]
     if: needs.preflight.outputs.full == 'true'
     runs-on: ubuntu-26.04
     timeout-minutes: 45
-    # Advisory, not a merge gate. These three suites execute real Vulkan work.
-    # With no ICD they self-skip (skip_if_no_gpu turns an init failure into a
-    # printed SKIP and returns ok) and would prove nothing; with the lavapipe
-    # software ICD installed below they run for real, because
-    # caps/device_select.rs ranks PHYSICAL_DEVICE_TYPE_CPU last but does not
-    # reject it, and lavapipe clears the Vulkan 1.2 floor in caps/api_floor.rs.
-    #
-    # Measured on this runner: zero skip_if_no_gpu skips, so lavapipe executes
-    # the whole suite. vk_engine_batch 6/6 and vk_engine_compute 14/14 pass;
-    # vk_engine_parity is 43 passed / 1 failed. The one failure is
-    # framebuffer_fetch_reads_destination_via_input_attachment, which reads back
-    # (0,0,0,2) where the seeded destination (191,127,64,255) is due -- an
-    # input-attachment read that llvmpipe does not serve the way hardware does.
-    # It is left failing rather than excluded by name: that case is the arm64
-    # MoltenVK GPU-address-fault regression guard, and calling it a software
-    # rasterizer limitation is a claim no run on this runner can settle.
-    # Promote to blocking once it is scored on a hardware GPU runner.
-    continue-on-error: true
+    continue-on-error: ${{ matrix.advisory }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: gate
+            tests: --test vk_engine_batch --test vk_engine_compute
+            advisory: false
+          - suite: parity
+            tests: --test vk_engine_parity
+            advisory: true
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust toolchain
@@ -194,10 +206,14 @@ jobs:
           lvp=(/usr/share/vulkan/icd.d/lvp_icd*.json)
           test "${#lvp[@]}" -gt 0
           echo "VK_DRIVER_FILES=${lvp[0]}" >> "$GITHUB_ENV"
-      - name: Test (Vulkan engine suites)
+          # llvmpipe codegen decides the parity result above, so record what
+          # produced it: a Mesa or LLVM bump can move that verdict either way.
+          dpkg-query -W -f='mesa-vulkan-drivers ${Version}\n' mesa-vulkan-drivers
+          llvm-dis --version | head -2
+      - name: Test (${{ matrix.suite }})
         run: |
           cargo test --workspace --no-default-features --features backend-vulkan \
-            --test vk_engine_parity --test vk_engine_compute --test vk_engine_batch \
+            ${{ matrix.tests }} \
             -- --test-threads=1 --nocapture
 
   efi-rom:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# The release job publishes a GitHub Release, so it needs write access to
+# repository contents. Nothing else here does.
+permissions:
+  contents: read
+
+# Never cancel a half-finished release: a cancelled QEMU build would leave the
+# tag with a partial or missing artifact set.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-26.04
+    # The vendored QEMU build dominates this job; the ROM is minutes.
+    timeout-minutes: 180
+    permissions:
+      contents: write
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v7
+        with:
+          # vendor/qemu is a submodule and is the product being built here.
+          # QEMU carries its own submodules (keycodemapdb and friends), so this
+          # has to be recursive.
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # libgcrypt20-dev backs --enable-gcrypt (VNC password auth needs DES).
+          # llvm provides llvm-dis, which the shader path shells out to at
+          # runtime and which the post-build device probes exercise.
+          sudo apt-get install -y \
+            build-essential pkg-config python3 python3-venv \
+            libglib2.0-dev libpixman-1-dev ninja-build meson \
+            libvulkan-dev libgcrypt20-dev nettle-dev llvm
+          command -v llvm-dis
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-uefi
+
+      # Cargo registry and the two Rust target dirs only. The QEMU build tree
+      # (vendor/qemu/build) is deliberately not cached: qemu-build.sh keys a
+      # reconfigure off build/qemu-build.stamp, and a restored tree from a
+      # different commit would be reused rather than rebuilt.
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: |
+            .
+            crates/reims-vgpu-efi
+
+      # Built first: it takes minutes and fails fast, ahead of the long build.
+      - name: Build EFI GOP option ROM
+        run: crates/reims-vgpu-efi/scripts/reims-vgpu-efi-rom/reims-vgpu-efi-rom.sh
+
+      # REIMS_VGPU_BACKEND must be set: without it qemu-build.sh picks the
+      # backend from the host OS, and backend-metal does not build off Apple.
+      # --backend vulkan passes the same value; both are set so neither the
+      # environment nor the argument can drift alone.
+      - name: Build patched QEMU (x86_64, Vulkan backend)
+        env:
+          REIMS_VGPU_BACKEND: vulkan
+        run: scripts/qemu-build/qemu-build.sh --target x86_64 --backend vulkan
+
+      - name: Collect artifacts and checksums
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp vendor/qemu/build/qemu-system-x86_64 dist/
+          cp crates/reims-vgpu-efi/out/reims-vgpu-gop.rom dist/
+          # Relative names so `sha256sum -c SHA256SUMS` works where downloaded.
+          (cd dist && sha256sum qemu-system-x86_64 reims-vgpu-gop.rom > SHA256SUMS)
+          cat dist/SHA256SUMS
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: reims-vgpu-x86_64-vulkan
+          path: dist/
+          if-no-files-found: error
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          draft: false
+          generate_release_notes: true
+          files: |
+            dist/qemu-system-x86_64
+            dist/reims-vgpu-gop.rom
+            dist/SHA256SUMS

--- a/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
@@ -302,11 +302,17 @@ impl DeviceFeatures {
     /// rung; on [`MirrorClampToEdge::KhrExtension`] the extension string carries
     /// it instead, and on [`MirrorClampToEdge::Unsupported`] nothing is
     /// requested and the sampler path declines.
+    /// Carries float16/int8 and 8-bit storage as well: the spec forbids their
+    /// standalone structures in a pNext chain that already has this one, and
+    /// every field they set lives here from Vulkan 1.2 onward.
     pub fn enabled_vulkan12(&self) -> vk::PhysicalDeviceVulkan12Features<'static> {
         vk::PhysicalDeviceVulkan12Features::default()
             .shader_output_viewport_index(self.shader_output_viewport_index)
             .timeline_semaphore(self.timeline_semaphore)
             .sampler_mirror_clamp_to_edge(self.mirror_clamp_to_edge == MirrorClampToEdge::Core12)
+            .shader_float16(self.float16)
+            .shader_int8(self.int8)
+            .storage_buffer8_bit_access(self.storage8)
     }
 
     /// 16-bit storage-buffer access, for shaders that pack half-precision data.

--- a/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
@@ -129,6 +129,11 @@ pub struct DeviceFeatures {
     /// it has a packed 24/8 depth format will name one.
     pub d24_unorm_s8_attachment: bool,
     pub shader_int16: bool,
+    /// Metal AIR routinely lowers to 64-bit integer ops, so translated SPIR-V
+    /// declares the `Int64` capability. A device that was never told to enable
+    /// the matching feature compiles it anyway and is then free to do anything:
+    /// NVIDIA copes, lavapipe null-dereferences inside its shader JIT.
+    pub shader_int64: bool,
     pub storage_image_extended_formats: bool,
     pub storage_image_write_without_format: bool,
     /// `shaderStorageImageReadWithoutFormat`. The read half of the pair above:
@@ -280,6 +285,7 @@ impl DeviceFeatures {
             .robust_buffer_access(self.robust_buffer_access)
             .sampler_anisotropy(self.sampler_anisotropy)
             .shader_int16(self.shader_int16)
+            .shader_int64(self.shader_int64)
             .shader_storage_image_extended_formats(self.storage_image_extended_formats)
             .shader_storage_image_write_without_format(self.storage_image_write_without_format)
             .shader_storage_image_read_without_format(self.storage_image_read_without_format)
@@ -349,6 +355,7 @@ impl DeviceFeatures {
             max_sample_count,
             d24_unorm_s8_attachment,
             shader_int16,
+            shader_int64,
             storage_image_extended_formats,
             storage_image_write_without_format,
             storage_image_read_without_format,
@@ -390,7 +397,7 @@ impl DeviceFeatures {
              max_compute_workgroup_size={max_compute_workgroup_size:?} \
              max_compute_shared_memory_bytes={max_compute_shared_memory_bytes} \
              max_sample_count={max_sample_count} d24_unorm_s8_attachment={d24_unorm_s8_attachment} \
-             shader_int16={shader_int16} \
+             shader_int16={shader_int16} shader_int64={shader_int64} \
              storage_image_extended_formats={storage_image_extended_formats} \
              storage_image_write_without_format={storage_image_write_without_format} \
              storage_image_read_without_format={storage_image_read_without_format} \
@@ -544,6 +551,7 @@ pub unsafe fn query(
         max_sample_count,
         d24_unorm_s8_attachment,
         shader_int16: supported.shader_int16 == vk::TRUE,
+        shader_int64: supported.shader_int64 == vk::TRUE,
         storage_image_extended_formats: supported.shader_storage_image_extended_formats == vk::TRUE,
         storage_image_write_without_format: supported.shader_storage_image_write_without_format
             == vk::TRUE,
@@ -580,6 +588,7 @@ mod tests {
             max_sample_count: 8,
             d24_unorm_s8_attachment: true,
             shader_int16: true,
+            shader_int64: true,
             storage_image_extended_formats: true,
             storage_image_write_without_format: true,
             storage_image_read_without_format: true,

--- a/crates/reims-vgpu/src/backend/vulkan/engine/caches.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/caches.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::Ordering;
 use super::context::DeviceContext;
 use super::counters::EngineCounters;
 use super::digest::Digest128;
+use super::spirv_declared::DeclaredKind;
 use super::pools::{DeferredHandle, ResourcePools};
 use super::types::{
     BlendKey, ColorWriteMask, CullMode, DepthClipMode, DrawError, FillMode, PrimitiveTopology,
@@ -513,6 +514,10 @@ pub(crate) struct ObjectCaches {
     /// to, so a repeat bind of the same module does not walk it three times to
     /// find that out.
     shader_digests: ShaderDigestIndex,
+    /// Descriptor slots a module declares. Derived by parsing the SPIR-V, so
+    /// it is memoised on the same content digest the shader cache keys on —
+    /// the draw path asks once per draw and must not pay a parse for it.
+    declared_slots: ObjectCache<Digest128, std::sync::Arc<Vec<(u32, DeclaredKind)>>>,
 }
 
 impl ObjectCaches {
@@ -525,6 +530,7 @@ impl ObjectCaches {
             samplers: ObjectCache::new(),
             compute_pipelines: ObjectCache::new(),
             shader_digests: ShaderDigestIndex::default(),
+            declared_slots: ObjectCache::new(),
         }
     }
 
@@ -649,6 +655,28 @@ impl ObjectCaches {
         let (key, module) = self.get_or_create_shader(ctx, words, counters, pools)?;
         self.shader_digests.insert(words, key);
         Ok((key, module))
+    }
+
+    /// The image and sampler slots `words` declares, parsed once per module.
+    pub(crate) fn declared_slots(
+        &mut self,
+        words: &[u32],
+    ) -> std::sync::Arc<Vec<(u32, DeclaredKind)>> {
+        let key = Digest128::of_u32_words(words);
+        if let Some(v) = self.declared_slots.get(&key) {
+            return v.clone();
+        }
+        // Set 0 only: the engine binds one set, and a decoration naming
+        // another is not ours to satisfy.
+        let v = std::sync::Arc::new(
+            super::spirv_declared::declared_descriptors(words)
+                .into_iter()
+                .filter(|(set, _, _)| *set == 0)
+                .map(|(_, binding, kind)| (binding, kind))
+                .collect::<Vec<_>>(),
+        );
+        self.declared_slots.insert(key, v.clone());
+        v
     }
 
     pub(crate) unsafe fn get_or_create_shader(

--- a/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
@@ -729,9 +729,6 @@ impl DeviceContext {
             features.storage_image_write_without_format_bgra();
         let sampled_linear_filter = features.sampled_linear_filter;
         let has16 = features.storage16;
-        let has8 = features.storage8;
-        let has_float16 = features.float16;
-        let has_int8 = features.int8;
         // Defined bounds-clamped behavior for out-of-range shader buffer access
         // is among these — the ONE feature the Vulkan spec requires every
         // implementation to support, so enabling it is portability-clean and
@@ -852,8 +849,6 @@ impl DeviceContext {
         // These three are built in `caps` too. They are bound to locals here
         // only because `push_next` borrows them for the lifetime of `dci`.
         let mut en16 = features.enabled_16bit_storage();
-        let mut en8 = features.enabled_8bit_storage();
-        let mut enfi = features.enabled_float16_int8();
         let mut dci = vk::DeviceCreateInfo::default()
             .queue_create_infos(&qci)
             .enabled_features(&enabled)
@@ -867,12 +862,6 @@ impl DeviceContext {
         }
         if has16 {
             dci = dci.push_next(&mut en16);
-        }
-        if has8 {
-            dci = dci.push_next(&mut en8);
-        }
-        if has_float16 || has_int8 {
-            dci = dci.push_next(&mut enfi);
         }
         let device = instance
             .create_device(pd, &dci, None)

--- a/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
@@ -769,6 +769,14 @@ impl DeviceContext {
         crate::runtime::guest_ram_map::reset();
         let portability_subset = has_device_extension(vk::KHR_PORTABILITY_SUBSET_NAME);
         let vertex_attribute_divisor = has_device_extension(vk::KHR_VERTEX_ATTRIBUTE_DIVISOR_NAME);
+        // A guest draw may name a texture the request never provides, leaving a
+        // shader-declared descriptor with nothing written to it. Metal reads
+        // such a slot as zeros; Vulkan calls it undefined, and the two ICDs we
+        // run on disagree loudly — NVIDIA returns garbage, lavapipe faults on a
+        // null dereference and takes the process with it. nullDescriptor makes
+        // the read defined as zeros on both, which is the Metal behaviour the
+        // guest already expects.
+        let null_descriptor = has_device_extension(vk::EXT_ROBUSTNESS2_NAME);
         #[cfg(feature = "host-window")]
         let swapchain = has_device_extension(ash::khr::swapchain::NAME);
         // Combined depth-stencil format for the stencil-test path. The Vulkan
@@ -820,10 +828,15 @@ impl DeviceContext {
         if vertex_attribute_divisor {
             enabled_device_extensions.push(vk::KHR_VERTEX_ATTRIBUTE_DIVISOR_NAME.as_ptr());
         }
+        if null_descriptor {
+            enabled_device_extensions.push(vk::EXT_ROBUSTNESS2_NAME.as_ptr());
+        }
         #[cfg(feature = "host-window")]
         if swapchain {
             enabled_device_extensions.push(ash::khr::swapchain::NAME.as_ptr());
         }
+        let mut enabled_robustness2 =
+            vk::PhysicalDeviceRobustness2FeaturesEXT::default().null_descriptor(null_descriptor);
         let mut enabled_divisor_features =
             vk::PhysicalDeviceVertexAttributeDivisorFeaturesKHR::default()
                 .vertex_attribute_instance_rate_divisor(vertex_divisor.instance_rate_divisor)
@@ -846,6 +859,9 @@ impl DeviceContext {
             .enabled_features(&enabled)
             .enabled_extension_names(&enabled_device_extensions)
             .push_next(&mut enabled_vulkan12);
+        if null_descriptor {
+            dci = dci.push_next(&mut enabled_robustness2);
+        }
         if vertex_attribute_divisor {
             dci = dci.push_next(&mut enabled_divisor_features);
         }

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -2209,6 +2209,15 @@ pub(crate) unsafe fn execute_draw_inner(
             stages: (vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT).as_raw(),
         });
     }
+    // Slots the shaders declare but this request never provided: the shader
+    // reads them either way, so leaving them out of the layout is what makes
+    // the read undefined. Images are written null below (nullDescriptor);
+    // samplers get a default-state handle, which the feature does not cover.
+    let declared_unprovided = add_declared_bindings(
+        &mut layout_bindings,
+        &[&req.vert_spirv, &req.frag_spirv],
+        vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT,
+    );
     if req.color_input {
         layout_bindings.push(BindingSig {
             binding: super::types::COLOR_INPUT_BINDING,
@@ -2430,6 +2439,21 @@ pub(crate) unsafe fn execute_draw_inner(
         let h = caches.get_or_create_sampler(ctx, &s.state_key(), counters, pools)?;
         sampler_handles.push((s.binding, h));
     }
+    // A declared-but-unprovided sampler cannot be written null: nullDescriptor
+    // does not cover VK_DESCRIPTOR_TYPE_SAMPLER. Default state is what Metal
+    // gives an unbound sampler, and the cache makes it one handle for all.
+    for (binding, kind) in &declared_unprovided {
+        if *kind == super::spirv_declared::DeclaredKind::Sampler {
+            let h = caches.get_or_create_sampler(
+                ctx,
+                &super::types::SamplerStateKey::default(),
+                counters,
+                pools,
+            )?;
+            sampler_handles.push((*binding, h));
+        }
+    }
+
 
     phase.enter(super::draw_phase::Phase::Stage);
     // Vertex buffers (with Constant step shift), deduplicated by content:
@@ -3113,6 +3137,23 @@ pub(crate) unsafe fn execute_draw_inner(
                     .dst_binding(*binding)
                     .descriptor_type(vk::DescriptorType::SAMPLER)
                     .image_info(std::slice::from_ref(&sampler_infos[i])),
+            );
+        }
+        // Null writes for the declared-but-unprovided slots put in the layout
+        // above. A descriptor left merely unwritten stays undefined; written
+        // null under nullDescriptor it reads as zeros, which is what Metal
+        // gives the guest for the same draw.
+        let null_image_info = vk::DescriptorImageInfo::default();
+        for (binding, kind) in &declared_unprovided {
+            if *kind != super::spirv_declared::DeclaredKind::SampledImage {
+                continue;
+            }
+            writes.push(
+                vk::WriteDescriptorSet::default()
+                    .dst_set(dset)
+                    .dst_binding(*binding)
+                    .descriptor_type(vk::DescriptorType::SAMPLED_IMAGE)
+                    .image_info(std::slice::from_ref(&null_image_info)),
             );
         }
         if req.color_input {
@@ -5467,6 +5508,39 @@ mod tests {
         assert_eq!(&bytes[..100], &backing[..100]);
         assert_eq!(&bytes[100..156], &backing[200..256]);
     }
+}
+
+/// Adds a layout entry for every image/sampler slot the shaders declare that
+/// `layout_bindings` does not already carry. Set 0 only: the engine binds one
+/// set, and a decoration naming another set is not ours to satisfy.
+pub(super) fn add_declared_bindings(
+    layout_bindings: &mut Vec<BindingSig>,
+    modules: &[&[u32]],
+    stages: vk::ShaderStageFlags,
+) -> Vec<(u32, super::spirv_declared::DeclaredKind)> {
+    use super::spirv_declared::{DeclaredKind, declared_descriptors};
+    let mut added = Vec::new();
+    for words in modules {
+        for (set, binding, kind) in declared_descriptors(words) {
+            if set != 0 || layout_bindings.iter().any(|b| b.binding == binding) {
+                continue;
+            }
+            if added.iter().any(|(b, _)| *b == binding) {
+                continue;
+            }
+            let ty = match kind {
+                DeclaredKind::SampledImage => vk::DescriptorType::SAMPLED_IMAGE,
+                DeclaredKind::Sampler => vk::DescriptorType::SAMPLER,
+            };
+            layout_bindings.push(BindingSig {
+                binding,
+                ty: ty.as_raw() as u32,
+                stages: stages.as_raw(),
+            });
+            added.push((binding, kind));
+        }
+    }
+    added
 }
 
 #[cfg(test)]

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -2220,9 +2220,11 @@ pub(crate) unsafe fn execute_draw_inner(
     // reads them either way, so leaving them out of the layout is what makes
     // the read undefined. Images are written null below (nullDescriptor);
     // samplers get a default-state handle, which the feature does not cover.
+    let mut declared = (*caches.declared_slots(&req.vert_spirv)).clone();
+    declared.extend_from_slice(&caches.declared_slots(&req.frag_spirv));
     let declared_unprovided = add_declared_bindings(
         &mut layout_bindings,
-        &[&req.vert_spirv, &req.frag_spirv],
+        &declared,
         vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT,
     );
     layout_bindings.sort_by_key(|b| b.binding);
@@ -5511,37 +5513,30 @@ mod tests {
 }
 
 /// Adds a layout entry for every image/sampler slot the shaders declare that
-/// `layout_bindings` does not already carry. Set 0 only: the engine binds one
-/// set, and a decoration naming another set is not ours to satisfy.
+/// `layout_bindings` does not already carry.
 pub(super) fn add_declared_bindings(
     layout_bindings: &mut Vec<BindingSig>,
-    modules: &[&[u32]],
+    declared: &[(u32, super::spirv_declared::DeclaredKind)],
     stages: vk::ShaderStageFlags,
 ) -> Vec<(u32, super::spirv_declared::DeclaredKind)> {
-    use super::spirv_declared::{DeclaredKind, declared_descriptors};
+    use super::spirv_declared::DeclaredKind;
     let mut added = Vec::new();
-    if std::env::var_os("REIMS_NO_DECLARED_SCAN").is_some() {
-        return added;
-    }
-    for words in modules {
-        for (set, binding, kind) in declared_descriptors(words) {
-            if set != 0 || layout_bindings.iter().any(|b| b.binding == binding) {
-                continue;
-            }
-            if added.iter().any(|(b, _)| *b == binding) {
-                continue;
-            }
-            let ty = match kind {
-                DeclaredKind::SampledImage => vk::DescriptorType::SAMPLED_IMAGE,
-                DeclaredKind::Sampler => vk::DescriptorType::SAMPLER,
-            };
-            layout_bindings.push(BindingSig {
-                binding,
-                ty: ty.as_raw() as u32,
-                stages: stages.as_raw(),
-            });
-            added.push((binding, kind));
+    for (binding, kind) in declared {
+        if layout_bindings.iter().any(|b| b.binding == *binding)
+            || added.iter().any(|(b, _)| *b == *binding)
+        {
+            continue;
         }
+        let ty = match kind {
+            DeclaredKind::SampledImage => vk::DescriptorType::SAMPLED_IMAGE,
+            DeclaredKind::Sampler => vk::DescriptorType::SAMPLER,
+        };
+        layout_bindings.push(BindingSig {
+            binding: *binding,
+            ty: ty.as_raw() as u32,
+            stages: stages.as_raw(),
+        });
+        added.push((*binding, *kind));
     }
     added
 }

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -2209,6 +2209,13 @@ pub(crate) unsafe fn execute_draw_inner(
             stages: (vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT).as_raw(),
         });
     }
+    if req.color_input {
+        layout_bindings.push(BindingSig {
+            binding: super::types::COLOR_INPUT_BINDING,
+            ty: vk::DescriptorType::INPUT_ATTACHMENT.as_raw() as u32,
+            stages: vk::ShaderStageFlags::FRAGMENT.as_raw(),
+        });
+    }
     // Slots the shaders declare but this request never provided: the shader
     // reads them either way, so leaving them out of the layout is what makes
     // the read undefined. Images are written null below (nullDescriptor);
@@ -2218,13 +2225,6 @@ pub(crate) unsafe fn execute_draw_inner(
         &[&req.vert_spirv, &req.frag_spirv],
         vk::ShaderStageFlags::VERTEX | vk::ShaderStageFlags::FRAGMENT,
     );
-    if req.color_input {
-        layout_bindings.push(BindingSig {
-            binding: super::types::COLOR_INPUT_BINDING,
-            ty: vk::DescriptorType::INPUT_ATTACHMENT.as_raw() as u32,
-            stages: vk::ShaderStageFlags::FRAGMENT.as_raw(),
-        });
-    }
     layout_bindings.sort_by_key(|b| b.binding);
     let layout_key = LayoutKey {
         bindings: layout_bindings,
@@ -5520,6 +5520,9 @@ pub(super) fn add_declared_bindings(
 ) -> Vec<(u32, super::spirv_declared::DeclaredKind)> {
     use super::spirv_declared::{DeclaredKind, declared_descriptors};
     let mut added = Vec::new();
+    if std::env::var_os("REIMS_NO_DECLARED_SCAN").is_some() {
+        return added;
+    }
     for words in modules {
         for (set, binding, kind) in declared_descriptors(words) {
             if set != 0 || layout_bindings.iter().any(|b| b.binding == binding) {

--- a/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod draw_validation;
 mod driver_breadcrumb;
 mod exec;
 mod exec_compute;
+mod spirv_declared;
 mod facade_decline;
 mod guest_scatter;
 mod host_ram;

--- a/crates/reims-vgpu/src/backend/vulkan/engine/spirv_declared.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/spirv_declared.rs
@@ -1,0 +1,106 @@
+//! Descriptor slots a SPIR-V module declares.
+//!
+//! The engine builds its descriptor-set layout from the resources a request
+//! provides. A guest draw may name fewer than the shader reads — Metal answers
+//! such a slot with zeros, so the guest issues it freely — and the shader then
+//! indexes a descriptor the set never declared. That is undefined in Vulkan and
+//! the ICDs disagree loudly: NVIDIA returns garbage, lavapipe dereferences null
+//! and takes the process down. Scanning the module tells the layout builder
+//! which slots must exist regardless of what the request carried.
+
+use std::collections::HashMap;
+
+const OP_DECORATE: u16 = 71;
+const OP_TYPE_IMAGE: u16 = 25;
+const OP_TYPE_SAMPLER: u16 = 26;
+const OP_TYPE_SAMPLED_IMAGE: u16 = 27;
+const OP_TYPE_POINTER: u16 = 32;
+const OP_VARIABLE: u16 = 59;
+
+const DECORATION_BINDING: u32 = 33;
+const DECORATION_DESCRIPTOR_SET: u32 = 34;
+
+const SPIRV_MAGIC: u32 = 0x0723_0203;
+const SPIRV_HEADER_WORDS: usize = 5;
+
+/// What a declared slot needs from the layout. Storage buffers are already
+/// derived from the request in every path that has them, so only the image and
+/// sampler kinds — the ones a draw legitimately omits — are reported.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DeclaredKind {
+    SampledImage,
+    Sampler,
+}
+
+/// `(set, binding, kind)` for every image or sampler variable the module
+/// decorates with both a set and a binding. Returns nothing for a module that
+/// is not valid SPIR-V rather than guessing — a caller that cannot parse the
+/// shader has no business editing the layout it implies.
+pub(crate) fn declared_descriptors(words: &[u32]) -> Vec<(u32, u32, DeclaredKind)> {
+    if words.len() < SPIRV_HEADER_WORDS || words[0] != SPIRV_MAGIC {
+        return Vec::new();
+    }
+    let mut binding_of: HashMap<u32, u32> = HashMap::new();
+    let mut set_of: HashMap<u32, u32> = HashMap::new();
+    let mut image_types: Vec<u32> = Vec::new();
+    let mut sampler_types: Vec<u32> = Vec::new();
+    // pointer result id -> pointee type id
+    let mut pointee_of: HashMap<u32, u32> = HashMap::new();
+    // variable result id -> its pointer type id
+    let mut variables: Vec<(u32, u32)> = Vec::new();
+
+    let mut i = SPIRV_HEADER_WORDS;
+    while i < words.len() {
+        let word_count = (words[i] >> 16) as usize;
+        let opcode = (words[i] & 0xffff) as u16;
+        // A zero word count cannot advance the cursor: stop rather than spin.
+        if word_count == 0 || i + word_count > words.len() {
+            break;
+        }
+        let operands = &words[i + 1..i + word_count];
+        match opcode {
+            OP_DECORATE if operands.len() >= 3 => match operands[1] {
+                DECORATION_BINDING => {
+                    binding_of.insert(operands[0], operands[2]);
+                }
+                DECORATION_DESCRIPTOR_SET => {
+                    set_of.insert(operands[0], operands[2]);
+                }
+                _ => {}
+            },
+            OP_TYPE_IMAGE | OP_TYPE_SAMPLED_IMAGE if !operands.is_empty() => {
+                image_types.push(operands[0]);
+            }
+            OP_TYPE_SAMPLER if !operands.is_empty() => {
+                sampler_types.push(operands[0]);
+            }
+            OP_TYPE_POINTER if operands.len() >= 3 => {
+                pointee_of.insert(operands[0], operands[2]);
+            }
+            OP_VARIABLE if operands.len() >= 2 => {
+                variables.push((operands[1], operands[0]));
+            }
+            _ => {}
+        }
+        i += word_count;
+    }
+
+    let mut out = Vec::new();
+    for (var_id, ptr_type) in variables {
+        let (Some(binding), Some(set)) = (binding_of.get(&var_id), set_of.get(&var_id)) else {
+            continue;
+        };
+        let Some(pointee) = pointee_of.get(&ptr_type) else {
+            continue;
+        };
+        let kind = if image_types.contains(pointee) {
+            DeclaredKind::SampledImage
+        } else if sampler_types.contains(pointee) {
+            DeclaredKind::Sampler
+        } else {
+            continue;
+        };
+        out.push((*set, *binding, kind));
+    }
+    out
+}

--- a/crates/reims-vgpu/src/backend/vulkan/engine/spirv_declared.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/spirv_declared.rs
@@ -20,6 +20,8 @@ const OP_VARIABLE: u16 = 59;
 const DECORATION_BINDING: u32 = 33;
 const DECORATION_DESCRIPTOR_SET: u32 = 34;
 
+const DIM_SUBPASS_DATA: u32 = 6;
+
 const SPIRV_MAGIC: u32 = 0x0723_0203;
 const SPIRV_HEADER_WORDS: usize = 5;
 
@@ -68,7 +70,13 @@ pub(crate) fn declared_descriptors(words: &[u32]) -> Vec<(u32, u32, DeclaredKind
                 }
                 _ => {}
             },
-            OP_TYPE_IMAGE | OP_TYPE_SAMPLED_IMAGE if !operands.is_empty() => {
+            // Dim (operand 2) SubpassData means an input attachment, which the
+            // engine binds from the request's own color-input state — adding it
+            // here would declare binding 96 twice with two different types.
+            OP_TYPE_IMAGE if operands.len() >= 3 && operands[2] != DIM_SUBPASS_DATA => {
+                image_types.push(operands[0]);
+            }
+            OP_TYPE_SAMPLED_IMAGE if !operands.is_empty() => {
                 image_types.push(operands[0]);
             }
             OP_TYPE_SAMPLER if !operands.is_empty() => {

--- a/crates/reims-vgpu/src/backend/vulkan/engine/types.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/types.rs
@@ -1043,7 +1043,7 @@ impl SamplerResource {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 pub(crate) struct SamplerStateKey {
     pub min_filter: SamplerFilter,
     pub mag_filter: SamplerFilter,

--- a/crates/reims-vgpu/tests/lvp_null_descriptor_repro.rs
+++ b/crates/reims-vgpu/tests/lvp_null_descriptor_repro.rs
@@ -11,8 +11,8 @@
 
 use metal2vulkan::passes::Stage;
 use reims_vgpu::backend::vulkan::engine::{
-    self, DrawRequest, LoadOp, PrimitiveTopology, SampledImageResource, SampledSource,
-    SamplerResource, StorageBufferResource,
+    self, DrawRequest, PrimitiveTopology, SampledImageResource, SampledSource, SamplerResource,
+    StorageBufferResource,
 };
 use std::path::PathBuf;
 
@@ -72,14 +72,17 @@ fn base_request_px(with_texture: bool, with_sampler: bool, px: [u8; 4], dim: u32
         width: 64,
         height: 64,
         vertex_count: 6,
-        flip_viewport_y: true,
         first_vertex: 0,
         instance_count: Some(1),
         base_instance: 0,
         primitive_topology: PrimitiveTopology::Triangle,
+        // Default `target_clear` is `[0.0; 4]` and no seed/load-from-target is
+        // set, so the pass clears to transparent black — the same load action
+        // this request spelled explicitly before `LoadOp` was retired in favor
+        // of `target_clear` + the load-source fields it now shares the struct
+        // with (see `DrawRequest::target_clear`'s doc).
         ..Default::default()
     };
-    req.load_op = Some(LoadOp::Clear([0.0, 0.0, 0.0, 0.0]));
     req.storage_buffers.push(StorageBufferResource {
         binding: 0,
         content: encode_f32(&quad.into_iter().flatten().collect::<Vec<_>>()).into(),

--- a/crates/reims-vgpu/tests/lvp_null_descriptor_repro.rs
+++ b/crates/reims-vgpu/tests/lvp_null_descriptor_repro.rs
@@ -1,0 +1,160 @@
+//! Repro: a fragment shader that samples a texture whose descriptor binding is
+//! absent from the request (and therefore from the descriptor set layout).
+//!
+//! `textured_quad.air` declares set 0 binding 32 (sampled image) and binding 64
+//! (sampler). The engine derives both the descriptor set layout and the
+//! descriptor writes from the DrawRequest, so a request that omits the sampled
+//! image produces a pipeline whose shader reads a descriptor the set never
+//! declared or wrote.
+
+#![cfg(feature = "backend-vulkan")]
+
+use metal2vulkan::passes::Stage;
+use reims_vgpu::backend::vulkan::engine::{
+    self, DrawRequest, LoadOp, PrimitiveTopology, SampledImageResource, SampledSource,
+    SamplerResource, StorageBufferResource,
+};
+use std::path::PathBuf;
+
+fn fixtures() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/air")
+}
+
+fn translate_words(name: &str, stage: Stage) -> Vec<u32> {
+    let tmp = std::env::temp_dir().join(format!(
+        "lvp_repro_{}_{}_{:?}",
+        std::process::id(),
+        name,
+        stage
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("tmp");
+    let path = fixtures().join(name);
+    let spv = metal2vulkan::translate(path.to_str().unwrap(), stage, &tmp)
+        .unwrap_or_else(|e| panic!("translate {name}: {e}"));
+    spv.chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+fn encode_f32(values: &[f32]) -> Vec<u8> {
+    values.iter().flat_map(|v| v.to_le_bytes()).collect()
+}
+
+/// Full-screen quad + UVs in storage buffers 0/1, which is what the vertex half
+/// of `textured_quad.air` fetches.
+fn base_request(with_texture: bool, with_sampler: bool) -> DrawRequest {
+    base_request_px(with_texture, with_sampler, [17u8, 140, 203, 255], 2)
+}
+
+fn base_request_px(with_texture: bool, with_sampler: bool, px: [u8; 4], dim: u32) -> DrawRequest {
+    let vert = translate_words("textured_quad.air", Stage::Vertex);
+    let frag = translate_words("textured_quad.air", Stage::Fragment);
+    let quad: [[f32; 4]; 6] = [
+        [-1.0, -1.0, 0.5, 1.0],
+        [1.0, -1.0, 0.5, 1.0],
+        [-1.0, 1.0, 0.5, 1.0],
+        [-1.0, 1.0, 0.5, 1.0],
+        [1.0, -1.0, 0.5, 1.0],
+        [1.0, 1.0, 0.5, 1.0],
+    ];
+    let uvs: [[f32; 2]; 6] = [
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [1.0, 1.0],
+        [1.0, 0.0],
+    ];
+    let mut req = DrawRequest {
+        vert_spirv: std::sync::Arc::new(vert),
+        frag_spirv: std::sync::Arc::new(frag),
+        width: 64,
+        height: 64,
+        vertex_count: 6,
+        flip_viewport_y: true,
+        first_vertex: 0,
+        instance_count: Some(1),
+        base_instance: 0,
+        primitive_topology: PrimitiveTopology::Triangle,
+        ..Default::default()
+    };
+    req.load_op = Some(LoadOp::Clear([0.0, 0.0, 0.0, 0.0]));
+    req.storage_buffers.push(StorageBufferResource {
+        binding: 0,
+        content: encode_f32(&quad.into_iter().flatten().collect::<Vec<_>>()).into(),
+    });
+    req.storage_buffers.push(StorageBufferResource {
+        binding: 1,
+        content: encode_f32(&uvs.into_iter().flatten().collect::<Vec<_>>()).into(),
+    });
+    if with_texture {
+        req.sampled_images.push(SampledImageResource {
+            binding: 32,
+            width: dim,
+            height: dim,
+            layers: 1,
+            arrayed: false,
+            volume: false,
+            cube: false,
+            one_dim: false,
+            source: SampledSource::Bytes(std::sync::Arc::new(px.repeat((dim * dim) as usize))),
+            format: ash::vk::Format::R8G8B8A8_UNORM,
+            identity: None,
+            swizzle: Default::default(),
+        });
+    }
+    if with_sampler {
+        req.samplers.push(SamplerResource::normalized_default(64));
+    }
+    req
+}
+
+fn run(label: &str, req: &DrawRequest) {
+    eprintln!("[{label}] executing draw");
+    match engine::execute_draw_request(req) {
+        Ok(out) => eprintln!(
+            "[{label}] OK first_pixel={:?} bgra={}",
+            &out.pixels[..4],
+            out.pixels_bgra
+        ),
+        Err(e) => eprintln!("[{label}] declined: {e}"),
+    }
+    eprintln!("[{label}] survived");
+}
+
+/// Control: every binding the shader reads is present in the request.
+#[test]
+fn texture_and_sampler_present() {
+    run("control", &base_request(true, true));
+}
+
+/// Repro: the sampler is bound, the sampled image is not.
+#[test]
+fn texture_missing_sampler_present() {
+    run("no-texture", &base_request(false, true));
+}
+
+/// Repro: neither the sampled image nor the sampler is bound.
+#[test]
+fn texture_and_sampler_missing() {
+    run("neither", &base_request(false, false));
+}
+
+/// The proposed fix: the guest bound nothing, but a 1x1 opaque-black placeholder
+/// is synthesized at the reflected binding so every descriptor the shader reads
+/// is declared and written.
+#[test]
+fn placeholder_texture_substituted() {
+    run(
+        "placeholder",
+        &base_request_px(true, true, [0u8, 0, 0, 255], 1),
+    );
+}
+
+/// Transparent-black placeholder: Metal reads an unbound texture as zero, and
+/// this is what NVIDIA already returns for the unbound case.
+#[test]
+fn placeholder_transparent_black() {
+    run("zero-placeholder", &base_request_px(true, true, [0u8, 0, 0, 0], 1));
+}


### PR DESCRIPTION
## Summary

Rebases a set of commits from [CMGS/reims-vgpu](https://github.com/CMGS/reims-vgpu)'s `dev` branch onto current `master`, forward-ported here because they were sitting unmerged and address a real correctness/crash bug in the Vulkan backend. All commit authorship is preserved (`git cherry-pick -x`); I only resolved the merge conflicts from ~1600 commits of drift and adapted one test to an API that moved since CMGS forked (see the last commit).

**The critical fix (`Declare every descriptor slot the shaders read...`):** the engine derived its descriptor-set layout purely from resources a draw request explicitly carried, so a shader that *read* a slot the guest never bound indexed a descriptor the set never declared. Vulkan calls that undefined behavior, and drivers act on it differently — NVIDIA returns garbage pixels, lavapipe null-dereferences inside its shader JIT and crashes the process. The fix scans the SPIR-V for every slot it actually declares and fills the layout gaps; unbound images read as zero via `robustness2`'s `nullDescriptor`, unbound samplers get a default-state handle since that feature doesn't cover samplers.

I verified this live against the NVIDIA path CMGS's own testing (lavapipe + reports of NVIDIA behavior) didn't have direct hardware for — see the last commit's message.

**Also included, same branch/stack:**
- `Keep subpass inputs out of the declared-slot scan` — follow-up correctness fix on the above
- `Memoise the declared-slot scan on the shader content digest` — the SPIR-V scan was a full parse in the hot draw path; memoises on the same content digest the shader cache already keys on
- `Fold float16/int8 and 8-bit storage into VkPhysicalDeviceVulkan12Features` — `VkPhysicalDeviceShaderFloat16Int8Features`/`VkPhysicalDevice8BitStorageFeatures` are spec-forbidden in a pNext chain that already carries `VkPhysicalDeviceVulkan12Features`, and every field they set has lived there since 1.2. Validation flagged this on every device creation; now clean.
- `ci: *` (4 commits) — adds `.github/workflows/ci.yml` and `release.yml` (build, batch/compute Vulkan suites as a merge gate, lavapipe result recording). Upstream currently has no CI at all.

**Left out of this PR** (also on CMGS's `dev` branch, not carried over):
- `Add R8Uint and R16Unorm to the pixel-format byte table` — upstream `master` already added both independently since CMGS forked (with `R16Unorm` mapped even more precisely, to `R16_BPP` rather than CMGS's `RG8_BPP`); fully redundant now, dropped via `git cherry-pick --skip`.
- `Track metal2vulkan at our fork's dev HEAD instead of a pinned rev` — repoints `Cargo.toml` at `CMGS/metal2vulkan`'s own fork/branch. Not appropriate to propose upstream as a dependency change.
- `qemu-build: enable gcrypt on the x86_64 configure` — legitimate fix for the release-build VNC-password path, but orthogonal to this PR's scope; happy to open separately if wanted.

## Conflicts resolved while rebasing

`master` has moved ~1600 commits since this fork's base. Two real structural conflicts, both from upstream features added independently in that gap:
- `device_features.rs`: upstream's `report_line()` uses an exhaustive `let Self { .. }` destructure specifically so a new field can't be added without updating it (documented at its call site) — added the missing `shader_int64` arm.
- `caches.rs`/`exec.rs`: upstream replaced the old `FifoCache` type with a new unbounded `ObjectCache` and added its own `shader_digests` memoization (`get_or_create_shader_memoized`) in the same window CMGS added `declared_slots` memoization. Merged both memoizers to coexist, using `ObjectCache` consistently for the new cache field.

## Verification

- `cargo build -p reims-vgpu --no-default-features --features backend-vulkan,host-window`: clean
- `cargo test -p reims-vgpu --no-default-features --features backend-vulkan,host-window --lib -- --test-threads=1`: **1907 passed**, 0 failed
- `cargo test -p reims-vgpu --no-default-features --features backend-vulkan,host-window --tests -- --test-threads=1`: all integration suites green (`vk_engine_batch`, `vk_engine_compute`, `vk_engine_parity` 52 passed/1 pre-existing-ignored, `lvp_null_descriptor_repro` 5 passed — this repo's own repro test for the bug this PR fixes)
- `cargo clippy -p reims-vgpu --all-targets --no-default-features --features backend-vulkan,host-window -- -D warnings`: clean
- `cargo clippy -p reims-vgpu --target x86_64-unknown-linux-gnu --all-targets --no-default-features --features backend-vulkan,host-window -- -D warnings`: clean
- `.github/workflows/*.yml` parse as valid YAML

**Not verified:** `cargo clippy --target aarch64-apple-darwin --features backend-metal` — this environment has no Apple Rust target installed and no `rustup` to add one. This PR touches no `backend-metal` code, but per this repo's own `AGENTS.md` I'm calling that arm out explicitly rather than letting a partial "clippy clean" read as covering it. No live macOS-guest boot was performed (no `--testing`/screenshot verification) — this PR is offered as a rebase-and-verify of already-authored, already-reasoned-about fixes, not as freshly-designed work I'm claiming full pathway verification for.