### PR TITLE
vm/boot-x86.sh: only default WAYLAND_DISPLAY when a Wayland socket exists

### DIFF
--- a/vm/boot-x86.sh
+++ b/vm/boot-x86.sh
@@ -679,7 +679,14 @@ if [ -n "${REIMS_VGPU_WINDOW:-}" ]; then
   # per-login random suffix; override any of these in the environment if yours
   # differ (e.g. a different seat, DISPLAY, or Wayland socket).
   : "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
-  : "${WAYLAND_DISPLAY:=wayland-0}"
+  # winit's Linux backend picks Wayland whenever WAYLAND_DISPLAY is a non-empty
+  # string, regardless of whether that socket actually exists (see winit
+  # platform_impl/linux/mod.rs EventLoop::new). Defaulting it unconditionally
+  # therefore forces Wayland (and a silent, unlogged EventLoopError) on
+  # X11-only hosts. Only default it when a real Wayland socket is present.
+  if [ -z "${WAYLAND_DISPLAY:-}" ] && [ -S "$XDG_RUNTIME_DIR/wayland-0" ]; then
+    WAYLAND_DISPLAY="wayland-0"
+  fi
   : "${DISPLAY:=:0}"
   # XAUTHORITY's suffix is a per-login random string, so it cannot be written
   # down: a hardcoded one goes stale at the next login and then points at a file


### PR DESCRIPTION
## Summary

Forward-ports one commit from [MakrSas/reims-vgpu](https://github.com/MakrSas/reims-vgpu)'s `host-import-working-set` branch. Authorship preserved via `git cherry-pick -x`.

winit's Linux backend picks Wayland whenever `WAYLAND_DISPLAY` is a non-empty string, regardless of whether that socket actually exists. `vm/boot-x86.sh` currently defaults it unconditionally (`: "${WAYLAND_DISPLAY:=wayland-0}"`), which forces Wayland — and a silent, unlogged `EventLoopError` — on an X11-only host. This only defaults it when `$XDG_RUNTIME_DIR/wayland-0` is actually a socket.

## Why this is the only commit from that branch

The source branch had 8 commits; I evaluated all of them and 7 turned out to be superseded by independent work upstream has done in the ~2000 commits since this fork's base — noting it here since it's a useful confirmation that these bugs are already handled, and I don't want the drop to look like I missed them:

- **Host-import budget/working-set fix** — targeted the old windowed/bucketed `VK_EXT_external_memory_host` import scheme (`pools/host_import.rs`). That whole scheme is gone: `runtime/guest_ram.rs` now does one whole-RAMBlock import per RAMBlock for the life of the VM, so the bug class (only the first window's budget ever usable) can't occur in an architecture with no windows.
- **"Keep host-import windows coarse"** — follow-up to the above, same reason.
- **Control-page reservation bound to live object refs** — `runtime/mapper.rs` → `runtime/mapper/mod.rs`'s `first_control_page_collision` now has a much deeper fix with its own doc explaining why the whole check was invalid (it compared a GVA-space address against GPA-space surface addresses — a coincidental comparison regardless of stride), and that doc explicitly cites the same 12-vs-16-byte `OBJECT_LIST_ENTRY_LEN` stride bug this commit found. Superseded, not just duplicated.
- **SPIR-V R32f decode fix** — `ImageFormat::R32Float` (`from_raw(3)`/`raw()->3`) is already in current `spirv_bind.rs` with tests. The original commit message even says so: *"found the maintainer's own in-flight fix (steelbrain/reims-vgpu#5) doing exactly this."*
- **Periodic redraw pump on Linux** — patched the old `ENGINE_WINDOW_REDRAW_POLL`/`about_to_wait` periodic-poll mechanism to also run on non-macOS. That whole mechanism is gone, replaced by `WindowWaker`/`EventLoopProxy`: the publisher wakes the loop directly instead of polling, which structurally can't hit the "stalls until an external X11 event unsticks it" bug this patched.
- **README rewrite** — fork-identity content (its own bench hardware, fork description). Not appropriate for upstream's README.
- **`docs/linux-x86-radv.md`** — bring-up notes scoped by the author's own admission to one specific host (AMD iGPU/RADV); left local rather than merged as generic project docs.

## Verification

- `cargo build -p reims-vgpu --no-default-features --features backend-vulkan,host-window`: clean
- `cargo clippy -p reims-vgpu --all-targets --no-default-features --features backend-vulkan,host-window -- -D warnings`: clean
- `bash -n vm/boot-x86.sh`: clean
- Manually confirmed the gating logic against a live GNOME/Wayland session with a real `$XDG_RUNTIME_DIR/wayland-0` socket present (defaults correctly) — did not have an X11-only host available to confirm the negative case, but the logic is a direct, small conditional and the original commit's own live testing covered that path.