### PR TITLE
vgpu: bump metal2vulkan for correct vec3 struct layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "metal2vulkan"
 version = "0.1.0"
-source = "git+https://github.com/steelbrain/metal2vulkan.git?rev=8b78eaca3be72b4e596aa1c790a4cd114ac1e9ec#8b78eaca3be72b4e596aa1c790a4cd114ac1e9ec"
+source = "git+https://github.com/steelbrain/metal2vulkan.git?rev=22358a143#22358a1436f262205ed52bedbd4269cb6d98770e"
 dependencies = [
  "spirv",
  "wait-timeout",

--- a/crates/reims-vgpu/Cargo.toml
+++ b/crates/reims-vgpu/Cargo.toml
@@ -47,7 +47,7 @@ reims-vgpu-wire = { path = "../reims-vgpu-wire" }
 reims-vgpu-paging = { path = "../reims-vgpu-paging" }
 ash = { version = "0.38", optional = true }
 # Always available for Linux MTLB→AIR→SPIR-V (encode path + probes).
-metal2vulkan = { git = "https://github.com/steelbrain/metal2vulkan.git", rev = "8b78eaca3be72b4e596aa1c790a4cd114ac1e9ec" }
+metal2vulkan = { git = "https://github.com/steelbrain/metal2vulkan.git", rev = "22358a143" }
 winit = { version = "0.30", optional = true }
 ash-window = { version = "0.13", optional = true }
 raw-window-handle = { version = "0.6", optional = true }


### PR DESCRIPTION
Bump metal2vulkan from `8b78eaca` to `22358a143`.

The new revision fixes ABI offsets following three-lane vectors. On an x86/Vulkan macOS Tahoe boot, this removed the major WindowServer rendering corruption.

A tiny fix for #2, which is still far from working (transparent popups and other rendering artifacts). Verified with a driven boot and 2,193 serial Vulkan library tests.