### PR TITLE
x86/Vulkan: BC texture family, cube maps, packed ten-bit targets, pass-shared depth, and two drain-thread costs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ __pycache__/
 !/vm/boot-arm64.sh
 !/vm/boot-x86.sh
 !/vm/guest-authorize.sh
+!/vm/guest-ip.sh
+# `/vm/*` above stops git descending into vm/lib at all, so the directory has to
+# be un-ignored before the file in it can be.
+!/vm/lib/
+!/vm/lib/*.sh
 !/vm/rail-debug-posture.sh
 vm/debug/
 vm/logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -632,8 +632,26 @@ yet". `vm/guest-authorize.sh` waits for sshd, installs the key into the running 
 `ssh macos-vm` before returning. It is idempotent and needs no password on a rail that already has
 the key, so a harness may call it unconditionally.
 
-It also forgets the host-key pin for `127.0.0.1:2222`, which is a different machine on every rail —
-without that, whichever rail booted first wins and every later rail fails the host-key check.
+**Which endpoint it authorizes depends on how the boot was networked, and the default moved.**
+`vm/boot-x86.sh` now defaults to `NET=bridge`: the guest is a peer on `virbr0` with its own DHCP
+lease and there is **no hostfwd**, so `127.0.0.1:2222` reaches nothing. `guest-authorize.sh` matches
+that default, resolves the lease through `vm/guest-ip.sh` keyed on the pinned `GUEST_MAC`, and
+writes the `macos-vm` alias for whichever endpoint the boot actually has into
+`vm/disks/run/ssh-config`. Pass `NET=user` when the boot used SLIRP. Under `NET=none` it refuses:
+that boot has no NIC.
+
+`ssh macos-vm` — what every probe types — reads `~/.ssh/config`, not the generated file, so the
+alias resolves only once that config carries `Include <repo>/vm/disks/run/ssh-config`.
+`--write-ssh-config` prepends it, once and idempotently; without it the script prints the line and
+**exits non-zero** rather than letting twenty probes fail at their first hop. Prepending is not
+tidiness: ssh takes the first value it finds for any keyword, so an Include below an existing
+`Host macos-vm` or `Host *` block loses to it.
+
+The generated alias sets `StrictHostKeyChecking no` with a `/dev/null` known-hosts, which replaces
+the old `ssh-keygen -R` dance. The reason is unchanged and applies to both modes: this endpoint is a
+different machine on every rail, whether it is spelled `127.0.0.1:2222` or a `virbr0` lease dnsmasq
+hands to whichever rail asked first. A pin can only produce a mismatch, and `BatchMode=yes` turns a
+mismatch into a silent probe failure that reads as a dead guest.
 
 **Bound every guest-side command with `timeout` on the host side.** An unattended harness cannot
 tell a wedged guest command from a wedged boot. `system_profiler SPDisplaysDataType` has been
@@ -672,9 +690,10 @@ six rails rots, and the rail it skips is the one with the open defects. `dock-ho
 state — a process list, a log — ssh remains the only route, but bound it with `timeout` and never
 read its absence as a device result.
 
-**sshd answers well before the desktop composites.** A probe started when port 2222 opens
-photographs the Apple logo and the boot progress bar. Wait for `pgrep -x Dock` over ssh, then give
-the dock and wallpaper a few seconds to settle.
+**sshd answers well before the desktop composites.** A probe started the moment the guest accepts
+ssh — port 2222 under `NET=user`, its DHCP lease under `NET=bridge` — photographs the Apple logo and
+the boot progress bar. Wait for `pgrep -x Dock` over ssh, then give the dock and wallpaper a few
+seconds to settle.
 
 ### `probe exit=0` is not a clean boot — grep the boot's own stdout for a panic
 
@@ -861,16 +880,23 @@ A `--testing` boot reaches the desktop and then sits there. Reading its counters
 behavior is how a rail gets called dead when the workload simply never asked for it. If a change is
 about throughput, caching, writeback or present cadence, the boot has to be driven.
 
-Run the boot in the background and drive the guest **while it is up** — the `--testing` boot exposes
-SSH on `localhost:2222` (`macos-vm` in `~/.ssh/config`) for its whole life, so a probe does not need
-its own boot:
+Run the boot in the background and drive the guest **while it is up** — the `--testing` boot keeps
+the guest reachable for its whole life, so a probe does not need its own boot. Where that is depends
+on `NET`: a bridged boot (the default) has a DHCP lease and no forwarded port, so `vm/guest-authorize.sh`
+resolves it and points `macos-vm` at it. Call it before the first probe rather than waiting on ssh
+directly:
 
 ```sh
 pkill -f 'qemu-system-x86_6[4].*reims-vgpu'; rm -f /tmp/reims-vgpu-fail.log
 vm/boot-x86.sh --device reims-vgpu-pci --testing &     # ~7 min before its own hard kill
-until [ -f /tmp/reims-vgpu-fail.log ] && ssh macos-vm true; do sleep 5; done
+until [ -f /tmp/reims-vgpu-fail.log ]; do sleep 5; done
+vm/guest-authorize.sh                                  # resolves the endpoint, points `macos-vm` at it
 scripts/window-drag-probe/window-drag-probe.sh --seconds 25 --app Safari
 ```
+
+The old spelling of the wait — `until [ -f ... ] && ssh macos-vm true` — is now wrong on a bridged
+boot for a reason worth keeping: it waits on an alias that does not point anywhere until
+`guest-authorize.sh` has run, so it spins until the boot's own hard kill and reports nothing.
 
 That produces real window-server compositing, against 0 draws/s idle. The probe refuses a verdict if
 the window never moved, so a run that produced no motion cannot be mistaken for a slow device.
@@ -962,6 +988,16 @@ counters and a screenshot of a working desktop, all from the binary you were try
 Only a live device creates `/tmp/reims-vgpu-fail.log`, so waiting on it catches the case, and
 killing any surviving QEMU first avoids the race. Confirm afterwards that the log is a boot's and
 not the test suite's, by the presence of `store_routes`/`present_page_identity`.
+
+**On a bridged boot that race loses its only loud symptom, so killing first is no longer optional.**
+The `hostfwd` bind failure above was a *signal*: two VMs could not both hold `localhost:2222`, so the
+second one died and said so. `NET=bridge` has no port to contend for — both guests attach to
+`virbr0` happily and then collide on `GUEST_MAC`, which is pinned precisely so the lease is stable
+across reverts. Nothing fails. dnsmasq hands the address to one of them, `vm/guest-ip.sh` returns
+that one address, and the probe drives whichever guest answers, with no line anywhere saying there
+were two. That is the same wrong-binary result as before with the diagnostic removed, so
+`pkill -f 'qemu-system-x86_6[4].*reims-vgpu'` before the boot is now load-bearing rather than
+merely tidy. Where two guests must genuinely run at once, give the second its own `GUEST_MAC`.
 
 ### A boot measured next to your own subagents measures the contention
 

--- a/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
@@ -328,6 +328,24 @@ pub struct DeviceFeatures {
     /// pipeline invalid. Same shape as [`Self::dual_src_blend`] — optional
     /// core, asked rather than assumed, declined by name where absent.
     pub fill_mode_non_solid: bool,
+    /// `VkPhysicalDeviceFeatures::textureCompressionBC` — whether this device
+    /// can sample the BC (DXT / S3TC) block-compressed families.
+    ///
+    /// One bit covers BC1 through BC7, which is why
+    /// `pixel_format::MTL_FORMAT_BC1_RGBA`'s doc admits the family whole: there
+    /// is no per-member capability to measure. Enabling it also brings the
+    /// guarantees the sampled rail relies on — Vulkan's mandatory-format table
+    /// requires `SAMPLED_IMAGE`, `SAMPLED_IMAGE_FILTER_LINEAR` and `BLIT_SRC`
+    /// of every BC format on a device that has this feature enabled, so no
+    /// per-format query is owed either.
+    ///
+    /// **Asked and enabled rather than assumed**, and this one genuinely
+    /// divides hosts: desktop GPUs have it and Apple GPUs do not — they carry
+    /// ASTC instead — so the arm64/Metal pathways and MoltenVK refuse a BC
+    /// bind by name. Creating a BC image without the feature enabled is invalid
+    /// use, not a slower path, which is why the gate is at
+    /// `draw::texture_view::NativeUploads` and not a `#[cfg]`.
+    pub texture_compression_bc: bool,
     /// `VkPhysicalDeviceFeatures::depthClamp` — whether a pipeline may set
     /// `depthClampEnable`.
     ///
@@ -422,6 +440,7 @@ impl DeviceFeatures {
             .shader_storage_image_read_without_format(self.storage_image_read_without_format)
             .dual_src_blend(self.dual_src_blend)
             .fill_mode_non_solid(self.fill_mode_non_solid)
+            .texture_compression_bc(self.texture_compression_bc)
             .depth_clamp(self.depth_clamp)
             .multi_viewport(self.multi_viewport)
             .occlusion_query_precise(self.occlusion_query_precise)
@@ -534,6 +553,7 @@ impl DeviceFeatures {
             storage_image_write_without_format,
             storage_image_read_without_format,
             bgra8_storage,
+            texture_compression_bc,
             sampled_linear_filter,
             color_attachment_blend,
             storage16,
@@ -579,6 +599,7 @@ impl DeviceFeatures {
              max_compute_shared_memory_bytes={max_compute_shared_memory_bytes} \
              max_sample_count={max_sample_count} d24_unorm_s8_attachment={d24_unorm_s8_attachment} \
              shader_int16={shader_int16} shader_int64={shader_int64} \
+             texture_compression_bc={texture_compression_bc} \
              sampled_image_array_dynamic_indexing={sampled_image_array_dynamic_indexing} \
              storage_image_array_dynamic_indexing={storage_image_array_dynamic_indexing} \
              sampled_image_descriptor_limit={sampled_image_descriptor_limit} \
@@ -762,6 +783,7 @@ pub unsafe fn query(
         sampler_anisotropy: supported.sampler_anisotropy == vk::TRUE,
         dual_src_blend: supported.dual_src_blend == vk::TRUE,
         fill_mode_non_solid: supported.fill_mode_non_solid == vk::TRUE,
+        texture_compression_bc: supported.texture_compression_bc == vk::TRUE,
         depth_clamp: supported.depth_clamp == vk::TRUE,
         multi_viewport: supported.multi_viewport == vk::TRUE,
         occlusion_query_precise: supported.occlusion_query_precise == vk::TRUE,
@@ -829,6 +851,7 @@ mod tests {
         DeviceFeatures {
             occlusion_query_precise: true,
             robust_buffer_access: true,
+            texture_compression_bc: true,
             sampler_anisotropy: true,
             max_sampler_anisotropy: 16.0,
             max_image_dimension_2d: 16384,

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -1870,11 +1870,18 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                 },
             ));
         }
-        // Footprint of one texel of the image's own format. `None` means a
-        // format whose bytes are not one number per texel (block-compressed,
-        // multi-planar) reached a rail that sizes a linear buffer — decline by
-        // name rather than compute a wrong length.
-        let Some(texel) = super::super::translate::pixel::bytes_per_texel(image.format) else {
+        // Storage grid of the image's own format. `None` means a format whose
+        // footprint this table cannot describe at all (multi-planar) reached a
+        // rail that sizes a linear buffer — decline by name rather than compute
+        // a wrong length.
+        //
+        // The **grid** and not a bytes-per-texel, because a block-compressed
+        // image is a legitimate sampled bind and its buffer is a quarter as wide
+        // and a quarter as tall in blocks as it is in texels. Sizing one per
+        // texel over-counts by sixteen and refuses the guest's own
+        // correctly-sized bytes as `SampledBytesLength` — which is a refusal
+        // wearing the name of a guest error.
+        let Some(block) = super::super::translate::pixel::vk_block_geometry(image.format) else {
             return Err(DrawError::DrawValidation(
                 DrawValidationDecline::SampledNoLinearTexelFootprint {
                     binding: image.binding,
@@ -1882,22 +1889,21 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                 },
             ));
         };
-        let texel = texel as usize;
         // Four factors, so the widening the operands already carry is not
         // enough — see the target-seed check above for why two of them exhaust
         // a u64 on their own. `contract::extent` owns the checked form.
-        let Some(expected) = crate::contract::extent::tight_layered_image_bytes(
+        let Some(expected) = crate::contract::extent::tight_layered_block_bytes(
             image.width,
             image.height,
             image.layers,
-            texel,
+            block,
         ) else {
             return Err(DrawError::DrawValidation(
                 DrawValidationDecline::UnrepresentableImageBytes {
                     width: image.width,
                     height: image.height,
                     layers: image.layers,
-                    bytes_per_texel: texel as u32,
+                    bytes_per_texel: block.bytes,
                 },
             ));
         };
@@ -1943,12 +1949,42 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                         },
                     ));
                 }
+                // Every count below is in units of the image's storage grid —
+                // rows of blocks and bytes per block — which for an
+                // uncompressed format is exactly the texel arithmetic this
+                // always was (a 1x1 block whose bytes are the bytes-per-texel).
+                // `bufferRowLength` stays Vulkan's unit, texels: the stride in
+                // bytes is `(row_length / block.width) * block.bytes`, and a
+                // row length that does not divide into whole blocks cannot
+                // describe a compressed row at all, so it refuses as a stride
+                // defect rather than rounding into a shifted image.
+                let texel = block.bytes as usize;
                 let planes = image.layers as usize;
+                let storage_rows = block.block_rows(image.height) as usize;
+                let tight_row = block.blocks_across(image.width) as usize * texel;
+                if storage_rows == 0 || tight_row == 0 {
+                    return Err(DrawError::DrawValidation(
+                        DrawValidationDecline::SampledZeroGeometry {
+                            binding: image.binding,
+                            width: image.width,
+                            height: image.height,
+                            layers: image.layers,
+                        },
+                    ));
+                }
                 let run_expected = if src.row_length_texels == 0 {
                     expected
                 } else {
-                    let stride = src.row_length_texels as usize * texel;
-                    let tight_row = image.width as usize * texel;
+                    if !src.row_length_texels.is_multiple_of(block.width) {
+                        return Err(DrawError::DrawValidation(
+                            DrawValidationDecline::GuestSampleRowStride {
+                                binding: image.binding,
+                                stride: src.row_length_texels as usize,
+                                tight_row,
+                            },
+                        ));
+                    }
+                    let stride = (src.row_length_texels / block.width) as usize * texel;
                     if stride < tight_row {
                         return Err(DrawError::DrawValidation(
                             DrawValidationDecline::GuestSampleRowStride {
@@ -1958,8 +1994,8 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                             },
                         ));
                     }
-                    (planes - 1) * image.height as usize * stride
-                        + (image.height as usize - 1) * stride
+                    (planes - 1) * storage_rows * stride
+                        + (storage_rows - 1) * stride
                         + tight_row
                 };
                 if src.total_len as usize != run_expected {

--- a/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
@@ -407,12 +407,30 @@ struct DeviceCapabilitySnapshot(u64);
 
 const CAP_MAX_DIMENSION_BITS: u32 = u32::BITS;
 const CAP_LAYOUT_SHIFT: u32 = CAP_MAX_DIMENSION_BITS;
-const CAP_GPU_ONLY_BIT: u32 =
-    CAP_LAYOUT_SHIFT + crate::contract::pixel_format::TexelLayout::ALL.len() as u32;
+/// Both per-layout masks span the **uncompressed** vocabulary only.
+///
+/// Two masks of the full `TexelLayout::ALL` no longer fit beside a `u32`
+/// dimension and two flags in one word, and the assertion below is what said so
+/// — it failed the build the moment the ten BC layouts were declared, which is
+/// exactly what a `const` relation is for. Narrowing rather than widening is
+/// also the right answer on the merits: a block-compressed layout is never a
+/// colour attachment, and Vulkan's mandatory-format table already guarantees it
+/// linear filtering wherever `textureCompressionBC` is enabled. See
+/// `TexelLayout::UNCOMPRESSED_COUNT`.
+const CAP_LAYOUT_COUNT: u32 =
+    crate::contract::pixel_format::TexelLayout::UNCOMPRESSED_COUNT as u32;
+const CAP_GPU_ONLY_BIT: u32 = CAP_LAYOUT_SHIFT + CAP_LAYOUT_COUNT;
 const CAP_SAMPLED_FILTER_SHIFT: u32 = CAP_GPU_ONLY_BIT + 1;
-const CAP_PUBLISHED_BIT: u32 =
-    CAP_SAMPLED_FILTER_SHIFT + crate::contract::pixel_format::TexelLayout::ALL.len() as u32;
-const _: () = assert!(CAP_PUBLISHED_BIT < u64::BITS);
+const CAP_PUBLISHED_BIT: u32 = CAP_SAMPLED_FILTER_SHIFT + CAP_LAYOUT_COUNT;
+/// Whether this device can sample the BC block-compressed families.
+///
+/// One bit for the whole family, because Vulkan gates BC1 through BC7 behind one
+/// feature — see `caps::device_features::DeviceFeatures::texture_compression_bc`.
+/// It rides this word rather than being asked under the engine lock for the
+/// reason the rest of it does: the sampled ladder consults it while a draw
+/// request is being assembled, before the engine transaction opens.
+const CAP_TEXTURE_COMPRESSION_BC_BIT: u32 = CAP_PUBLISHED_BIT + 1;
+const _: () = assert!(CAP_TEXTURE_COMPRESSION_BC_BIT < u64::BITS);
 
 impl DeviceCapabilitySnapshot {
     const CONSERVATIVE: Self =
@@ -427,18 +445,26 @@ impl DeviceCapabilitySnapshot {
         quirks: crate::backend::vulkan::caps::DriverQuirk,
     ) -> Self {
         let mut word = u64::from(features.max_image_dimension_2d);
-        for (index, supported) in features.color_attachment_blend.iter().enumerate() {
-            if *supported {
-                word |= 1_u64 << (CAP_LAYOUT_SHIFT + index as u32);
+        // Walked by layout rather than by array position: the feature arrays are
+        // indexed by `TexelLayout::index()` over the whole vocabulary and the
+        // masks by `uncompressed_index()` over part of it, so enumerating the
+        // array would put a layout's answer in another layout's bit.
+        for layout in crate::contract::pixel_format::TexelLayout::ALL {
+            let Some(bit) = layout.uncompressed_index() else {
+                continue;
+            };
+            if features.color_attachment_blend[layout.index()] {
+                word |= 1_u64 << (CAP_LAYOUT_SHIFT + bit as u32);
+            }
+            if features.sampled_linear_filter[layout.index()] {
+                word |= 1_u64 << (CAP_SAMPLED_FILTER_SHIFT + bit as u32);
             }
         }
         if !quirks.guest_pages_stay_authoritative {
             word |= 1_u64 << CAP_GPU_ONLY_BIT;
         }
-        for (index, supported) in features.sampled_linear_filter.iter().enumerate() {
-            if *supported {
-                word |= 1_u64 << (CAP_SAMPLED_FILTER_SHIFT + index as u32);
-            }
+        if features.texture_compression_bc {
+            word |= 1_u64 << CAP_TEXTURE_COMPRESSION_BC_BIT;
         }
         word |= 1_u64 << CAP_PUBLISHED_BIT;
         Self(word)
@@ -452,19 +478,50 @@ impl DeviceCapabilitySnapshot {
         self,
         layout: crate::contract::pixel_format::TexelLayout,
     ) -> bool {
-        self.0 & (1_u64 << (CAP_LAYOUT_SHIFT + layout.index() as u32)) != 0
+        let Some(bit) = layout.uncompressed_index() else {
+            // No host renders into a block-compressed format, and this device
+            // does not ask it to: `pixel_format::render_target_bpp` has no BC
+            // arm, so the resolve refuses one before reaching here. Answering
+            // `false` keeps that true instead of reading a bit the word does not
+            // carry.
+            return false;
+        };
+        self.0 & (1_u64 << (CAP_LAYOUT_SHIFT + bit as u32)) != 0
     }
 
     fn deferred_gpu_only_content_allowed(self) -> bool {
         self.0 & (1_u64 << CAP_GPU_ONLY_BIT) != 0
     }
 
+    /// Whether the published device sampled BC formats, or `None` before any
+    /// device has published.
+    ///
+    /// `None` rather than `false` for the unpublished case, so a caller creates
+    /// the device and asks it rather than refusing every compressed texture for
+    /// the life of a process that simply had not drawn yet — the same shape
+    /// [`Self::sampled_layout_linear_filter_if_published`] has.
+    fn texture_compression_bc_if_published(self) -> Option<bool> {
+        (self.0 & (1_u64 << CAP_PUBLISHED_BIT) != 0)
+            .then_some(self.0 & (1_u64 << CAP_TEXTURE_COMPRESSION_BC_BIT) != 0)
+    }
+
     fn sampled_layout_linear_filter_if_published(
         self,
         layout: crate::contract::pixel_format::TexelLayout,
     ) -> Option<bool> {
-        (self.0 & (1_u64 << CAP_PUBLISHED_BIT) != 0)
-            .then_some(self.0 & (1_u64 << (CAP_SAMPLED_FILTER_SHIFT + layout.index() as u32)) != 0)
+        if self.0 & (1_u64 << CAP_PUBLISHED_BIT) == 0 {
+            return None;
+        }
+        let Some(bit) = layout.uncompressed_index() else {
+            // Vulkan's mandatory-format table requires
+            // `SAMPLED_IMAGE_FILTER_LINEAR` of every BC format on a device that
+            // enables `textureCompressionBC`, and that feature is what admits
+            // the format at `translate::pixel::sampled_pixels` in the first
+            // place. So there is nothing to query — the same unconditional
+            // reading `R16_SFLOAT` gets from the spec, one family over.
+            return Some(true);
+        };
+        Some(self.0 & (1_u64 << (CAP_SAMPLED_FILTER_SHIFT + bit as u32)) != 0)
     }
 }
 
@@ -2336,7 +2393,47 @@ pub fn supports_sampled_layout_linear_filter(
         ..
     } = &mut *guard;
     match owner.ensure(counters) {
-        Ok(ctx) => ctx.sampled_linear_filter[layout.index()],
+        Ok(ctx) => {
+            if layout.is_block_compressed() {
+                // Mandated by the spec wherever the family is available at all,
+                // so there is nothing in this array to read and its BC entries
+                // are never written. Same answer the published snapshot gives.
+                ctx.features.texture_compression_bc
+            } else {
+                ctx.sampled_linear_filter[layout.index()]
+            }
+        }
+        Err(error) => {
+            engine_probe_decline(EngineProbe::SampledLayoutLinearFilter, &error)
+                .fail_once(EngineProbe::SampledLayoutLinearFilter.discriminant());
+            false
+        }
+    }
+}
+
+/// Whether this host samples the BC block-compressed families.
+///
+/// The gate `runtime::draw::texture_view::NativeUploads` carries into the linear
+/// sampled loaders. Structured exactly like
+/// [`supports_sampled_layout_linear_filter`]: the lock-free snapshot when a
+/// device has published, and otherwise the first query is allowed to create one.
+///
+/// A `false` here is not a slow path — there is no CPU decompressor and there
+/// will not be one — so it becomes a typed refusal and the guest loses that
+/// texture. That is the honest answer for a host without the format: Apple GPUs
+/// carry ASTC instead, so the arm64 pathways and MoltenVK read `false`.
+pub fn supports_block_compressed_sampled() -> bool {
+    if let Some(supported) = device_capabilities().texture_compression_bc_if_published() {
+        return supported;
+    }
+    let mut guard = lock_engine();
+    let EngineState {
+        ref mut owner,
+        ref counters,
+        ..
+    } = &mut *guard;
+    match owner.ensure(counters) {
+        Ok(ctx) => ctx.features.texture_compression_bc,
         Err(error) => {
             engine_probe_decline(EngineProbe::SampledLayoutLinearFilter, &error)
                 .fail_once(EngineProbe::SampledLayoutLinearFilter.discriminant());

--- a/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
@@ -147,6 +147,48 @@ pub fn translate(mtl: u16) -> Result<PixelFormat, TranslateReason> {
             srgb(vk::Format::B8G8R8A8_SRGB, vk::Format::B8G8R8A8_UNORM, 4)
         }
         p::MTL_FORMAT_RGB9E5_FLOAT => linear(vk::Format::E5B9G9R9_UFLOAT_PACK32, 4),
+        // The BC block-compressed families. `bytes_per_texel` here is bytes per
+        // **4x4 block** — 8 or 16 — which is what `pixel_format::block_geometry`
+        // says and what every sizing expression on the sampled rail asks for.
+        // The uncompressed arms above are the same field with a 1x1 block, so
+        // this is not a second meaning; it is the same number with the grid
+        // stated. See `pixel_format::MTL_FORMAT_BC1_RGBA` for why the family
+        // arrives whole and `caps::device_features::DeviceFeatures::
+        // texture_compression_bc` for the one feature that gates all of it.
+        p::MTL_FORMAT_BC1_RGBA => linear(vk::Format::BC1_RGBA_UNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC1_RGBA_SRGB => srgb(
+            vk::Format::BC1_RGBA_SRGB_BLOCK,
+            vk::Format::BC1_RGBA_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+        ),
+        p::MTL_FORMAT_BC2_RGBA => linear(vk::Format::BC2_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC2_RGBA_SRGB => srgb(
+            vk::Format::BC2_SRGB_BLOCK,
+            vk::Format::BC2_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
+        p::MTL_FORMAT_BC3_RGBA => linear(vk::Format::BC3_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC3_RGBA_SRGB => srgb(
+            vk::Format::BC3_SRGB_BLOCK,
+            vk::Format::BC3_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
+        p::MTL_FORMAT_BC4_R_UNORM => linear(vk::Format::BC4_UNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC4_R_SNORM => linear(vk::Format::BC4_SNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC5_RG_UNORM => linear(vk::Format::BC5_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC5_RG_SNORM => linear(vk::Format::BC5_SNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC6H_RGB_FLOAT => {
+            linear(vk::Format::BC6H_SFLOAT_BLOCK, p::BC_BLOCK_BYTES_16)
+        }
+        p::MTL_FORMAT_BC6H_RGB_UFLOAT => {
+            linear(vk::Format::BC6H_UFLOAT_BLOCK, p::BC_BLOCK_BYTES_16)
+        }
+        p::MTL_FORMAT_BC7_RGBA_UNORM => linear(vk::Format::BC7_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB => srgb(
+            vk::Format::BC7_SRGB_BLOCK,
+            vk::Format::BC7_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
         // The packed 32-bit colour family. Each Vulkan spelling is the same
         // word cut the same way as its Metal one — `A2B10G10R10` puts red in
         // the low bits as `RGB10A2Unorm` does, `A2R10G10B10` puts blue there as
@@ -213,6 +255,14 @@ pub fn sampled_pixels(
     mtl: u16,
 ) -> Result<(TexelLayout, Option<TranslateReason>, SwizzlePlan), TranslateReason> {
     let f = translate(mtl)?;
+    // The compressed families answer from the contract rather than from a
+    // `linear_vk` arm here, because `runtime::draw::texture_view` needs the same
+    // answer and cannot reach this module. One mapping, asked twice — see
+    // `pixel_format::block_compressed_layout`. Whether this host can sample it
+    // is a capability the rail carries, not a fact of the translation.
+    if let Some(layout) = pixel_format::block_compressed_layout(mtl) {
+        return Ok((layout, None, pixel_format::swizzle_identity()));
+    }
     // A format whose Metal channels do not sit identically on its Vulkan
     // channels needs a component mapping on the view to sample correctly.
     let layout = match f.linear_vk {
@@ -289,6 +339,20 @@ pub fn vk_texel_layout(layout: TexelLayout) -> vk::Format {
         TexelLayout::Rgb10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
         TexelLayout::Bgr10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,
         TexelLayout::Rg11b10Float => vk::Format::B10G11R11_UFLOAT_PACK32,
+        // The BC families. Each Metal spelling and its Vulkan counterpart are
+        // the same block layout with the same bytes in the same order, so the
+        // guest's payload is uploaded verbatim — which is why these need no
+        // conversion arm anywhere and are admitted as one family.
+        TexelLayout::Bc1Rgba => vk::Format::BC1_RGBA_UNORM_BLOCK,
+        TexelLayout::Bc2Rgba => vk::Format::BC2_UNORM_BLOCK,
+        TexelLayout::Bc3Rgba => vk::Format::BC3_UNORM_BLOCK,
+        TexelLayout::Bc4RUnorm => vk::Format::BC4_UNORM_BLOCK,
+        TexelLayout::Bc4RSnorm => vk::Format::BC4_SNORM_BLOCK,
+        TexelLayout::Bc5RgUnorm => vk::Format::BC5_UNORM_BLOCK,
+        TexelLayout::Bc5RgSnorm => vk::Format::BC5_SNORM_BLOCK,
+        TexelLayout::Bc6hRgbFloat => vk::Format::BC6H_SFLOAT_BLOCK,
+        TexelLayout::Bc6hRgbUfloat => vk::Format::BC6H_UFLOAT_BLOCK,
+        TexelLayout::Bc7Rgba => vk::Format::BC7_UNORM_BLOCK,
     }
 }
 
@@ -306,6 +370,13 @@ pub fn srgb_texel_layout(layout: TexelLayout) -> Option<vk::Format> {
     match layout {
         TexelLayout::Rgba8 => Some(vk::Format::R8G8B8A8_SRGB),
         TexelLayout::Bgra8 => Some(vk::Format::B8G8R8A8_SRGB),
+        // The four BC families Apple gives an sRGB spelling. BC4/BC5 are
+        // single- and two-channel data rather than colour and BC6H is HDR
+        // float, so none of the three has one on either side of the boundary.
+        TexelLayout::Bc1Rgba => Some(vk::Format::BC1_RGBA_SRGB_BLOCK),
+        TexelLayout::Bc2Rgba => Some(vk::Format::BC2_SRGB_BLOCK),
+        TexelLayout::Bc3Rgba => Some(vk::Format::BC3_SRGB_BLOCK),
+        TexelLayout::Bc7Rgba => Some(vk::Format::BC7_SRGB_BLOCK),
         _ => None,
     }
 }
@@ -384,6 +455,15 @@ pub fn storage_format(format: vk::Format) -> vk::Format {
     match format {
         vk::Format::R8G8B8A8_SRGB => vk::Format::R8G8B8A8_UNORM,
         vk::Format::B8G8R8A8_SRGB => vk::Format::B8G8R8A8_UNORM,
+        // The four BC families with an sRGB spelling. Same rule one storage
+        // shape over: a compressed image's blocks are identical bytes under
+        // either qualifier, so both spellings must resolve to one allocation
+        // and differ only in the view. `the_srgb_spelling_of_a_layout_stores_
+        // that_layout` is what holds this to `srgb_texel_layout`.
+        vk::Format::BC1_RGBA_SRGB_BLOCK => vk::Format::BC1_RGBA_UNORM_BLOCK,
+        vk::Format::BC2_SRGB_BLOCK => vk::Format::BC2_UNORM_BLOCK,
+        vk::Format::BC3_SRGB_BLOCK => vk::Format::BC3_UNORM_BLOCK,
+        vk::Format::BC7_SRGB_BLOCK => vk::Format::BC7_UNORM_BLOCK,
         other => other,
     }
 }
@@ -749,6 +829,30 @@ pub fn resident_color(bgra: bool) -> vk::Format {
 /// know is indistinguishable from a block-compressed one and declines by the
 /// same name. Same argument as [`texel_layout_of`] being a search rather than a
 /// second `match`.
+/// The storage **block** grid of a Vulkan format, for the formats this table can
+/// produce.
+///
+/// [`bytes_per_texel`] with the grid stated, and derived from the same
+/// [`texel_layout_of`] search so the two cannot disagree. A caller sizing a
+/// linear buffer for an image must ask this rather than `bytes_per_texel`:
+/// multiplying a block byte count by width and height over-counts a compressed
+/// image by sixteen, which is a refusal against the guest's own correctly-sized
+/// buffer rather than a wrong image.
+///
+/// sRGB spellings fold through [`storage_format`] onto the allocation they share
+/// with their linear sibling. That fold is what covers the four `BC*_SRGB_BLOCK`
+/// formats, which a sampled bind of an sRGB compressed texture is created as.
+pub fn vk_block_geometry(format: vk::Format) -> Option<pixel_format::BlockGeometry> {
+    if let Some(layout) = texel_layout_of(storage_format(format)) {
+        return Some(layout.block());
+    }
+    Some(pixel_format::BlockGeometry {
+        width: 1,
+        height: 1,
+        bytes: bytes_per_texel(format)?,
+    })
+}
+
 pub fn bytes_per_texel(format: vk::Format) -> Option<u32> {
     if let Some(layout) = texel_layout_of(format) {
         return Some(layout.bytes_per_texel());
@@ -1026,6 +1130,21 @@ mod tests {
     ///   pinning that. Admitting it silently here would break the symmetry the
     ///   crate relies on, so it waits for the rail to gain a warning channel.
     ///
+    /// - The **BC block-compressed families** cannot cross this rail at all,
+    ///   and that is structural rather than pending a channel. A
+    ///   [`StorageImageFormat`] is what a compute *storage* binding is created
+    ///   as, and Vulkan has no block-compressed storage-image format — a shader
+    ///   cannot write a block. The compute rail routes its sampled textures
+    ///   through that same selector, so a compressed texture sampled inside a
+    ///   dispatch is refused by name. Giving it a rail of its own means a
+    ///   compute sampled path that does not go through the storage selector,
+    ///   which is a change to that rail and not to this table.
+    ///
+    ///   Measured on the workload that brought the family in: Asphalt 8 samples
+    ///   its BC3 textures from **fragment** shaders only, so this refusal cost
+    ///   nothing there. A guest that samples one in a dispatch loses that
+    ///   dispatch's texture and says so.
+    ///
     /// The converse is deliberately not asserted: this rail carries the integer
     /// and packed formats a compute shader reads and [`sampled_pixels`] has no
     /// [`TexelLayout`] for, because that one answers a CPU-upload byte order and
@@ -1036,6 +1155,23 @@ mod tests {
             (p::MTL_FORMAT_A8_UNORM, "needs a component mapping"),
             (p::MTL_FORMAT_RGBA8_UNORM_SRGB, "would downgrade unrecorded"),
             (p::MTL_FORMAT_BGRA8_UNORM_SRGB, "would downgrade unrecorded"),
+            (p::MTL_FORMAT_BC1_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC1_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC2_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC2_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC3_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC3_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC4_R_UNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC4_R_SNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC5_RG_UNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC5_RG_SNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC6H_RGB_FLOAT, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC6H_RGB_UFLOAT, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC7_RGBA_UNORM, "no block-compressed storage image exists"),
+            (
+                p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+                "no block-compressed storage image exists",
+            ),
         ];
 
         let mut refused = Vec::new();
@@ -1233,6 +1369,94 @@ mod tests {
             4,
             TransferFunction::Linear,
         ),
+        // The BC families. The width column is bytes per 4x4 **block** for
+        // these, which is what `pixel_format::block_geometry` says and what the
+        // sampled rail sizes rows and images from; the uncompressed rows above
+        // are the same field with a 1x1 block.
+        (
+            p::MTL_FORMAT_BC1_RGBA,
+            vk::Format::BC1_RGBA_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC1_RGBA_SRGB,
+            vk::Format::BC1_RGBA_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC2_RGBA,
+            vk::Format::BC2_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC2_RGBA_SRGB,
+            vk::Format::BC2_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC3_RGBA,
+            vk::Format::BC3_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC3_RGBA_SRGB,
+            vk::Format::BC3_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC4_R_UNORM,
+            vk::Format::BC4_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC4_R_SNORM,
+            vk::Format::BC4_SNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC5_RG_UNORM,
+            vk::Format::BC5_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC5_RG_SNORM,
+            vk::Format::BC5_SNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC6H_RGB_FLOAT,
+            vk::Format::BC6H_SFLOAT_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC6H_RGB_UFLOAT,
+            vk::Format::BC6H_UFLOAT_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC7_RGBA_UNORM,
+            vk::Format::BC7_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+            vk::Format::BC7_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
         (
             p::MTL_FORMAT_R16_UNORM,
             vk::Format::R16_UNORM,
@@ -1334,12 +1558,19 @@ mod tests {
     /// The texel size this module reports is the decode contract's, not a
     /// second opinion — the drift `byte_size`-beside-`vk_format` was written to
     /// prevent.
+    ///
+    /// Compared against the contract's **block** size rather than its
+    /// bytes-per-texel. For every uncompressed format those are the same number
+    /// — the block is 1x1 — and for the BC families only the block form exists,
+    /// because a BC1 texel is half a byte and `bytes_per_pixel` says `None` on
+    /// purpose. So this is the stronger reading of the same invariant, not a
+    /// weakened one.
     #[test]
     fn texel_size_agrees_with_the_decode_contract() {
         for (mtl, _, _, _) in EXPECTED {
             assert_eq!(
                 Some(translate(*mtl).unwrap().bytes_per_texel),
-                pixel_format::bytes_per_pixel(*mtl),
+                pixel_format::block_geometry(*mtl).map(|block| block.bytes),
                 "MTL {mtl:#x}"
             );
         }
@@ -1917,6 +2148,27 @@ mod tests {
                 p::MTL_FORMAT_RGB10A2_UNORM,
                 p::MTL_FORMAT_RG11B10_FLOAT,
                 p::MTL_FORMAT_BGR10A2_UNORM,
+                // The BC block-compressed families, in `EXPECTED`'s order.
+                // Named unconditionally here because `sampled_pixels` is a
+                // decode fact: whether this host can sample one is
+                // `engine::supports_block_compressed_sampled`, which the rail
+                // carries in `NativeUploads::block_compressed`. A host without
+                // the feature refuses the bind by name — it does not make the
+                // format untranslatable.
+                p::MTL_FORMAT_BC1_RGBA,
+                p::MTL_FORMAT_BC1_RGBA_SRGB,
+                p::MTL_FORMAT_BC2_RGBA,
+                p::MTL_FORMAT_BC2_RGBA_SRGB,
+                p::MTL_FORMAT_BC3_RGBA,
+                p::MTL_FORMAT_BC3_RGBA_SRGB,
+                p::MTL_FORMAT_BC4_R_UNORM,
+                p::MTL_FORMAT_BC4_R_SNORM,
+                p::MTL_FORMAT_BC5_RG_UNORM,
+                p::MTL_FORMAT_BC5_RG_SNORM,
+                p::MTL_FORMAT_BC6H_RGB_FLOAT,
+                p::MTL_FORMAT_BC6H_RGB_UFLOAT,
+                p::MTL_FORMAT_BC7_RGBA_UNORM,
+                p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
                 // The ten-bit biplanar video planes and the four-channel
                 // sixteen-bit unorm. These three were carried by `translate`
                 // and by the layout table but were absent from `EXPECTED`, so
@@ -1956,6 +2208,19 @@ mod tests {
                 p::MTL_FORMAT_RGBA8_UNORM_SRGB,
                 p::MTL_FORMAT_BGRA8_UNORM,
                 p::MTL_FORMAT_BGRA8_UNORM_SRGB,
+                // The first packed 32-bit colour attachment, and the first one
+                // admitted for a *game* rather than for the window server. An
+                // `'l10r'` IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`
+                // — is what Asphalt 8 renders into on a macos-13 x86/Vulkan
+                // boot, and every draw of it failed at
+                // `draw::render_target`'s `rt_type4_base_format` until the
+                // FourCC and `render_target_bpp` both named it.
+                //
+                // Unlike every other member here this one is not a format
+                // Vulkan mandates for `COLOR_ATTACHMENT_BIT`, so a host may
+                // decline it and this rail is where that decline appears. The
+                // NVIDIA host it was measured on advertises it.
+                p::MTL_FORMAT_BGR10A2_UNORM,
                 // Admitted since the two arms became one answer. The contract
                 // has said a half-float render target is renderable since one
                 // could be created at that format; only this side still refused

--- a/crates/reims-vgpu/src/contract/extent.rs
+++ b/crates/reims-vgpu/src/contract/extent.rs
@@ -126,6 +126,35 @@ pub fn tight_layered_image_bytes(
         .ok()
 }
 
+/// [`tight_layered_image_bytes`] over a storage **block** grid.
+///
+/// The same product with the grid stated, so it covers a block-compressed image
+/// as well as an uncompressed one: an uncompressed block is 1x1 and its `bytes`
+/// is the bytes-per-texel, so this reduces to the sibling above for every format
+/// that has one. Blocks round *up* on both axes, which is the contract — a 2x2
+/// BC3 level still occupies one whole sixteen-byte block.
+///
+/// Zero on either axis is `None` for [`tight_image_bytes`]'s reason: a zero
+/// length passes every "does the guest's buffer hold this" check there is.
+pub fn tight_layered_block_bytes(
+    width: u32,
+    height: u32,
+    layers: u32,
+    block: crate::contract::pixel_format::BlockGeometry,
+) -> Option<usize> {
+    if layers == 0 || width == 0 || height == 0 || block.bytes == 0 {
+        return None;
+    }
+    let across = u64::from(block.blocks_across(width));
+    let down = u64::from(block.block_rows(height));
+    across
+        .checked_mul(down)?
+        .checked_mul(u64::from(block.bytes))?
+        .checked_mul(u64::from(layers))?
+        .try_into()
+        .ok()
+}
+
 /// [`tight_image_bytes`] together with the row stride it implies, as one pair.
 ///
 /// For the callers that hand a buffer to a texel-copy API. Such a call is given

--- a/crates/reims-vgpu/src/contract/pixel_format.rs
+++ b/crates/reims-vgpu/src/contract/pixel_format.rs
@@ -131,6 +131,232 @@ pub const MTL_FORMAT_BGR10A2_UNORM: u16 = 0x5e;
 /// answered `None`, so every path that asks about a texel width refused it, not
 /// just the sampled one.
 pub const MTL_FORMAT_RGBA16_UNORM: u16 = 0x6e;
+/// The BC (a.k.a. DXT / S3TC) block-compressed families, as Apple numbers them.
+///
+/// Every one of these stores a **4x4 block of texels** in a fixed 8 or 16 bytes,
+/// which is what separates them from everything else in this file: there is no
+/// bytes-per-texel for a BC1 texel — it is half a byte — so
+/// [`bytes_per_pixel`] deliberately answers `None` for all of them and
+/// [`block_geometry`] is the accessor that can describe them. That `None` is
+/// load-bearing: it is what keeps a BC format out of every rail that sizes work
+/// per texel, which is every rail except the sampled bind.
+///
+/// # Why the whole family arrives at once
+///
+/// Elsewhere this file adds members on measurement — `RG8_UNORM` is still absent
+/// from [`render_target_bpp`] for exactly that reason. This family is added
+/// whole, and the difference is real rather than convenience:
+///
+/// * **One capability covers all of them.** Vulkan gates BC1 through BC7 behind
+///   the single `textureCompressionBC` feature bit, and Metal behind the single
+///   `supportsBCTextureCompression`. There is no per-member capability to
+///   measure, so a member left out is refused by *this table* rather than by the
+///   host.
+/// * **There is no per-member conversion to write.** The guest's bytes are the
+///   `VK_FORMAT_BC*_BLOCK` payload already, so a member costs one row in each
+///   mapping and nothing else. The three conversion arms `render_target_bpp`'s
+///   doc obliges a *renderable* format to satisfy do not arise: a BC format is
+///   sampled-only, and every other rail refuses it by name.
+/// * **A partial family is the shape that bites later.** A game ships BC1 for
+///   opaque albedo, BC3 for alpha, BC4/BC5 for single- and two-channel maps and
+///   BC7 for anything modern, in one asset pipeline. Admitting the one that was
+///   measured and refusing its four siblings buys a second black-texture report.
+///
+/// # What was measured
+///
+/// `BC3_RGBA` (`0x86`), on a driven macos-13 x86/Vulkan boot running Asphalt 8:
+/// six distinct textures, and the 12 419 draws that sampled them were the only
+/// draws still failing once the `'l10r'` attachment and the pipeline-tag
+/// refusals were fixed. Its geometry is the confirmation and it is exact — the
+/// guest's own descriptors read `L0=1024x1024 bpr=4096`, which is
+/// `(1024/4) * 16`, with `alloc=1400832` for the eleven-level pyramid of a
+/// 1 MiB base; and `L0=64x64 bpr=256`, which is `(64/4) * 16`. The guest's SDK
+/// names `MTLPixelFormatBC3_RGBA = 134` and its paravirt device answers
+/// `supportsBCTextureCompression = 1`.
+pub const MTL_FORMAT_BC1_RGBA: u16 = 130;
+/// sRGB spelling of [`MTL_FORMAT_BC1_RGBA`]. Identical stored bytes; the
+/// qualifier is the conversion the sampler applies, which is why it folds onto
+/// the same [`TexelLayout`] and is carried as a transfer function instead.
+pub const MTL_FORMAT_BC1_RGBA_SRGB: u16 = 131;
+/// `MTLPixelFormatBC2_RGBA` — 16 bytes a block, four-bit explicit alpha.
+pub const MTL_FORMAT_BC2_RGBA: u16 = 132;
+/// sRGB spelling of [`MTL_FORMAT_BC2_RGBA`].
+pub const MTL_FORMAT_BC2_RGBA_SRGB: u16 = 133;
+/// `MTLPixelFormatBC3_RGBA` — 16 bytes a block, interpolated alpha. DXT5, and
+/// the member this family was measured through.
+pub const MTL_FORMAT_BC3_RGBA: u16 = 134;
+/// sRGB spelling of [`MTL_FORMAT_BC3_RGBA`].
+pub const MTL_FORMAT_BC3_RGBA_SRGB: u16 = 135;
+/// `MTLPixelFormatBC4_RUnorm` — one channel, 8 bytes a block.
+pub const MTL_FORMAT_BC4_R_UNORM: u16 = 140;
+/// `MTLPixelFormatBC4_RSnorm` — the signed twin of [`MTL_FORMAT_BC4_R_UNORM`].
+pub const MTL_FORMAT_BC4_R_SNORM: u16 = 141;
+/// `MTLPixelFormatBC5_RGUnorm` — two channels, 16 bytes a block. The usual
+/// tangent-space normal-map encoding.
+pub const MTL_FORMAT_BC5_RG_UNORM: u16 = 142;
+/// `MTLPixelFormatBC5_RGSnorm` — the signed twin of [`MTL_FORMAT_BC5_RG_UNORM`].
+pub const MTL_FORMAT_BC5_RG_SNORM: u16 = 143;
+/// `MTLPixelFormatBC6H_RGBFloat` — three signed half-float channels, 16 bytes a
+/// block. An HDR source format.
+pub const MTL_FORMAT_BC6H_RGB_FLOAT: u16 = 150;
+/// `MTLPixelFormatBC6H_RGBUfloat` — the unsigned twin of
+/// [`MTL_FORMAT_BC6H_RGB_FLOAT`].
+pub const MTL_FORMAT_BC6H_RGB_UFLOAT: u16 = 151;
+/// `MTLPixelFormatBC7_RGBAUnorm` — 16 bytes a block, the modern four-channel
+/// mode-switching encoding.
+pub const MTL_FORMAT_BC7_RGBA_UNORM: u16 = 152;
+/// sRGB spelling of [`MTL_FORMAT_BC7_RGBA_UNORM`].
+pub const MTL_FORMAT_BC7_RGBA_UNORM_SRGB: u16 = 153;
+
+/// Side of a BC block, in texels. Every BC family uses the same 4x4 grid.
+pub const BC_BLOCK_SIDE: u32 = 4;
+/// Bytes one block occupies in the two BC weight classes.
+pub const BC_BLOCK_BYTES_8: u32 = 8;
+/// The 16-byte class — everything that carries explicit alpha or two channels.
+pub const BC_BLOCK_BYTES_16: u32 = 16;
+/// A 4x4 block of BC1 is 64 texels' worth of colour in 8 bytes, and of BC3 in
+/// 16. Stated as a relation so a wrong constant cannot look right.
+const _: () = assert!(
+    BC_BLOCK_BYTES_16 == BC_BLOCK_BYTES_8 * 2
+        && BC_BLOCK_SIDE * BC_BLOCK_SIDE == 16
+        && BC_BLOCK_BYTES_8 * 2 == BC_BLOCK_SIDE * BC_BLOCK_SIDE
+);
+
+/// The texel grid one addressable unit of storage covers, and its size.
+///
+/// Uncompressed formats have a 1x1 block whose `bytes` is [`bytes_per_pixel`],
+/// so this is not a second vocabulary for them — it is the same number with the
+/// grid stated. That is what lets [`tight_row_bytes`] be one expression for
+/// both families instead of a branch, and what
+/// `a_block_geometry_agrees_with_the_texel_table` holds honest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockGeometry {
+    /// Texels a block spans horizontally.
+    pub width: u32,
+    /// Texels a block spans vertically.
+    pub height: u32,
+    /// Bytes one block occupies.
+    pub bytes: u32,
+}
+
+impl BlockGeometry {
+    /// Blocks needed to cover `texels` along one axis, rounding up.
+    ///
+    /// The rounding is the contract and not a convenience: a 2x2 BC3 mip level
+    /// still occupies one whole 16-byte block, so a caller that divided down
+    /// would read four bytes of a level and none of the tail of a pyramid.
+    pub const fn blocks_for(divisor: u32, texels: u32) -> u32 {
+        if divisor == 0 {
+            return 0;
+        }
+        texels.div_ceil(divisor)
+    }
+
+    /// Blocks in one row of a `texels`-wide image.
+    pub const fn blocks_across(self, texels: u32) -> u32 {
+        Self::blocks_for(self.width, texels)
+    }
+
+    /// Rows of blocks in a `texels`-tall image — what a row loop over this
+    /// format must count, rather than the texel height.
+    pub const fn block_rows(self, texels: u32) -> u32 {
+        Self::blocks_for(self.height, texels)
+    }
+
+    /// Whether this describes a compressed format, i.e. a block wider or taller
+    /// than one texel.
+    pub const fn is_compressed(self) -> bool {
+        self.width > 1 || self.height > 1
+    }
+}
+
+/// Bytes one BC block of `format` occupies, or `None` if it is not a BC format.
+///
+/// The one place the family membership is spelled. Everything else asks
+/// [`block_geometry`] or [`is_block_compressed`].
+const fn bc_block_bytes(format: u16) -> Option<u32> {
+    Some(match format {
+        MTL_FORMAT_BC1_RGBA
+        | MTL_FORMAT_BC1_RGBA_SRGB
+        | MTL_FORMAT_BC4_R_UNORM
+        | MTL_FORMAT_BC4_R_SNORM => BC_BLOCK_BYTES_8,
+        MTL_FORMAT_BC2_RGBA
+        | MTL_FORMAT_BC2_RGBA_SRGB
+        | MTL_FORMAT_BC3_RGBA
+        | MTL_FORMAT_BC3_RGBA_SRGB
+        | MTL_FORMAT_BC5_RG_UNORM
+        | MTL_FORMAT_BC5_RG_SNORM
+        | MTL_FORMAT_BC6H_RGB_FLOAT
+        | MTL_FORMAT_BC6H_RGB_UFLOAT
+        | MTL_FORMAT_BC7_RGBA_UNORM
+        | MTL_FORMAT_BC7_RGBA_UNORM_SRGB => BC_BLOCK_BYTES_16,
+        _ => return None,
+    })
+}
+
+/// Whether `format` stores texels in compressed blocks rather than one at a time.
+pub const fn is_block_compressed(format: u16) -> bool {
+    bc_block_bytes(format).is_some()
+}
+
+/// The [`TexelLayout`] a block-compressed guest format's bytes are already in,
+/// or `None` for an uncompressed one.
+///
+/// **The single mapping**, consulted by both the backend-independent sampled
+/// loaders in `runtime::draw::texture_view` and by
+/// `backend::vulkan::translate::pixel::sampled_pixels`. The uncompressed
+/// families reach their layout through [`sampled_class`], whose vocabulary is
+/// deliberately narrow and has no room for a block; rather than widen it or keep
+/// a second table in the backend, the compressed families are answered here and
+/// both sides ask.
+///
+/// The four sRGB spellings fold onto their linear sibling's layout, as
+/// `RGBA8Unorm_sRGB` folds onto `Rgba8`: identical stored bytes, and the
+/// qualifier travels as [`SampledByteFormat`]'s source format so the bind picks
+/// the `_SRGB_BLOCK` view.
+///
+/// Saying `Some` is **not** a claim that this host can sample it. That is a
+/// capability — `engine::supports_block_compressed_sampled` — and the rail
+/// carries it in `NativeUploads::block_compressed`. Naming the layout
+/// unconditionally is what makes the refusal a typed one rather than an
+/// unrecognised format.
+pub fn block_compressed_layout(format: u16) -> Option<TexelLayout> {
+    Some(match format {
+        MTL_FORMAT_BC1_RGBA | MTL_FORMAT_BC1_RGBA_SRGB => TexelLayout::Bc1Rgba,
+        MTL_FORMAT_BC2_RGBA | MTL_FORMAT_BC2_RGBA_SRGB => TexelLayout::Bc2Rgba,
+        MTL_FORMAT_BC3_RGBA | MTL_FORMAT_BC3_RGBA_SRGB => TexelLayout::Bc3Rgba,
+        MTL_FORMAT_BC4_R_UNORM => TexelLayout::Bc4RUnorm,
+        MTL_FORMAT_BC4_R_SNORM => TexelLayout::Bc4RSnorm,
+        MTL_FORMAT_BC5_RG_UNORM => TexelLayout::Bc5RgUnorm,
+        MTL_FORMAT_BC5_RG_SNORM => TexelLayout::Bc5RgSnorm,
+        MTL_FORMAT_BC6H_RGB_FLOAT => TexelLayout::Bc6hRgbFloat,
+        MTL_FORMAT_BC6H_RGB_UFLOAT => TexelLayout::Bc6hRgbUfloat,
+        MTL_FORMAT_BC7_RGBA_UNORM | MTL_FORMAT_BC7_RGBA_UNORM_SRGB => TexelLayout::Bc7Rgba,
+        _ => return None,
+    })
+}
+
+/// The storage grid `format` addresses, or `None` for a format this crate has
+/// no width for at all.
+///
+/// Derived from [`bytes_per_pixel`] for the uncompressed families rather than
+/// re-listed, so the two cannot disagree — the second spelling is the bug this
+/// avoids having.
+pub fn block_geometry(format: u16) -> Option<BlockGeometry> {
+    if let Some(bytes) = bc_block_bytes(format) {
+        return Some(BlockGeometry {
+            width: BC_BLOCK_SIDE,
+            height: BC_BLOCK_SIDE,
+            bytes,
+        });
+    }
+    Some(BlockGeometry {
+        width: 1,
+        height: 1,
+        bytes: bytes_per_pixel(format)?,
+    })
+}
+
 pub const MTL_FORMAT_RGBA16_UINT: u16 = 0x71;
 pub const MTL_FORMAT_RGBA16_FLOAT: u16 = 0x73;
 pub const MTL_FORMAT_RGBA32_UINT: u16 = 0x7b;
@@ -192,6 +418,18 @@ pub enum SampledClass {
     Bgra8Unorm,
     Rgba16Float,
     Rg16Float,
+    /// The packed 32-bit word `MTLPixelFormatBGR10A2Unorm` stores a texel in.
+    ///
+    /// Declared for the cross-check and not for a CPU upload rail. This class is
+    /// how [`store_texel_order`]'s admission of that format is held against an
+    /// independent statement of the same byte layout, which is what
+    /// `a_byte_copy_destination_is_the_texel_every_other_table_agrees_it_is`
+    /// asks. `runtime::draw::texture_view`'s `linear_native_upload_format`
+    /// answers `None` for it, so a **sampled** bind still takes the native
+    /// packed rail `translate::pixel::sampled_pixels` has carried all along;
+    /// nothing here moves such a bind to the CPU, which could not serve it
+    /// anyway — its channels do not sit on byte boundaries.
+    Bgr10a2Unorm,
 }
 
 /// The byte layout of one guest texel on the sampled rails, independent of any
@@ -305,6 +543,43 @@ pub enum TexelLayout {
     /// sampled natively as `B10G11R11_UFLOAT_PACK32`. An HDR-intermediate
     /// colour format, native for the same reason as its two neighbours.
     Rg11b10Float,
+    // The BC block-compressed layouts. Every one is 4x4 texels in 8 or 16 bytes,
+    // so `bytes_per_texel` answers about a **block** for these and
+    // `block_geometry` is what a caller sizing an image must ask — read that
+    // method's doc before using either on one of these.
+    //
+    // They are the only layouts here that no CPU rail can serve: decoding a
+    // block needs a decompressor this crate does not have and does not want, so
+    // `has_cpu_loader_arm` is false, the two `rgba8` conversions refuse, and the
+    // bind is native or nothing. Nothing is a typed refusal, which is why the
+    // capability gate lives at `translate::pixel::sampled_pixels`.
+    //
+    // The sRGB spellings of BC1/BC2/BC3/BC7 fold onto these same layouts, as
+    // `Rgba8`'s sRGB spelling folds onto `Rgba8`: the stored bytes are
+    // identical and the qualifier is a sampler conversion carried by
+    // `SampledByteFormat`'s source format.
+    /// 8 bytes per 4x4 block — BC1/DXT1, three colour channels plus one bit of
+    /// alpha, sampled as `VK_FORMAT_BC1_RGBA_UNORM_BLOCK`.
+    Bc1Rgba,
+    /// 16 bytes per 4x4 block — BC2/DXT3, four-bit explicit alpha.
+    Bc2Rgba,
+    /// 16 bytes per 4x4 block — BC3/DXT5, interpolated alpha. The member a guest
+    /// was measured binding; see [`MTL_FORMAT_BC3_RGBA`].
+    Bc3Rgba,
+    /// 8 bytes per 4x4 block — BC4, one unsigned channel.
+    Bc4RUnorm,
+    /// 8 bytes per 4x4 block — BC4, one signed channel.
+    Bc4RSnorm,
+    /// 16 bytes per 4x4 block — BC5, two unsigned channels.
+    Bc5RgUnorm,
+    /// 16 bytes per 4x4 block — BC5, two signed channels.
+    Bc5RgSnorm,
+    /// 16 bytes per 4x4 block — BC6H, three signed half-float channels (HDR).
+    Bc6hRgbFloat,
+    /// 16 bytes per 4x4 block — BC6H, three unsigned half-float channels.
+    Bc6hRgbUfloat,
+    /// 16 bytes per 4x4 block — BC7, four channels, mode-switching.
+    Bc7Rgba,
 }
 
 impl TexelLayout {
@@ -331,6 +606,16 @@ impl TexelLayout {
         Self::Rgb10a2Unorm,
         Self::Bgr10a2Unorm,
         Self::Rg11b10Float,
+        Self::Bc1Rgba,
+        Self::Bc2Rgba,
+        Self::Bc3Rgba,
+        Self::Bc4RUnorm,
+        Self::Bc4RSnorm,
+        Self::Bc5RgUnorm,
+        Self::Bc5RgSnorm,
+        Self::Bc6hRgbFloat,
+        Self::Bc6hRgbUfloat,
+        Self::Bc7Rgba,
     ];
 
     /// This layout's position in [`Self::ALL`], so a host-side table can be an
@@ -357,10 +642,164 @@ impl TexelLayout {
             Self::Rgb10a2Unorm => 11,
             Self::Bgr10a2Unorm => 12,
             Self::Rg11b10Float => 13,
+            Self::Bc1Rgba => 14,
+            Self::Bc2Rgba => 15,
+            Self::Bc3Rgba => 16,
+            Self::Bc4RUnorm => 17,
+            Self::Bc4RSnorm => 18,
+            Self::Bc5RgUnorm => 19,
+            Self::Bc5RgSnorm => 20,
+            Self::Bc6hRgbFloat => 21,
+            Self::Bc6hRgbUfloat => 22,
+            Self::Bc7Rgba => 23,
         }
     }
 
-    /// Bytes occupied by one texel in guest linear storage.
+    /// The texel grid one unit of this layout's storage covers.
+    ///
+    /// 1x1 for every uncompressed layout, 4x4 for the BC families. A caller
+    /// sizing an image or striding a row must ask this rather than
+    /// [`Self::bytes_per_texel`], which for a BC layout answers about a block
+    /// and would under-count a row by four and an image by sixteen.
+    pub fn block(self) -> BlockGeometry {
+        let side = if self.is_block_compressed() {
+            BC_BLOCK_SIDE
+        } else {
+            1
+        };
+        BlockGeometry {
+            width: side,
+            height: side,
+            bytes: self.bytes_per_texel(),
+        }
+    }
+
+    /// Whether this layout stores a 4x4 block per addressable unit.
+    ///
+    /// Exhaustive rather than a range test on [`Self::index`]: the positions are
+    /// an implementation detail of the table above and a new uncompressed layout
+    /// appended after the BC block would silently join the compressed set.
+    pub const fn is_block_compressed(self) -> bool {
+        match self {
+            Self::Rgba8
+            | Self::Bgra8
+            | Self::R8
+            | Self::Rg8
+            | Self::R16Float
+            | Self::R32Float
+            | Self::R16Unorm
+            | Self::Rg16Unorm
+            | Self::Rgba16Float
+            | Self::Rg16Float
+            | Self::Rgba16Unorm
+            | Self::Rgb10a2Unorm
+            | Self::Bgr10a2Unorm
+            | Self::Rg11b10Float => false,
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => true,
+        }
+    }
+
+    /// How many of [`Self::ALL`] address one texel at a time.
+    ///
+    /// Counted from `ALL` rather than written down, so it cannot fall behind the
+    /// vocabulary. It exists because `backend::vulkan::engine`'s
+    /// `DeviceCapabilitySnapshot` packs **two** per-layout bitmasks into one
+    /// atomically-published `u64`, and two masks of the full vocabulary no
+    /// longer fit — the `const` assertion there is what said so when the BC
+    /// families were added, which is the whole reason that assertion exists.
+    ///
+    /// Narrowing the masks rather than widening the word is right on the merits
+    /// and not only on the bit budget: both masks answer questions a
+    /// block-compressed layout is never asked. One is colour-attachment blend,
+    /// and no BC format is a colour attachment on any host. The other is
+    /// sampled linear filtering, which Vulkan's mandatory-format table
+    /// *requires* for every BC format on a device that enables
+    /// `textureCompressionBC` — so there is nothing to query.
+    pub const UNCOMPRESSED_COUNT: usize = {
+        let mut count = 0;
+        let mut i = 0;
+        while i < Self::ALL.len() {
+            if !Self::ALL[i].is_block_compressed() {
+                count += 1;
+            }
+            i += 1;
+        }
+        count
+    };
+
+    /// This layout's position among the uncompressed layouts, or `None` for a
+    /// block-compressed one.
+    ///
+    /// Walks [`Self::ALL`] rather than keeping a second ordering, for
+    /// [`Self::UNCOMPRESSED_COUNT`]'s reason: one list, one order, nothing to
+    /// drift.
+    pub fn uncompressed_index(self) -> Option<usize> {
+        if self.is_block_compressed() {
+            return None;
+        }
+        let mut index = 0;
+        for layout in Self::ALL {
+            if *layout == self {
+                return Some(index);
+            }
+            if !layout.is_block_compressed() {
+                index += 1;
+            }
+        }
+        None
+    }
+
+    /// Bytes one tightly-packed row of `width` texels of this layout occupies.
+    ///
+    /// One row of **blocks** for a compressed layout, so a caller comparing a
+    /// guest row stride against "one tight row of the upload layout" gets the
+    /// right answer for both families from one expression. `None` on overflow.
+    pub fn tight_row_bytes(self, width: u32) -> Option<u32> {
+        let block = self.block();
+        block.blocks_across(width).checked_mul(block.bytes)
+    }
+
+    /// Rows a copy of a `height`-tall image of this layout must walk — a quarter
+    /// of the texel height, rounded up, for a compressed layout.
+    pub fn tight_row_count(self, height: u32) -> u32 {
+        self.block().block_rows(height)
+    }
+
+    /// Bytes a whole `width` x `height` image of this layout occupies, tightly
+    /// packed.
+    ///
+    /// The one sizing expression for both families. `None` on overflow, so a
+    /// caller declines rather than allocating a wrapped length.
+    pub fn image_bytes(self, width: u32, height: u32) -> Option<u64> {
+        let block = self.block();
+        let across = u64::from(block.blocks_across(width));
+        let down = u64::from(block.block_rows(height));
+        across.checked_mul(down)?.checked_mul(u64::from(block.bytes))
+    }
+
+    /// Bytes occupied by one texel in guest linear storage — or by one **4x4
+    /// block**, for the BC layouts.
+    ///
+    /// The name is kept because ninety-odd call sites use it and every one of
+    /// them is on a rail a BC layout cannot reach: a BC format has no
+    /// [`render_target_bpp`], no [`storage_selector`], no [`sampled_class`] and
+    /// no [`bytes_per_pixel`], so it is refused before any of them.
+    /// `a_bc_format_is_refused_by_every_rail_but_the_sampled_bind` is that
+    /// argument as a test rather than as this paragraph.
+    ///
+    /// For anything that sizes storage, ask [`Self::image_bytes`] or
+    /// [`Self::block`]. Multiplying this by width and height is correct for the
+    /// uncompressed layouts and wrong by sixteen for the BC ones.
     pub fn bytes_per_texel(self) -> u32 {
         match self {
             Self::Rgba8 | Self::Bgra8 => RGBA8_BPP,
@@ -372,6 +811,17 @@ impl TexelLayout {
             Self::Rg16Unorm => RG16_BPP,
             Self::Rgba16Float => RGBA16F_BPP,
             Self::Rg16Float => RG16F_BPP,
+            Self::Bc1Rgba => BC_BLOCK_BYTES_8,
+            Self::Bc2Rgba => BC_BLOCK_BYTES_16,
+            Self::Bc3Rgba => BC_BLOCK_BYTES_16,
+            Self::Bc4RUnorm => BC_BLOCK_BYTES_8,
+            Self::Bc4RSnorm => BC_BLOCK_BYTES_8,
+            Self::Bc5RgUnorm => BC_BLOCK_BYTES_16,
+            Self::Bc5RgSnorm => BC_BLOCK_BYTES_16,
+            Self::Bc6hRgbFloat => BC_BLOCK_BYTES_16,
+            Self::Bc6hRgbUfloat => BC_BLOCK_BYTES_16,
+            Self::Bc7Rgba => BC_BLOCK_BYTES_16,
+
             Self::Rgba16Unorm => RGBA16_BPP,
             Self::Rgb10a2Unorm | Self::Bgr10a2Unorm | Self::Rg11b10Float => RGBA8_BPP,
         }
@@ -430,6 +880,22 @@ impl TexelLayout {
             | Self::Rgb10a2Unorm
             | Self::Bgr10a2Unorm
             | Self::Rg11b10Float => false,
+            // No CPU rail can serve a BC layout, and none should be written:
+            // decoding a block needs a decompressor, and a decompressed block
+            // is not the guest's bytes. `false` here is what keeps a cost
+            // threshold from routing one to a loader that does not exist — the
+            // native bind or a typed refusal are the only two answers.
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => false,
         }
     }
 
@@ -462,6 +928,20 @@ impl TexelLayout {
             | Self::Rgb10a2Unorm
             | Self::Bgr10a2Unorm
             | Self::Rg11b10Float => false,
+            // Vacuously false: there is no arm, so no arm loses anything.
+            // `has_cpu_loader_arm` is the question a caller should be asking
+            // about these, and it answers `false`.
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => false,
         }
     }
 
@@ -501,7 +981,11 @@ impl TexelLayout {
     /// four-byte ones, and they answer different questions. A three-byte
     /// `RGB8_SRGB` layout would separate them.
     pub fn has_srgb_encoding(self) -> bool {
-        matches!(self, Self::Rgba8 | Self::Bgra8)
+        matches!(
+            self,
+            Self::Rgba8 | Self::Bgra8 | Self::Bc1Rgba | Self::Bc2Rgba | Self::Bc3Rgba
+                | Self::Bc7Rgba
+        )
     }
 }
 
@@ -889,7 +1373,17 @@ pub fn blit_aspect_bytes_per_pixel(format: u16, aspect: BlitAspect) -> Option<u3
             }
             Some(1)
         }
-        BlitAspect::Full => bytes_per_pixel(format),
+        // The whole texel — or the whole **block**, for a compressed format,
+        // whose addressable unit is what a copy strides by. Derived from
+        // `block_geometry` rather than `bytes_per_pixel` so the two families are
+        // one expression: an uncompressed block is 1x1 and its `bytes` *is* the
+        // bytes-per-texel, so this is the same number it always was for them.
+        //
+        // A caller taking this for a compressed format is being told the size of
+        // one block and must stride in blocks. `runtime::blit_exec`'s
+        // texture-to-texture copy is the one rail that does; every other blit
+        // rail refuses a compressed format by name.
+        BlitAspect::Full => block_geometry(format).map(|block| block.bytes),
     }
 }
 
@@ -1076,7 +1570,16 @@ pub fn insert_plane_row(
 pub fn is_srgb(format: u16) -> bool {
     matches!(
         format,
-        MTL_FORMAT_RGBA8_UNORM_SRGB | MTL_FORMAT_BGRA8_UNORM_SRGB
+        MTL_FORMAT_RGBA8_UNORM_SRGB
+            | MTL_FORMAT_BGRA8_UNORM_SRGB
+            // The four BC families Apple gives an sRGB spelling. The fold this
+            // predicate exists beside is the same one: `block_compressed_layout`
+            // maps both spellings of each onto one layout, so the qualifier is
+            // recoverable only from here.
+            | MTL_FORMAT_BC1_RGBA_SRGB
+            | MTL_FORMAT_BC2_RGBA_SRGB
+            | MTL_FORMAT_BC3_RGBA_SRGB
+            | MTL_FORMAT_BC7_RGBA_UNORM_SRGB
     )
 }
 
@@ -1120,6 +1623,7 @@ pub fn sampled_class(format: u16) -> Option<SampledClass> {
         MTL_FORMAT_BGRA8_UNORM | MTL_FORMAT_BGRA8_UNORM_SRGB => SampledClass::Bgra8Unorm,
         MTL_FORMAT_RGBA16_FLOAT => SampledClass::Rgba16Float,
         MTL_FORMAT_RG16_FLOAT => SampledClass::Rg16Float,
+        MTL_FORMAT_BGR10A2_UNORM => SampledClass::Bgr10a2Unorm,
         _ => return None,
     })
 }
@@ -1196,6 +1700,26 @@ pub fn storage_selector(format: u16) -> Option<StorageImageSelector> {
 /// one, because a one-byte texel had never been a render target: the readback
 /// narrow, the CPU `Load` seed expansion and the CPU Store converter.
 ///
+/// `BGR10A2_UNORM` is here because a **game** asks for it, and it is the first
+/// packed 32-bit colour format admitted. A driven macos-13 x86/Vulkan boot
+/// running Asphalt 8 creates its 1280x720 render surface as an `'l10r'`
+/// IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`, which
+/// `runtime::objects::iosurface_pixel_format_to_mtl` now names — and before
+/// either half of that change every draw of the frame was refused at
+/// `draw::render_target`'s `rt_type4_base_format` and the window was black:
+/// 20 822 `draw_fail_clear_fallback` records and zero successful draws in one
+/// 100 s capture. Vulkan does not *mandate* `A2R10G10B10_UNORM_PACK32` as a
+/// colour attachment the way it does `R16_SFLOAT`, so unlike the two members
+/// above this one is a format a host could in principle decline —
+/// `translate::pixel::color_attachment` is where such a decline would surface,
+/// and the NVIDIA host this was measured on advertises it.
+///
+/// It needed all three conversion rails plus a fourth thing the two members
+/// above did not: an arm in [`store_texel_order`], because its channels do not
+/// sit on byte boundaries and so the CPU converter's eight-bit round trip is the
+/// only lossy rail in the set. The byte copy is what normally runs and it is
+/// exact.
+///
 /// `RG8_UNORM` is deliberately *not* here. No guest has been observed declaring
 /// a two-channel eight-bit render target, and admitting a format costs three
 /// conversions plus a census line, so members are added on measurement rather
@@ -1215,6 +1739,7 @@ pub fn render_target_bpp(format: u16) -> Option<u32> {
         MTL_FORMAT_RG16_FLOAT => RG16F_BPP,
         MTL_FORMAT_R16_FLOAT => R16F_BPP,
         MTL_FORMAT_R8_UNORM => R8_BPP,
+        MTL_FORMAT_BGR10A2_UNORM => RGBA8_BPP,
         _ => return None,
     })
 }
@@ -1275,16 +1800,39 @@ pub fn store_texel_order(format: u16) -> Option<TexelLayout> {
         MTL_FORMAT_RGBA8_UNORM | MTL_FORMAT_RGBA8_UNORM_SRGB => TexelLayout::Rgba8,
         MTL_FORMAT_BGRA8_UNORM | MTL_FORMAT_BGRA8_UNORM_SRGB => TexelLayout::Bgra8,
         MTL_FORMAT_RGBA16_FLOAT => TexelLayout::Rgba16Float,
+        // The packed ten-bit colour word. Admitted because the byte copy is the
+        // only rail that can land it without loss: the CPU converter reaches
+        // [`rgba8_to_texel`], whose arm for this format requantizes each channel
+        // from eight bits back up to ten, and ten bits is what the guest picked
+        // the format for. A resident created in the declared format holds the
+        // identical `VK_FORMAT_A2R10G10B10_UNORM_PACK32` word the guest's
+        // destination does, so the copy converts nothing.
+        MTL_FORMAT_BGR10A2_UNORM => TexelLayout::Bgr10a2Unorm,
         _ => return None,
     })
 }
 
+/// Bytes one row of `width` texels occupies with no padding.
+///
+/// For a compressed format this is one row of **blocks**, which is the row a
+/// copy strides by and the row `VkBufferImageCopy::bufferRowLength` describes
+/// when it is left at zero. One expression covers both families because an
+/// uncompressed format's block is 1x1 — see [`block_geometry`].
 pub fn tight_row_bytes(width: u32, format: u16) -> Option<u32> {
     if width == 0 {
         return None;
     }
-    let bpp = bytes_per_pixel(format)?;
-    width.checked_mul(bpp)
+    let block = block_geometry(format)?;
+    block.blocks_across(width).checked_mul(block.bytes)
+}
+
+/// Rows a copy of a `height`-tall image of `format` must walk.
+///
+/// The texel height for an uncompressed format and a quarter of it, rounded up,
+/// for BC. Named rather than open-coded because the row loops that need it are
+/// in three files and a `height` left un-divided reads as correct.
+pub fn tight_row_count(height: u32, format: u16) -> Option<u32> {
+    Some(block_geometry(format)?.block_rows(height))
 }
 
 pub fn swizzle_identity() -> SwizzlePlan {
@@ -1561,6 +2109,75 @@ fn unorm8_to_f16_lut() -> &'static [u16; 256] {
 /// arrives with eight bits per channel whatever this writes it as. What it buys
 /// is that the seed lands as the attachment's texels instead of as a quarter of
 /// them, and the *rendering* on top of it keeps the full range.
+/// Bit position of each channel in `MTLPixelFormatBGR10A2Unorm`'s texel word.
+///
+/// One little-endian 32-bit word: blue in bits 0..9, green in 10..19, red in
+/// 20..29 and alpha in 30..31. Those are the same bits in the same order as
+/// `VK_FORMAT_A2R10G10B10_UNORM_PACK32`, which is why the byte copy is exact and
+/// [`store_texel_order`] admits the format — the two functions below serve only
+/// the rails that cannot copy.
+///
+/// Stated as shifts rather than as a struct because the channels do not sit on
+/// byte boundaries, which is also why no byte-shaped loader can serve this
+/// format and why [`TexelLayout::has_cpu_loader_arm`] answers `false` for it.
+const BGR10A2_BLUE_SHIFT: u32 = 0;
+const BGR10A2_GREEN_SHIFT: u32 = 10;
+const BGR10A2_RED_SHIFT: u32 = 20;
+const BGR10A2_ALPHA_SHIFT: u32 = 30;
+/// Width of one colour channel in [`BGR10A2_RED_SHIFT`]'s word.
+const BGR10A2_COLOR_MASK: u32 = 0x3ff;
+/// Width of the alpha channel in the same word.
+const BGR10A2_ALPHA_MASK: u32 = 0x3;
+/// The three colour channels tile the word below alpha, and alpha closes it.
+const _: () = assert!(
+    BGR10A2_ALPHA_SHIFT == BGR10A2_RED_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_RED_SHIFT == BGR10A2_GREEN_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_GREEN_SHIFT == BGR10A2_BLUE_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_ALPHA_SHIFT + BGR10A2_ALPHA_MASK.count_ones() == u32::BITS
+);
+
+/// One `BGR10A2Unorm` word read as the four channels a semantic RGBA8 frame
+/// holds — the narrowing half of the pair, for the host readback rails.
+///
+/// A truncation and nothing else: ten bits of unorm become the eight most
+/// significant of them, and two bits of alpha become the four-fold replication
+/// of themselves, so the two-bit values `0..3` read back as `0, 85, 170, 255`.
+/// That replication is what makes the pair below an identity on every value a
+/// widened channel can hold, which is the property
+/// `a_packed_ten_bit_texel_survives_the_seed_and_readback_round_trip` checks.
+fn bgr10a2_word_to_rgba8(word: u32) -> [u8; 4] {
+    let channel = |shift: u32| (((word >> shift) & BGR10A2_COLOR_MASK) >> 2) as u8;
+    let alpha = ((word >> BGR10A2_ALPHA_SHIFT) & BGR10A2_ALPHA_MASK) as u8;
+    let mut out = [0u8; COMPONENT_COUNT];
+    out[COMPONENT_R] = channel(BGR10A2_RED_SHIFT);
+    out[COMPONENT_G] = channel(BGR10A2_GREEN_SHIFT);
+    out[COMPONENT_B] = channel(BGR10A2_BLUE_SHIFT);
+    out[COMPONENT_A] = alpha * BGR10A2_ALPHA_REPLICATE;
+    out
+}
+
+/// `0b01` in two bits is this value in eight, so multiplying replicates the pair
+/// across the byte and maps `0b11` to full scale rather than to `0xc0`.
+const BGR10A2_ALPHA_REPLICATE: u8 = 0x55;
+
+/// Four semantic-RGBA8 channels written into one `BGR10A2Unorm` word — the
+/// widening half, for a CPU `Load` seed and for the CPU Store converter.
+///
+/// Each colour channel gains two bits and they are filled with the value's own
+/// top two, which is the unorm widening that keeps both endpoints: `0` stays `0`
+/// and `255` becomes `1023`. Alpha loses six bits and keeps its top two, which
+/// is [`bgr10a2_word_to_rgba8`]'s replication inverted.
+fn rgba8_to_bgr10a2_word(rgba: [u8; COMPONENT_COUNT]) -> u32 {
+    let channel = |v: u8| {
+        let v = u32::from(v);
+        (v << 2) | (v >> 6)
+    };
+    (u32::from(rgba[COMPONENT_A]) >> 6) << BGR10A2_ALPHA_SHIFT
+        | channel(rgba[COMPONENT_R]) << BGR10A2_RED_SHIFT
+        | channel(rgba[COMPONENT_G]) << BGR10A2_GREEN_SHIFT
+        | channel(rgba[COMPONENT_B]) << BGR10A2_BLUE_SHIFT
+}
+
 pub fn expand_rgba8_to_texel(
     layout: TexelLayout,
     src_rgba: &[u8],
@@ -1622,6 +2239,19 @@ pub fn expand_rgba8_to_texel(
                 *d = src_rgba[i * RGBA8_BPP as usize + COMPONENT_R];
             }
         }
+        // The packed ten-bit colour word, which a guest was measured rendering
+        // into: an `'l10r'` IOSurface, named `BGR10A2Unorm` by
+        // `runtime::objects::iosurface_pixel_format_to_mtl`. A seed is semantic
+        // RGBA8, so each channel is widened into the bits it gains rather than
+        // shifted into place — see [`rgba8_to_bgr10a2_word`].
+        TexelLayout::Bgr10a2Unorm => {
+            for i in 0..px {
+                let (s, d) = (i * RGBA8_BPP as usize, i * RGBA8_BPP as usize);
+                let mut rgba = [0u8; COMPONENT_COUNT];
+                rgba.copy_from_slice(&src_rgba[s..s + COMPONENT_COUNT]);
+                dst[d..d + 4].copy_from_slice(&rgba8_to_bgr10a2_word(rgba).to_le_bytes());
+            }
+        }
         // Not colour-attachment layouts this device creates a render target at,
         // so a seed for one is a wiring error rather than a conversion. What
         // decides that is `render_target_bpp`, whose doc states the obligation
@@ -1633,20 +2263,34 @@ pub fn expand_rgba8_to_texel(
         // the arm is trivial to add when one is. Admitting a layout costs three
         // conversions and a census line, so they are added on measurement.
         //
-        // The three packed 32-bit colour layouts are here because
+        // The two remaining packed 32-bit colour layouts are here because
         // `render_target_bpp` does not admit their formats: no guest has been
         // observed declaring a render target in one, so there is no seed to
         // convert and an arm would be a conversion written against nothing. Add
         // both halves together if one is ever measured — the obligation
-        // `render_target_bpp` states runs in that direction.
+        // `render_target_bpp` states runs in that direction, and `Bgr10a2Unorm`
+        // is the member that has now been measured and moved out.
         TexelLayout::Rg8
         | TexelLayout::R32Float
         | TexelLayout::R16Unorm
         | TexelLayout::Rg16Unorm
         | TexelLayout::Rgba16Unorm
         | TexelLayout::Rgb10a2Unorm
-        | TexelLayout::Bgr10a2Unorm
         | TexelLayout::Rg11b10Float => return false,
+        // A BC layout is never a render target, so it never has a `Load` seed to
+        // widen. `render_target_bpp` has no arm for any BC format, which is what
+        // makes that a fact rather than an expectation.
+        TexelLayout::Bc1Rgba
+        | TexelLayout::Bc2Rgba
+        | TexelLayout::Bc3Rgba
+        | TexelLayout::Bc4RUnorm
+        | TexelLayout::Bc4RSnorm
+        | TexelLayout::Bc5RgUnorm
+        | TexelLayout::Bc5RgSnorm
+        | TexelLayout::Bc6hRgbFloat
+        | TexelLayout::Bc6hRgbUfloat
+        | TexelLayout::Bc7Rgba
+        => return false,
     }
     true
 }
@@ -1734,14 +2378,38 @@ pub fn narrow_texel_to_rgba8(
                 dst_rgba[d + COMPONENT_A] = UNORM8_MAX;
             }
         }
+        // The packed ten-bit colour word, read back the way a shader sampling
+        // it reads it: each channel truncated to its top eight bits and the
+        // two-bit alpha replicated out. `expand_rgba8_to_texel` is the inverse.
+        // This is the *fallback* rail — a host with no guest-RAM import, where
+        // refusing would lose the frame outright rather than quantize it.
+        TexelLayout::Bgr10a2Unorm => {
+            for i in 0..px {
+                let (s, d) = (i * RGBA8_BPP as usize, i * RGBA8_BPP as usize);
+                let word = u32::from_le_bytes([src[s], src[s + 1], src[s + 2], src[s + 3]]);
+                dst_rgba[d..d + COMPONENT_COUNT].copy_from_slice(&bgr10a2_word_to_rgba8(word));
+            }
+        }
         TexelLayout::Rg8
         | TexelLayout::R32Float
         | TexelLayout::R16Unorm
         | TexelLayout::Rg16Unorm
         | TexelLayout::Rgba16Unorm
         | TexelLayout::Rgb10a2Unorm
-        | TexelLayout::Bgr10a2Unorm
         | TexelLayout::Rg11b10Float => return false,
+        // Nothing reads a BC resident back: there is no BC render target to read
+        // back from, and a sampled BC image is never the source of a readback.
+        TexelLayout::Bc1Rgba
+        | TexelLayout::Bc2Rgba
+        | TexelLayout::Bc3Rgba
+        | TexelLayout::Bc4RUnorm
+        | TexelLayout::Bc4RSnorm
+        | TexelLayout::Bc5RgUnorm
+        | TexelLayout::Bc5RgSnorm
+        | TexelLayout::Bc6hRgbFloat
+        | TexelLayout::Bc6hRgbUfloat
+        | TexelLayout::Bc7Rgba
+        => return false,
     }
     true
 }
@@ -1844,6 +2512,14 @@ pub fn rgba8_to_texel(format: u16, rgba: [u8; 4], dst: &mut [u8]) -> bool {
             // directions are governed separately and nothing here couples them.
             let lut = unorm8_to_f16_lut();
             st16(&mut dst[0..2], lut[rgba[COMPONENT_R] as usize]);
+        }
+        MTL_FORMAT_BGR10A2_UNORM => {
+            // The third of the three rails `render_target_bpp`'s doc obliges a
+            // renderable format to satisfy. Lossy in the direction that matters
+            // — a seed only ever carries eight bits — which is why
+            // `store_texel_order` admits this format so the byte copy is what
+            // normally runs.
+            dst[..4].copy_from_slice(&rgba8_to_bgr10a2_word(rgba).to_le_bytes());
         }
         _ => return false,
     }
@@ -2701,11 +3377,34 @@ mod tests {
                 TexelLayout::Rgb10a2Unorm => MTL_FORMAT_RGB10A2_UNORM,
                 TexelLayout::Bgr10a2Unorm => MTL_FORMAT_BGR10A2_UNORM,
                 TexelLayout::Rg11b10Float => MTL_FORMAT_RG11B10_FLOAT,
+                TexelLayout::Bc1Rgba => MTL_FORMAT_BC1_RGBA,
+                TexelLayout::Bc2Rgba => MTL_FORMAT_BC2_RGBA,
+                TexelLayout::Bc3Rgba => MTL_FORMAT_BC3_RGBA,
+                TexelLayout::Bc4RUnorm => MTL_FORMAT_BC4_R_UNORM,
+                TexelLayout::Bc4RSnorm => MTL_FORMAT_BC4_R_SNORM,
+                TexelLayout::Bc5RgUnorm => MTL_FORMAT_BC5_RG_UNORM,
+                TexelLayout::Bc5RgSnorm => MTL_FORMAT_BC5_RG_SNORM,
+                TexelLayout::Bc6hRgbFloat => MTL_FORMAT_BC6H_RGB_FLOAT,
+                TexelLayout::Bc6hRgbUfloat => MTL_FORMAT_BC6H_RGB_UFLOAT,
+                TexelLayout::Bc7Rgba => MTL_FORMAT_BC7_RGBA_UNORM,
             };
+            // Compared as whole **block geometries** rather than as texel
+            // widths. That subsumes the reading this used to take — an
+            // uncompressed block is 1x1 and its `bytes` *is* `bytes_per_pixel`
+            // — and it is the only form that can say anything about a
+            // compressed layout, whose `bytes_per_pixel` is deliberately
+            // `None`. A layout and its guest format disagreeing on the grid is
+            // rows read at the wrong stride, which shears an image rather than
+            // refusing it.
             assert_eq!(
-                Some(layout.bytes_per_texel()),
-                bytes_per_pixel(mtl),
-                "{layout:?} and its guest format {mtl:#x} disagree on texel width"
+                Some(layout.block()),
+                block_geometry(mtl),
+                "{layout:?} and its guest format {mtl:#x} disagree on the storage grid"
+            );
+            assert_eq!(
+                layout.is_block_compressed(),
+                is_block_compressed(mtl),
+                "{layout:?} and its guest format {mtl:#x} disagree on being compressed"
             );
             // [`TexelLayout::has_cpu_loader_arm`] is a claim about
             // [`texel_to_rgba8`], so it is checked against `texel_to_rgba8`.
@@ -3129,8 +3828,21 @@ mod tests {
                 sampled_class(fmt),
                 Some(match order {
                     TexelLayout::Rgba8 => SampledClass::Rgba8Unorm,
+                    TexelLayout::Bgra8 => SampledClass::Bgra8Unorm,
                     TexelLayout::Rgba16Float => SampledClass::Rgba16Float,
-                    _ => SampledClass::Bgra8Unorm,
+                    TexelLayout::Bgr10a2Unorm => SampledClass::Bgr10a2Unorm,
+                    // Named rather than defaulted. This arm used to be
+                    // `_ => SampledClass::Bgra8Unorm`, which was true only while
+                    // the admitted set was {Rgba8, Bgra8, Rgba16Float}: the next
+                    // member widened into it would have been asserted against a
+                    // class describing a different word, and the assertion would
+                    // have *passed* if that class happened to be what
+                    // `sampled_class` answered. A panic here is the honest
+                    // failure — name the new layout's class above.
+                    other => panic!(
+                        "{fmt:#x} is admitted to the byte copy as {other:?}, which this \
+                         cross-check has no sampled class for"
+                    ),
                 }),
                 "{fmt:#x} is read as one layout by the sampler and copied as another"
             );
@@ -3150,6 +3862,253 @@ mod tests {
             "a half-float render target must reach the byte-copy rail, or its \
              frame is quantized to eight bits on the way to the guest"
         );
+        assert_eq!(
+            store_texel_order(MTL_FORMAT_BGR10A2_UNORM),
+            Some(TexelLayout::Bgr10a2Unorm),
+            "a packed ten-bit render target must reach the byte-copy rail: the CPU \
+             converter requantizes its channels through eight bits, which is the \
+             resolution the guest picked the format for"
+        );
+    }
+
+    /// A packed ten-bit texel survives the seed and readback pair unchanged.
+    ///
+    /// The pair is the *fallback* rail — a host with no guest-RAM import seeds a
+    /// `Load` from semantic RGBA8 and narrows the readback back to it — so the
+    /// property that matters is not that ten bits survive (they cannot; a seed
+    /// carries eight) but that the widening and the narrowing invert each other
+    /// exactly. If they did not, a frame that took the CPU rail twice would
+    /// drift, and a drift of one level per pass is invisible until it is not.
+    ///
+    /// Both endpoints are checked explicitly because the bit-replication
+    /// widening exists for them: a truncating `v << 2` would map 255 to 1020 and
+    /// read back as 254, so full white would darken on every round trip.
+    #[test]
+    fn a_packed_ten_bit_texel_survives_the_seed_and_readback_round_trip() {
+        for r in 0u16..=255 {
+            let rgba = [r as u8, (255 - r) as u8, r.wrapping_mul(7) as u8, 0];
+            for a in [0u8, 0x55, 0xaa, 0xff] {
+                let mut src = rgba;
+                src[COMPONENT_A] = a;
+                let word = rgba8_to_bgr10a2_word(src);
+                assert_eq!(
+                    bgr10a2_word_to_rgba8(word),
+                    src,
+                    "{src:?} did not survive the pair (word {word:#010x})"
+                );
+            }
+        }
+        // The endpoints of the widening, stated as words so a channel landing in
+        // the wrong bits fails here rather than in a frame.
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0, 0, 0xff]), 0xc000_0000);
+        assert_eq!(rgba8_to_bgr10a2_word([0xff, 0, 0, 0]), 0x3ff << 20);
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0xff, 0, 0]), 0x3ff << 10);
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0, 0xff, 0]), 0x3ff);
+        // And the whole-frame wrappers agree with the per-texel pair, so a
+        // caller cannot be served a different conversion by going through the
+        // row functions the rails actually call.
+        let rgba: Vec<u8> = (0u8..=63).flat_map(|v| [v, 255 - v, v << 2, 0xff]).collect();
+        let pixels = (rgba.len() / 4) as u32;
+        let mut packed = vec![0u8; rgba.len()];
+        assert!(expand_rgba8_to_texel(
+            TexelLayout::Bgr10a2Unorm,
+            &rgba,
+            pixels,
+            &mut packed
+        ));
+        let mut back = vec![0u8; rgba.len()];
+        assert!(narrow_texel_to_rgba8(
+            TexelLayout::Bgr10a2Unorm,
+            &packed,
+            pixels,
+            &mut back
+        ));
+        assert_eq!(back, rgba, "the row rails and the texel pair disagree");
+        // The CPU Store converter is the same widening, one texel at a time.
+        let mut one = [0u8; 4];
+        assert!(rgba8_to_texel(
+            MTL_FORMAT_BGR10A2_UNORM,
+            [12, 34, 56, 0xff],
+            &mut one
+        ));
+        assert_eq!(
+            u32::from_le_bytes(one),
+            rgba8_to_bgr10a2_word([12, 34, 56, 0xff])
+        );
+    }
+
+    /// Every BC format the contract names, so a sweep is derived rather than
+    /// hand-listed the way `TexelLayout::ALL` is for the layouts.
+    const BC_FORMATS: &[u16] = &[
+        MTL_FORMAT_BC1_RGBA,
+        MTL_FORMAT_BC1_RGBA_SRGB,
+        MTL_FORMAT_BC2_RGBA,
+        MTL_FORMAT_BC2_RGBA_SRGB,
+        MTL_FORMAT_BC3_RGBA,
+        MTL_FORMAT_BC3_RGBA_SRGB,
+        MTL_FORMAT_BC4_R_UNORM,
+        MTL_FORMAT_BC4_R_SNORM,
+        MTL_FORMAT_BC5_RG_UNORM,
+        MTL_FORMAT_BC5_RG_SNORM,
+        MTL_FORMAT_BC6H_RGB_FLOAT,
+        MTL_FORMAT_BC6H_RGB_UFLOAT,
+        MTL_FORMAT_BC7_RGBA_UNORM,
+        MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+    ];
+
+    /// The list above is exactly the formats `is_block_compressed` claims.
+    ///
+    /// Swept over the whole `u16` space, so a family added to `bc_block_bytes`
+    /// and not to the list — or the reverse — fails here instead of being missed
+    /// by every test that iterates the list.
+    #[test]
+    fn the_bc_sweep_list_is_every_block_compressed_format() {
+        let claimed: Vec<u16> = (0..=u16::MAX).filter(|&f| is_block_compressed(f)).collect();
+        assert_eq!(claimed, BC_FORMATS.to_vec());
+    }
+
+    /// A block geometry is the texel table with its grid stated, for every
+    /// uncompressed format — not a second opinion about the same number.
+    ///
+    /// This is the invariant that lets [`tight_row_bytes`] be one expression
+    /// over both families. Swept over the whole space rather than a sample: the
+    /// two functions would agree on any list chosen after the fact.
+    #[test]
+    fn a_block_geometry_agrees_with_the_texel_table() {
+        for format in 0..=u16::MAX {
+            match (bytes_per_pixel(format), block_geometry(format)) {
+                (Some(bpp), Some(block)) => {
+                    assert!(
+                        !is_block_compressed(format),
+                        "{format:#x} has a bytes-per-texel and claims to be compressed"
+                    );
+                    assert_eq!(
+                        (block.width, block.height, block.bytes),
+                        (1, 1, bpp),
+                        "{format:#x}: an uncompressed block must be 1x1 of its own texel"
+                    );
+                }
+                (None, Some(block)) => {
+                    assert!(
+                        is_block_compressed(format),
+                        "{format:#x} has a block but no texel width and is not compressed"
+                    );
+                    assert_eq!((block.width, block.height), (BC_BLOCK_SIDE, BC_BLOCK_SIDE));
+                    assert!(block.bytes == BC_BLOCK_BYTES_8 || block.bytes == BC_BLOCK_BYTES_16);
+                }
+                (None, None) => {}
+                (Some(_), None) => panic!("{format:#x} has a texel width and no block"),
+            }
+        }
+    }
+
+    /// A BC format is refused by every rail except the sampled bind.
+    ///
+    /// **This is the whole safety argument for `TexelLayout::bytes_per_texel`
+    /// answering about a block**, and it is a test rather than a paragraph
+    /// because ninety-odd call sites call that method and none of them was
+    /// audited by hand. Each rail below is a total gate: a format the gate says
+    /// `None` for cannot reach the sizing code behind it, so the only rail a BC
+    /// layout travels is the sampled bind — where the staging buffer is sized
+    /// from the loader's own byte count and `VkBufferImageCopy` does the block
+    /// arithmetic itself.
+    ///
+    /// If a rail is ever widened to admit one, this test is what says the
+    /// argument has to be re-made.
+    #[test]
+    fn a_bc_format_is_refused_by_every_rail_but_the_sampled_bind() {
+        for &format in BC_FORMATS {
+            assert!(
+                bytes_per_pixel(format).is_none(),
+                "{format:#x}: a BC1 texel is half a byte, so there is no honest answer here"
+            );
+            assert!(
+                render_target_bpp(format).is_none(),
+                "{format:#x} must not be a colour attachment"
+            );
+            assert!(
+                storage_selector(format).is_none(),
+                "{format:#x} must not be a storage image — a shader cannot write a block"
+            );
+            assert!(
+                sampled_class(format).is_none(),
+                "{format:#x} must not claim a CPU-upload fast path"
+            );
+            assert!(
+                store_texel_order(format).is_none(),
+                "{format:#x} must not be a byte-copy Store destination"
+            );
+            assert!(
+                texel_to_rgba8(format, &[0u8; 16]).is_none(),
+                "{format:#x} must have no CPU loader arm"
+            );
+            assert!(
+                !rgba8_to_texel(format, [1, 2, 3, 4], &mut [0u8; 16]),
+                "{format:#x} must have no CPU Store converter"
+            );
+            // And the one rail it does travel names it.
+            let layout = block_compressed_layout(format)
+                .unwrap_or_else(|| panic!("{format:#x} must name a sampled layout"));
+            assert!(layout.is_block_compressed());
+            assert!(!layout.has_cpu_loader_arm());
+            assert_eq!(Some(layout.block()), block_geometry(format));
+        }
+    }
+
+    /// A BC3 level is sized and strided in blocks, on the geometry a guest was
+    /// measured sending.
+    ///
+    /// The bug class: every one of these numbers was computed per **texel**
+    /// before, so a 64x64 BC3 level read a 64-byte row instead of a 256-byte one
+    /// and claimed sixty-four rows instead of sixteen. Nothing about that is a
+    /// refusal — it is a texture bound from the wrong bytes — which is why the
+    /// figures here are the descriptors' own rather than round numbers.
+    ///
+    /// The mip tail is the half nobody writes down: a 2x2 and even a 1x1 level
+    /// still occupy one whole block, so the rounding is the contract and a
+    /// division would read four bytes of a sixteen-byte level.
+    #[test]
+    fn a_bc3_level_is_sized_and_strided_in_blocks() {
+        const BC3: u16 = MTL_FORMAT_BC3_RGBA;
+        // Measured on the boot that found the family: `L0=1024x1024 bpr=4096`
+        // and `L0=64x64 bpr=256`, both from the guest's own descriptors.
+        assert_eq!(tight_row_bytes(1024, BC3), Some(4096));
+        assert_eq!(tight_row_bytes(64, BC3), Some(256));
+        assert_eq!(tight_row_count(1024, BC3), Some(256));
+        assert_eq!(tight_row_count(64, BC3), Some(16));
+        // A 1 MiB base, which is what `alloc=1400832` is the eleven-level
+        // pyramid of.
+        assert_eq!(
+            TexelLayout::Bc3Rgba.image_bytes(1024, 1024),
+            Some(1024 * 1024)
+        );
+        // The tail. Every one of these is one block.
+        for side in [1u32, 2, 3, 4] {
+            assert_eq!(
+                tight_row_bytes(side, BC3),
+                Some(BC_BLOCK_BYTES_16),
+                "a {side}-wide BC3 row is one block"
+            );
+            assert_eq!(tight_row_count(side, BC3), Some(1));
+            assert_eq!(
+                TexelLayout::Bc3Rgba.image_bytes(side, side),
+                Some(u64::from(BC_BLOCK_BYTES_16))
+            );
+        }
+        // Five texels need two blocks, which is the rounding stated as a case
+        // rather than as a formula.
+        assert_eq!(tight_row_bytes(5, BC3), Some(2 * BC_BLOCK_BYTES_16));
+        assert_eq!(tight_row_count(5, BC3), Some(2));
+        // BC1 is the same grid at half the weight, so a wrong block-bytes
+        // constant cannot hide behind BC3's.
+        assert_eq!(tight_row_bytes(64, MTL_FORMAT_BC1_RGBA), Some(128));
+        assert_eq!(
+            TexelLayout::Bc1Rgba.image_bytes(1024, 1024),
+            Some(512 * 1024)
+        );
+        // And an uncompressed format is unchanged by all of it.
+        assert_eq!(tight_row_bytes(64, MTL_FORMAT_BGRA8_UNORM), Some(256));
+        assert_eq!(tight_row_count(64, MTL_FORMAT_BGRA8_UNORM), Some(64));
     }
 
     #[test]

--- a/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
@@ -354,6 +354,17 @@ struct LinearTextureLevel {
     height: u32,
     depth: u32,
     bpp: u32,
+    /// The storage grid one `bpp` unit covers.
+    ///
+    /// 1x1 for every uncompressed format, so `bpp` and this agree for all of
+    /// them and nothing downstream changes. 4x4 for the BC families, where `bpp`
+    /// is bytes per **block** — which is why the one rail that admits a
+    /// compressed texture, `exec_copy_texture_to_texture`, converts its
+    /// coordinates into block space before using any of the per-unit helpers
+    /// below. A compressed copy is an uncompressed copy of the block image, and
+    /// converting once at the top is what lets that be true rather than
+    /// threading a grid through every helper.
+    block: pixel_format::BlockGeometry,
     pixel_format: u16,
 }
 
@@ -418,6 +429,20 @@ impl TextureBacking {
             TextureBacking::Type11(t) => t.bpp,
         }
     }
+    /// The storage grid one [`Self::bpp`] unit covers.
+    fn block(&self) -> pixel_format::BlockGeometry {
+        match self {
+            TextureBacking::Linear(t) => t.block,
+            // A type-11 IOSurface is never block-compressed: its resolve takes
+            // `bytes_per_pixel`, which has no answer for a compressed format, so
+            // such a surface is refused as `t11_fmt_bpp` long before here.
+            TextureBacking::Type11(t) => pixel_format::BlockGeometry {
+                width: 1,
+                height: 1,
+                bytes: t.bpp,
+            },
+        }
+    }
     fn pixel_format(&self) -> u16 {
         match self {
             TextureBacking::Linear(t) => t.pixel_format,
@@ -430,8 +455,16 @@ impl TextureBacking {
 }
 
 impl LinearTextureLevel {
+    /// Bytes one depth plane / array slice of this level occupies.
+    ///
+    /// Counted in rows of **storage**: a block-compressed level is a quarter as
+    /// tall in rows as it is in texels, so the texel form overstated one by four
+    /// and would have strided a `z` plane or an array slice past its own image.
+    /// `block_rows` answers `height` for every uncompressed format, so this is
+    /// the same product it always was for them.
     fn bytes_per_image(&self) -> Option<u64> {
-        self.row_stride.checked_mul(self.height as u64)
+        self.row_stride
+            .checked_mul(u64::from(self.block.block_rows(self.height)))
     }
 
     /// Byte offset of texel origin (x,y,z) within the allocation (includes slice).
@@ -891,13 +924,22 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         ));
         return Err(br(BlitStatus::Unsupported, "tex_no_pixel_format"));
     }
-    let Some(bpp) = pixel_format::bytes_per_pixel(tex.pixel_format) else {
+    // The storage grid rather than a bytes-per-texel, so a block-compressed
+    // level resolves instead of being refused here. `tex_bad_bpp` fired 448
+    // times on one driven Asphalt 8 leg, every one of them a `kind=Copy` between
+    // two BC3 textures — a copy that moves whole blocks and converts nothing.
+    //
+    // Resolving is not admitting: only the texture-to-texture copy handles a
+    // compressed grid, and every other rail that takes this backing refuses one
+    // by name.
+    let Some(block) = pixel_format::block_geometry(tex.pixel_format) else {
         crate::observe::fail(format!(
             "blit tex bad_bpp ref={texture_ref} fmt={}",
             tex.pixel_format
         ));
         return Err(br(BlitStatus::Unsupported, "tex_bad_bpp"));
     };
+    let bpp = block.bytes;
     let Some((layout_gva, layout)) = tex.level_gva(level as u32, state.page_shift) else {
         crate::observe::fail(format!(
             "blit tex level_gva_shift fail ref={texture_ref} lvl={level} handle={} alloc={} mips={} page_shift={} w={} h={} fmt={:#x}",
@@ -979,6 +1021,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         alloc_size: tex.allocation_size,
         level_offset,
         row_stride: layout.row_stride,
+        block,
         slice_stride: one_slice,
         slice_index: slice as u32,
         width: layout.width,
@@ -2483,6 +2526,15 @@ fn exec_copy_buffer_to_texture<M: HostMemory + HostOps>(
         Ok(t) => t,
         Err(st) => return st,
     };
+    // A compressed texture reaches this rail only because
+    // `resolve_texture_backing` now admits one for the texture-to-texture copy.
+    // Everything below this line strides in texels, and a block is four of them
+    // in each axis — so the honest answer is a named refusal rather than a
+    // buffer sized a sixteenth of what it needs. See
+    // `exec_copy_texture_to_texture`, which converts to block space instead.
+    if dst.block().is_compressed() {
+        return br(BlitStatus::Unsupported, "b2t_compressed");
+    }
     let (aspect, copy_bpp) = match copy_aspect_for_options(dst.pixel_format(), cmd) {
         Ok(v) => v,
         Err(st) => return st,
@@ -2729,6 +2781,15 @@ fn exec_copy_texture_to_buffer<M: HostMemory + HostOps>(
         Ok(t) => t,
         Err(st) => return st,
     };
+    // A compressed texture reaches this rail only because
+    // `resolve_texture_backing` now admits one for the texture-to-texture copy.
+    // Everything below this line strides in texels, and a block is four of them
+    // in each axis — so the honest answer is a named refusal rather than a
+    // buffer sized a sixteenth of what it needs. See
+    // `exec_copy_texture_to_texture`, which converts to block space instead.
+    if src.block().is_compressed() {
+        return br(BlitStatus::Unsupported, "t2b_compressed");
+    }
     let (aspect, copy_bpp) = match copy_aspect_for_options(src.pixel_format(), cmd) {
         Ok(v) => v,
         Err(st) => return st,
@@ -3062,6 +3123,72 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
         "blit_t2t_resolve_us",
         phase_started.elapsed().as_micros() as u64,
     );
+    // From here down the coordinates are in units of `copy_bpp`, and for a
+    // block-compressed format that unit is a 4x4 **block**.
+    //
+    // A compressed copy is an uncompressed copy of the block image — same row
+    // stride, same staging, same page window — so the conversion happens once,
+    // here, and every per-unit helper below runs unchanged: `texel_offset`
+    // multiplies x by `bpp` and y by `row_stride`, which in block space is
+    // exactly a block column and a block row. Threading a grid through each
+    // helper instead would put the same division in six places.
+    //
+    // Above this line everything is texels, which is what the bounds checks and
+    // `note_t2t_shape` want; below it nothing is. That is the whole reason the
+    // conversion is a single shadowing binding rather than a flag.
+    let block = src.block();
+    let (sox, soy, dox, doy, copy_w, copy_h) = if !block.is_compressed() {
+        (sox, soy, dox, doy, copy_w, copy_h)
+    } else {
+        // Each refusal below is a copy this rail could describe wrongly rather
+        // than one Metal forbids, so each is named and none is a clamp.
+        if aspect != blit::BlitAspect::Full || repack_src || repack_dst {
+            // There is no depth or stencil plane inside a colour block, and a
+            // repack pass rewrites texels.
+            return br(BlitStatus::Unsupported, "t2t_compressed_aspect");
+        }
+        if any_t11 {
+            return br(BlitStatus::Unsupported, "t2t_compressed_t11");
+        }
+        if dst.block() != block {
+            // One allocation reinterpreted at two grids is not a copy; the
+            // format-mismatch check above lets a format-0 side through, and this
+            // is where that pairing stops.
+            return br(BlitStatus::Unsupported, "t2t_compressed_grid_mismatch");
+        }
+        if copy_d > 1 || soz != 0 || doz != 0 {
+            // `bytes_per_image` strides a depth plane by the *texel* height, and
+            // this conversion does not reach it. A 2D copy never asks.
+            return br(BlitStatus::Unsupported, "t2t_compressed_volume");
+        }
+        let (bw, bh) = (u64::from(block.width), u64::from(block.height));
+        if !sox.is_multiple_of(bw)
+            || !dox.is_multiple_of(bw)
+            || !soy.is_multiple_of(bh)
+            || !doy.is_multiple_of(bh)
+        {
+            // A block is the smallest unit this copy can move, so an origin
+            // inside one names bytes it cannot address.
+            return br(BlitStatus::Unsupported, "t2t_compressed_origin_unaligned");
+        }
+        // An extent may end mid-block only where it reaches the level edge on
+        // *both* ends — the one case a partial trailing block is the whole
+        // remainder of the image rather than a slice of a block.
+        let w_edge = sox + copy_w == src.width() as u64 && dox + copy_w == dst.width() as u64;
+        let h_edge = soy + copy_h == src.height() as u64 && doy + copy_h == dst.height() as u64;
+        if (!copy_w.is_multiple_of(bw) && !w_edge) || (!copy_h.is_multiple_of(bh) && !h_edge) {
+            return br(BlitStatus::Unsupported, "t2t_compressed_extent_unaligned");
+        }
+        crate::runtime::drain::note_store_route("blit_t2t_compressed");
+        (
+            sox / bw,
+            soy / bh,
+            dox / bw,
+            doy / bh,
+            copy_w.div_ceil(bw),
+            copy_h.div_ceil(bh),
+        )
+    };
     let row_bytes = match copy_w.checked_mul(copy_bpp as u64) {
         Some(v) => v,
         None => return br(BlitStatus::Capacity, "t2t_row_bytes_overflow"),
@@ -3890,7 +4017,15 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             }
         }
         let bpp = src0.bpp();
-        let row_bytes = match (w as u64).checked_mul(bpp as u64) {
+        // Whole levels, so a compressed one needs no origin or partial-block
+        // reasoning — only its row width and row *count* in blocks. The grids
+        // must agree for the same reason the `bpp`s must.
+        let block = src0.block();
+        if dst0.block() != block {
+            return br(BlitStatus::Unsupported, "sl_compressed_grid_mismatch");
+        }
+        let rows = u64::from(block.block_rows(h));
+        let row_bytes = match u64::from(block.blocks_across(w)).checked_mul(bpp as u64) {
             Some(v) => v,
             None => return br(BlitStatus::Capacity, "sl_row_bytes_overflow"),
         };
@@ -3948,7 +4083,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             // Same allocation overlap check (conservative).
             if sl.base_gva == dl.base_gva {
                 let span = row_bytes
-                    .saturating_mul(h as u64)
+                    .saturating_mul(rows)
                     .saturating_mul(image_count);
                 if ranges_overlap(src_off, span, dst_off, span) {
                     return br(BlitStatus::Overlap, "sl_overlap");
@@ -3965,7 +4100,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 dl.row_stride,
                 dst_img_stride,
                 row_bytes,
-                h as u64,
+                rows,
                 image_count,
             ) {
                 return st;
@@ -3984,7 +4119,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
         // were never the cost — re-entering the mapping rail per row was. It
         // stages the slice whole now; see [`read_texture_rect`].
         let sl_mixed_started = std::time::Instant::now();
-        let mut staged = vec![0u8; (row_bytes.saturating_mul(h as u64)) as usize];
+        let mut staged = vec![0u8; (row_bytes.saturating_mul(rows)) as usize];
         for si in 0..cmd.slice_count {
             let ss = match cmd.source_slice.checked_add(si) {
                 Some(v) => v,
@@ -4015,7 +4150,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 &dst,
                 Point { x: 0, y: 0, z: 0 },
                 w,
-                h as u64,
+                rows,
                 1,
                 bpp,
             ) {
@@ -4029,7 +4164,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 &src,
                 Point { x: 0, y: 0, z: 0 },
                 row_bytes,
-                h as u64,
+                rows,
                 &mut staged,
             ) {
                 return st;

--- a/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
@@ -1358,6 +1358,73 @@ fn type8_level_base_on_type11_rejected() {
     );
 }
 
+/// A compressed level's byte arithmetic is in blocks, in both axes.
+///
+/// The regression this pins is 448 refused copies on one driven Asphalt 8 leg:
+/// `blit_fail reason=tex_bad_bpp kind=Copy` between two BC3 textures, because
+/// the whole blit path asked `bytes_per_pixel` and a BC format has none. Now the
+/// backing carries its storage grid, and `exec_copy_texture_to_texture` converts
+/// the command's coordinates into block space once so every per-unit helper
+/// below it is correct unchanged.
+///
+/// Both halves are asserted because each fails differently. A wrong
+/// `bytes_per_image` strides an array slice or a `z` plane past its own image; a
+/// wrong `texel_offset` reads the right number of bytes from the wrong place.
+#[test]
+fn a_compressed_level_addresses_blocks_in_both_axes() {
+    use crate::contract::pixel_format::{self as pf, BlockGeometry};
+    // A 64x64 BC3 level as a guest sends it: 16 block columns of 16 bytes, and
+    // 16 block rows, so one image is 4096 bytes and not 16384.
+    let bc3 = LinearTextureLevel {
+        base_gva: 0,
+        alloc_size: 4096,
+        level_offset: 0,
+        row_stride: 256,
+        slice_stride: 4096,
+        slice_index: 0,
+        width: 64,
+        height: 64,
+        depth: 1,
+        bpp: pf::BC_BLOCK_BYTES_16,
+        block: pf::block_geometry(pf::MTL_FORMAT_BC3_RGBA).expect("bc3 has a grid"),
+        pixel_format: pf::MTL_FORMAT_BC3_RGBA,
+    };
+    assert_eq!(bc3.block, BlockGeometry { width: 4, height: 4, bytes: 16 });
+    assert_eq!(
+        bc3.bytes_per_image(),
+        Some(4096),
+        "16 block rows of 256 bytes — the texel form would say 16384 and stride \
+         a slice four times past its own image"
+    );
+    // Block coordinates, which is what the copy hands it: block (3, 2) starts at
+    // row 2 of blocks and column 3, i.e. 2*256 + 3*16.
+    assert_eq!(bc3.texel_offset(3, 2, 0), Some(2 * 256 + 3 * 16));
+    // The last block of the level is the last 16 bytes of the allocation, so the
+    // grid and the allocation agree exactly — a level that did not would be
+    // refused against `alloc_size` downstream.
+    assert_eq!(bc3.texel_offset(15, 15, 0), Some(4096 - 16));
+
+    // An uncompressed level is untouched by any of it: a 1x1 block whose bytes
+    // are the bytes-per-texel gives back the products this always computed.
+    let rgba = LinearTextureLevel {
+        base_gva: 0,
+        alloc_size: 0x1000,
+        level_offset: 0,
+        row_stride: 256,
+        slice_stride: 0,
+        slice_index: 0,
+        width: 64,
+        height: 4,
+        depth: 1,
+        bpp: 4,
+        block: pf::block_geometry(MTL_FORMAT_RGBA8_UNORM).expect("rgba8 has a grid"),
+        pixel_format: MTL_FORMAT_RGBA8_UNORM,
+    };
+    assert_eq!(rgba.block, BlockGeometry { width: 1, height: 1, bytes: 4 });
+    assert_eq!(rgba.bytes_per_image(), Some(256 * 4));
+    assert_eq!(rgba.texel_offset(3, 2, 0), Some(2 * 256 + 3 * 4));
+}
+
 #[test]
 fn texel_offset_math() {
     let t = LinearTextureLevel {
@@ -1371,6 +1438,11 @@ fn texel_offset_math() {
         height: 4,
         depth: 1,
         bpp: 4,
+        block: crate::contract::pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
         pixel_format: MTL_FORMAT_RGBA8_UNORM,
     };
     // (x=1,y=2) → 0x100 + 2*16 + 1*4 = 0x124
@@ -1413,6 +1485,11 @@ fn an_unmeasurable_copy_region_refuses_rather_than_writing_unbounded() {
         height: 1,
         depth: 1,
         bpp: 4,
+        block: crate::contract::pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
         pixel_format: MTL_FORMAT_RGBA8_UNORM,
     };
 

--- a/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
@@ -342,8 +342,23 @@ impl TextureLevelLayout {
     /// `None` for zero height (no rows) or on overflow. A bound this feeds must
     /// treat `None` as a refusal, never as "no limit".
     pub fn read_span(&self, tight_row: u32) -> Option<u64> {
-        self.height
-            .checked_sub(1)
+        self.read_span_rows(self.height, tight_row)
+    }
+
+    /// [`Self::read_span`] over a caller-supplied row count.
+    ///
+    /// The row count is a parameter because a **block-compressed** level has
+    /// fewer rows of storage than it has rows of texels: a 64x64 BC3 level is
+    /// sixteen 256-byte rows, not sixty-four. `contract::pixel_format::
+    /// tight_row_count` is what a caller passes, and it answers `height` for
+    /// every uncompressed format — so `read_span` above is this with the count
+    /// it always used.
+    ///
+    /// Deriving the count here instead would need this type to know the pixel
+    /// format, which it deliberately does not: a `TextureLevelLayout` is
+    /// geometry, and the format lives on the descriptor that owns it.
+    pub fn read_span_rows(&self, rows: u32, tight_row: u32) -> Option<u64> {
+        rows.checked_sub(1)
             .map(u64::from)?
             .checked_mul(self.row_stride)?
             .checked_add(u64::from(tight_row))
@@ -392,10 +407,20 @@ impl TextureLevelLayout {
     /// receiver holds, travelling as a loose argument that a second caller could
     /// get wrong with nothing to notice.
     pub fn slice_read_span(&self, tight_row: u32) -> Option<u64> {
+        self.slice_read_span_rows(self.height, tight_row)
+    }
+
+    /// [`Self::slice_read_span`] over a caller-supplied row count, for
+    /// [`Self::read_span_rows`]'s reason.
+    ///
+    /// BC compresses in two dimensions only, so each depth plane of a
+    /// compressed level is its own `rows`-tall block grid and the planes stack
+    /// exactly as they do uncompressed.
+    pub fn slice_read_span_rows(&self, rows: u32, tight_row: u32) -> Option<u64> {
         u64::from(self.planes() - 1)
             .checked_mul(self.row_stride)?
-            .checked_mul(u64::from(self.height))?
-            .checked_add(self.read_span(tight_row)?)
+            .checked_mul(u64::from(rows))?
+            .checked_add(self.read_span_rows(rows, tight_row)?)
     }
 }
 
@@ -504,7 +529,35 @@ impl TextureDescriptor {
 
 /// Texture descriptor field offsets (geometry prefix + format trailer).
 pub const TEXTURE_DESC_GEOMETRY_LEN: usize = 68;
+/// Offset of the mip-level count, which is **one byte wide**.
+///
+/// This was read as a `u16` and the byte above it is a field of its own. The
+/// descriptor's own length is what settles it, and it settles it exactly. A
+/// multi-mip body is `TEXTURE_DESC_BASE_LEN + (levels - 1) *
+/// TEXTURE_DESC_MIP_LEVEL_RECORD_LEN` bytes long, and on a driven macos-13
+/// x86/Vulkan boot running Asphalt 8 four distinct descriptors read the `u16`
+/// as `0x8001`, `0x8007`, `0x800a` and `0x800b` with body lengths 116, 332, 440
+/// and 476. Taking the low byte as the count reproduces all four lengths to the
+/// byte — 116, 116+6*36, 116+9*36, 116+10*36 — and no other reading of the field
+/// does.
+///
+/// What the byte above it means is **not** decided here and is not guessed: it
+/// read `0x80` on every one of those four and zero on every descriptor the
+/// desktop workload produces, which is why reading the pair as one count
+/// survived until a game set it. `decode_texture_descriptor` reports a non-zero
+/// one by name so the next session has the value rather than an absence.
+///
+/// Reading the pair cost the game every mipmapped texture it bound: a declared
+/// count of 32 779 put the format trailer 1 180 094 bytes into a 476-byte body,
+/// so `texture_desc_format_unreachable` fired, the descriptor carried no pixel
+/// format, and the fragment bind refused with
+/// `draw_prepare_texture_resolve_missing`.
 pub const TEXTURE_DESC_MIPMAP_LEVEL_COUNT: usize = 12;
+/// The byte above the mip-level count: a field this device does not decode.
+///
+/// Named so the read site is not an unexplained `+ 1`. See
+/// [`TEXTURE_DESC_MIPMAP_LEVEL_COUNT`] for why the two are separate fields.
+pub const TEXTURE_DESC_MIP_FIELD_UNDECODED: usize = TEXTURE_DESC_MIPMAP_LEVEL_COUNT + 1;
 pub const TEXTURE_DESC_DATA_OFFSET: usize = 16;
 pub const TEXTURE_DESC_BYTES_PER_ELEMENT: usize = 35;
 pub const TEXTURE_DESC_USED_SIZE: usize = 44;
@@ -1261,6 +1314,35 @@ pub const PIPELINE_TAG_TESSELLATION_OUTPUT_WINDING_ORDER: u8 = 0x12;
 /// policy choice: a pipeline built at any other count would not be compatible
 /// with the pass it is used in.
 pub const DEFAULT_RASTER_SAMPLE_COUNT: u32 = 1;
+/// `alphaTestEnabled` on Metal's internal render-pipeline descriptor.
+///
+/// One of the fixed-function fields Metal still carries from the OpenGL era.
+/// They live in `MTLRenderPipelineDescriptorPrivate`'s `miscHash` bitfield
+/// — `alphaTestFunc b3` next to `alphaTestEnabled b1`, and `logicOp b4` next to
+/// `logicOpEnabled b1` — reachable only through private setters on
+/// `MTLRenderPipelineDescriptorInternal`, which is why no workload built out of
+/// the public API had ever produced them here.
+///
+/// **This tag is deliberately neither consumed nor benign, so a pipeline
+/// carrying it is refused.** Its companion
+/// [`PIPELINE_TAG_ALPHA_TEST_FUNCTION`] *is* benign, and the pairing is the
+/// whole argument: a compare function with the test off changes nothing, while
+/// the test being *on* is a per-fragment discard this device does not implement.
+/// Dropping the enable would render every alpha-tested fragment that the guest
+/// asked to be discarded.
+pub const PIPELINE_TAG_ALPHA_TEST_ENABLED: u8 = 0x2d;
+/// `alphaTestFunction`, an `MTLCompareFunction`. Inert unless
+/// [`PIPELINE_TAG_ALPHA_TEST_ENABLED`] is present; see
+/// [`RENDER_PIPELINE_TAGS_BENIGN`].
+pub const PIPELINE_TAG_ALPHA_TEST_FUNCTION: u8 = 0x2e;
+/// `logicOperationEnabled`. Refused for [`PIPELINE_TAG_ALPHA_TEST_ENABLED`]'s
+/// reason one field over: a logic op is a fixed-function blend replacement this
+/// device does not implement, and dropping the enable would composite with the
+/// ordinary blend the guest asked to be replaced.
+pub const PIPELINE_TAG_LOGIC_OP_ENABLED: u8 = 0x2f;
+/// `logicOperation`, the op a
+/// [`PIPELINE_TAG_LOGIC_OP_ENABLED`] pipeline would apply. Inert without it.
+pub const PIPELINE_TAG_LOGIC_OP: u8 = 0x37;
 /// Mesh SPI section offset (analog of classic [`PIPELINE_TAG_COLOR_ATTACH_OFFSET`]).
 ///
 /// Live host Metal `-[_MTLDevice serializeMeshRenderPipelineDescriptor:]`
@@ -1762,8 +1844,27 @@ pub fn decode_texture_descriptor(bytes: &[u8]) -> Result<TextureDescriptor, Deco
         handle: ld32(&bytes[LINEAR_DESC_HANDLE..]),
         ..Default::default()
     };
-    if bytes.len() >= TEXTURE_DESC_MIPMAP_LEVEL_COUNT + 2 {
-        out.mipmap_level_count = ld16(&bytes[TEXTURE_DESC_MIPMAP_LEVEL_COUNT..]) as u32;
+    if bytes.len() > TEXTURE_DESC_MIPMAP_LEVEL_COUNT {
+        out.mipmap_level_count = u32::from(bytes[TEXTURE_DESC_MIPMAP_LEVEL_COUNT]);
+    }
+    // The field above the count is not part of it. Reported once per distinct
+    // value rather than interpreted, because nothing here knows what it means
+    // and a guess at it would be a rule the guest never agreed to.
+    let undecoded = bytes
+        .get(TEXTURE_DESC_MIP_FIELD_UNDECODED)
+        .copied()
+        .unwrap_or(0);
+    if undecoded != 0
+        && crate::observe::first_sight(
+            "texture_desc_mip_field_undecoded",
+            u64::from(undecoded),
+        )
+    {
+        crate::observe::fail(format!(
+            "texture_desc_mip_field_undecoded value={undecoded:#04x}              levels={} len={} (the byte above the mip-level count carries              something this device does not decode; the count is the low byte              and the body length confirms it)",
+            out.mipmap_level_count,
+            bytes.len()
+        ));
     }
     if bytes.len() >= TEXTURE_DESC_DATA_OFFSET + 4 {
         out.data_offset = ld32(&bytes[TEXTURE_DESC_DATA_OFFSET..]);
@@ -2378,10 +2479,27 @@ pub const PIPELINE_TAG_COMPUTE_STAGE_INPUT_OFFSET: u8 = 0x03;
 /// must refuse rather than be waved through. The third,
 /// [`PIPELINE_TAG_RASTER_SAMPLE_COUNT`], is now read — it is consumed on both
 /// shapes and carried to the backend render-pass and pipeline keys.
-const RENDER_PIPELINE_TAGS_BENIGN: [u8; 3] = [
+const RENDER_PIPELINE_TAGS_BENIGN: [u8; 5] = [
     RENDER_PIPELINE_TAG_LABEL,
     PIPELINE_TAG_DEPTH_ATTACH_FORMAT,
     PIPELINE_TAG_STENCIL_ATTACH_FORMAT,
+    // The two legacy fixed-function *values* whose enables stay refused. See
+    // the reading under `note_pipeline_tlv_fields` for what measured them and
+    // `PIPELINE_TAG_ALPHA_TEST_ENABLED` for why the pairing is what licenses
+    // this.
+    PIPELINE_TAG_ALPHA_TEST_FUNCTION,
+    PIPELINE_TAG_LOGIC_OP,
+];
+/// The enables that make the two benign members above load-bearing.
+///
+/// Not a list this decoder reads — it is here so the pairing is expressible, and
+/// so `an_alpha_test_or_logic_op_enable_is_still_refused` can assert it rather
+/// than restate two hex numbers. A tag in here must never join
+/// [`RENDER_PIPELINE_TAGS_BENIGN`].
+#[cfg(test)]
+const RENDER_PIPELINE_TAGS_STILL_REFUSED: [u8; 2] = [
+    PIPELINE_TAG_ALPHA_TEST_ENABLED,
+    PIPELINE_TAG_LOGIC_OP_ENABLED,
 ];
 /// The compute half of [`RENDER_PIPELINE_TAGS_BENIGN`]; same rule, and listed
 /// apart for the same reason `COMPUTE_PIPELINE_TAGS_CONSUMED` is.
@@ -2498,6 +2616,76 @@ const COMPUTE_PIPELINE_TAGS_BENIGN: [u8; 2] = [
 /// identified: see [`PIPELINE_TAG_RASTER_SAMPLE_COUNT`],
 /// [`PIPELINE_TAG_DEPTH_ATTACH_FORMAT`] and
 /// [`PIPELINE_TAG_STENCIL_ATTACH_FORMAT`].
+///
+/// # A game fired it twice, and the tags were named by driving the serializer
+///
+/// A macos-13 x86/Vulkan boot running Asphalt 8 produced one shape this list had
+/// never seen, and three pipeline refs carrying it were refused on every draw
+/// that used them — 1 348 `draw_load_pipeline reason=desc_decode` and 8 604
+/// `draw_fail_clear_fallback` in one capture, which is the game's canvas black
+/// while its window chrome composited:
+///
+/// ```text
+/// kind=render nfields=7 tags=[03:4,08:4,09:4*,2e:4*!,37:4*!,01:4,02:4]
+///                                          unconsumed=3 unknown=2
+/// ```
+///
+/// The two were identified the way this file's other layouts were — by
+/// perturbation against Apple's own serializer, not by reading ordinals. In the
+/// guest, `-[_MTLDevice serializeRenderPipelineDescriptor:]` returns this exact
+/// compact-TLV block (its `NSData` **starts** at the `fieldCount` byte; the
+/// 16-byte type-7 header this decoder reads is added by the transport). Build a
+/// baseline descriptor, set exactly one property through the runtime, serialize,
+/// and the tag that appears is that property's. Fifty-odd scalar setters on
+/// `MTLRenderPipelineDescriptor` and `MTLRenderPipelineDescriptorInternal`, one
+/// `fork` per probe so an assertion inside Metal costs one line:
+///
+/// ```text
+/// 0x00 label            0x0b inputPrimitiveTopology  0x2d alphaTestEnabled
+/// 0x01 vertexFunction   0x0c tessellationPartitionMode
+/// 0x02 fragmentFunction 0x0d maxTessellationFactor   0x2e alphaTestFunction
+/// 0x03 vertexDescriptor 0x0e tessellationFactorScaleEnabled
+/// 0x04 rasterSampleCount (also sampleCount)          0x2f logicOperationEnabled
+/// 0x05 alphaToCoverageEnabled  0x11 tessellationFactorStepFunction
+/// 0x06 alphaToOneEnabled       0x19 supportIndirectCommandBuffers
+/// 0x07 rasterizationEnabled    0x1a maxVertexAmplificationCount
+/// 0x08 colorAttachments offset 0x1b sampleCoverage   0x30 clipDistanceEnableMask
+/// 0x09 depthAttachmentPixelFormat  0x1c sampleMask   0x31 pointSmoothEnabled
+/// 0x0a stencilAttachmentPixelFormat 0x1e textureWriteRoundingMode
+/// 0x32 pointCoordLowerLeft  0x33 pointSizeOutputVS   0x34 twoSideEnabled
+/// 0x35 vertexDepthCompareClampMask  0x36 fragmentDepthCompareClampMask
+/// 0x37 logicOperation       0x38 depthStencilWriteDisabled
+/// 0x39 needsCustomBorderColorSamplers  0x3a explicitVisibilityGroupID
+/// ```
+///
+/// Only the four this commit acts on are declared as constants; the rest are
+/// recorded here because the sweep is cheap to re-run and expensive to
+/// rediscover. Everything from `0x2d` up is a private setter on the internal
+/// class, which is why a workload built on the public API never emits one — and
+/// the block is Metal's fixed-function inheritance: alpha test, logic op, point
+/// size and smoothing, two-sided lighting, clip-distance masks.
+///
+/// # Why the two values are benign and their two enables are not
+///
+/// The bitfield pairs each of these with an enable — `alphaTestFunc b3` beside
+/// `alphaTestEnabled b1`, `logicOp b4` beside `logicOpEnabled b1` — and a
+/// property left at its Metal default is omitted from this block rather than
+/// sent as a zero. That is measured, not assumed: the baseline descriptor emits
+/// **one** tag, and each of the fifty perturbations added exactly one. A fresh
+/// descriptor reads `isAlphaTestEnabled = 0` and `isLogicOperationEnabled = 0`.
+///
+/// The game's shape carries `0x2e` and `0x37` and **neither** `0x2d` nor
+/// `0x2f`. So both features are off, and a compare function and a logic op that
+/// nothing applies cannot change a pixel. Its `alphaTestFunction` was `7`,
+/// which is `MTLCompareFunctionAlways` — the value that discards nothing even
+/// were the test on.
+///
+/// The enables stay unnamed in both lists, which is the load-bearing half of
+/// this change: an alpha test that is *on* is a per-fragment discard this device
+/// does not implement, and a logic op that is on replaces blending. A pipeline
+/// asking for either is still refused by name, which is the right answer to a
+/// request that cannot be represented. `RENDER_PIPELINE_TAGS_STILL_REFUSED`
+/// holds them so that pairing is a test rather than a paragraph.
 ///
 /// Deduped per distinct `(tag, len)` rather than per value: what a reader needs
 /// first is which properties arrive, and a per-value latch on a field like a

--- a/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
@@ -1514,6 +1514,130 @@ fn multi_mip_level_layouts() {
     assert!(d.level_gva(2, PAGE_SHIFT_ARM64E).is_none());
 }
 
+/// A level's read span counts rows of storage, which for a compressed level is a
+/// quarter of its texel height.
+///
+/// The bound this feeds is the descriptor's own `allocation_size`, so a span
+/// computed from the texel height overstates a BC level by roughly four and gets
+/// the texture refused against an allocation the guest sized correctly — the
+/// same shape as the 27x27 mask `read_span` was written for, one axis over.
+///
+/// The numbers are a 1024x1024 BC3 level as a guest sends it: 256 block rows of
+/// 4096 bytes, which is 1 MiB exactly and no trailing padding to discount.
+#[test]
+fn a_compressed_level_spans_its_block_rows_not_its_texel_rows() {
+    use crate::contract::pixel_format as pf;
+    let level = TextureLevelLayout {
+        offset: 0,
+        size: 1024 * 1024,
+        row_stride: 4096,
+        width: 1024,
+        height: 1024,
+        depth: 1,
+    };
+    let tight = pf::tight_row_bytes(1024, pf::MTL_FORMAT_BC3_RGBA).expect("tight row");
+    let rows = pf::tight_row_count(1024, pf::MTL_FORMAT_BC3_RGBA).expect("rows");
+    assert_eq!((tight, rows), (4096, 256));
+    assert_eq!(
+        level.slice_read_span_rows(rows, tight),
+        Some(1024 * 1024),
+        "256 rows of 4096 bytes is the whole level and nothing past it"
+    );
+    // What the texel-height reading would have claimed, named so the difference
+    // is on the record rather than implied.
+    assert_eq!(level.slice_read_span(tight), Some(1023 * 4096 + 4096));
+    assert!(
+        level.slice_read_span(tight) > level.slice_read_span_rows(rows, tight),
+        "the texel-row form overstates a compressed level, which is the refusal \
+         this distinction exists to avoid"
+    );
+    // An uncompressed level is unchanged: `tight_row_count` answers its height,
+    // so the two forms agree by construction.
+    let plain = TextureLevelLayout {
+        offset: 0,
+        size: 64 * 4 * 32,
+        row_stride: 384,
+        width: 64,
+        height: 32,
+        depth: 1,
+    };
+    let ptight = pf::tight_row_bytes(64, pf::MTL_FORMAT_BGRA8_UNORM).expect("tight");
+    let prows = pf::tight_row_count(32, pf::MTL_FORMAT_BGRA8_UNORM).expect("rows");
+    assert_eq!(prows, 32);
+    assert_eq!(
+        plain.slice_read_span_rows(prows, ptight),
+        plain.slice_read_span(ptight)
+    );
+}
+
+/// The mip-level count is the low byte, and the byte above it does not join it.
+///
+/// The bug class this fixes: a game's mipmapped textures carry `0x80` in the
+/// byte above the count, the two were read as one `u16`, and a seven-level
+/// pyramid was decoded as 32 775 levels. Nothing about that reads as a wrong
+/// number downstream — it puts the format trailer a megabyte past the body, so
+/// the descriptor carries **no pixel format**, and seven downstream gates fail
+/// closed on that. The guest loses the texture and the draw refuses with
+/// `draw_prepare_texture_resolve_missing`.
+///
+/// The body length is the derivation and it is asserted here rather than
+/// described: a descriptor is `TEXTURE_DESC_BASE_LEN + (levels - 1) * 36` bytes,
+/// so a 332-byte body *is* seven levels and cannot be 32 775 of them. The four
+/// lengths measured on the boot that found this are on
+/// [`TEXTURE_DESC_MIPMAP_LEVEL_COUNT`].
+#[test]
+fn the_mip_level_count_is_one_byte_and_its_neighbour_is_another_field() {
+    use crate::contract::endian::{st16, st32};
+    use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
+    const LEVELS: usize = 7;
+    let body = TEXTURE_DESC_BASE_LEN + (LEVELS - 1) * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+    assert_eq!(body, 332, "the length identity this test turns on");
+    let mut b = vec![0u8; body];
+    b[TEXTURE_DESC_MIPMAP_LEVEL_COUNT] = LEVELS as u8;
+    // What the game sets and the desktop never does. Reading the pair as one
+    // count is what this asserts against.
+    b[TEXTURE_DESC_MIP_FIELD_UNDECODED] = 0x80;
+    st32(&mut b[TEXTURE_DESC_USED_SIZE..], 64 * 64 * 4);
+    st32(&mut b[TEXTURE_DESC_ROW_STRIDE..], 256);
+    st32(&mut b[TEXTURE_DESC_WIDTH..], 64);
+    st32(&mut b[TEXTURE_DESC_HEIGHT..], 64);
+    for extra in 0..LEVELS - 1 {
+        let rec = TEXTURE_DESC_LEVEL_RECORDS + extra * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+        let side = 32u32 >> extra;
+        st32(&mut b[rec + TEXTURE_LEVEL_WIDTH..], side.max(1));
+        st32(&mut b[rec + TEXTURE_LEVEL_HEIGHT..], side.max(1));
+        st32(&mut b[rec + TEXTURE_LEVEL_ROW_STRIDE..], side.max(1) * 4);
+    }
+    let pf_off = TEXTURE_DESC_PIXEL_FORMAT + (LEVELS - 1) * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+    st16(&mut b[pf_off..], MTL_FORMAT_BGRA8_UNORM);
+
+    let cap = crate::observe::FailCapture::start();
+    let d = decode_texture_descriptor(&b).expect("the descriptor decodes");
+    assert_eq!(d.mipmap_level_count, LEVELS as u32);
+    assert_eq!(d.levels.len(), LEVELS, "every level the body carries is read");
+    assert_eq!(
+        d.declared_pixel_format(),
+        Some(MTL_FORMAT_BGRA8_UNORM),
+        "the shifted format trailer must be inside the body, which is the whole \
+         thing the level count decides"
+    );
+    let lines = cap.lines();
+    assert!(
+        !lines
+            .iter()
+            .any(|l| l.starts_with("texture_desc_levels_over_cap")
+                || l.starts_with("texture_desc_format_unreachable")),
+        "neither corruption guard may fire on a well-formed seven-level \
+         descriptor: {lines:?}"
+    );
+    // The undecoded neighbour is on the record rather than merely absent.
+    let note = lines
+        .iter()
+        .find(|l| l.starts_with("texture_desc_mip_field_undecoded"))
+        .expect("a non-zero undecoded field must be reported once");
+    assert!(note.contains("value=0x80") && note.contains("levels=7"), "{note}");
+}
+
 /// A mip level the descriptor named but the body does not reach is a drop,
 /// and it says so.
 ///
@@ -1693,6 +1817,106 @@ fn a_depth_stencil_pipeline_with_a_sample_count_decodes() {
         d.raster_sample_count, 4,
         "the guest's requested sample count is read rather than defaulted"
     );
+}
+
+/// Build a type-7 render-pipeline descriptor out of a compact-TLV field list.
+///
+/// Three tests below differ only in the fields, and each hand-rolled the same
+/// header/offset arithmetic. One builder means a layout change fails once.
+#[cfg(test)]
+fn render_pipeline_desc(object_id: u32, fields: &[(u8, u32)]) -> Vec<u8> {
+    let mut b = vec![0u8; TYPE7_FIRST_TLVS + 1 + fields.len() * 6];
+    let len = b.len() as u32;
+    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[4..], len);
+    st32(&mut b[8..], object_id);
+    st32(&mut b[12..], len - TYPE7_FIRST_TLVS as u32);
+    b[TYPE7_FIRST_TLVS] = fields.len() as u8;
+    let mut p = TYPE7_FIRST_TLVS + 1;
+    for &(tag, value) in fields {
+        b[p] = tag;
+        b[p + 1] = 4;
+        st32(&mut b[p + 2..], value);
+        p += 6;
+    }
+    b
+}
+
+/// A pipeline carrying Metal's legacy alpha-test and logic-op **values** decodes.
+///
+/// The regression this pins is a game's whole canvas. Asphalt 8 on a macos-13
+/// x86/Vulkan boot builds pipelines carrying `0x2e` and `0x37` — private
+/// setters on `MTLRenderPipelineDescriptorInternal`, so no workload built out of
+/// Metal's public API had ever produced them — and while they were unidentified
+/// every draw through those three pipeline refs was refused: 1 348
+/// `draw_load_pipeline reason=desc_decode` and 8 604 clear-only fallbacks in one
+/// capture. Same shape as the map-view regression `0x04`/`0x09`/`0x0a` caused.
+///
+/// The field values are the ones the game actually sent, so this is that
+/// descriptor and not a synthetic stand-in for it.
+#[test]
+fn a_pipeline_with_legacy_alpha_test_and_logic_op_values_decodes() {
+    let b = render_pipeline_desc(
+        47,
+        &[
+            (PIPELINE_TAG_DEPTH_ATTACH_FORMAT, 252),
+            (PIPELINE_TAG_ALPHA_TEST_FUNCTION, 7),
+            (PIPELINE_TAG_LOGIC_OP, 2),
+            (PIPELINE_TAG_VERTEX_FUNC, 11),
+            (PIPELINE_TAG_FRAGMENT_FUNC, 12),
+        ],
+    );
+    let cap = crate::observe::FailCapture::start();
+    let d = decode_render_pipeline_descriptor(&b)
+        .expect("an alpha-test/logic-op pipeline is decoded, not refused");
+    assert_eq!((d.vertex_func_ref, d.fragment_func_ref), (11, 12));
+    assert!(
+        !cap.lines()
+            .iter()
+            .any(|l| l.contains("pipeline_descriptor_field_dropped")),
+        "a benign field is dropped with an argument, not on the fail channel: {:?}",
+        cap.lines()
+    );
+}
+
+/// The **enables** beside those two values are still refused, one at a time.
+///
+/// This is the load-bearing half of naming them. An alpha test that is on is a
+/// per-fragment discard this device does not implement and a logic op that is on
+/// replaces blending, so a pipeline asking for either must lose rather than
+/// render without it. Asserted against
+/// `RENDER_PIPELINE_TAGS_STILL_REFUSED` so adding one to the benign list fails
+/// here instead of silently rendering a frame the guest did not ask for.
+#[test]
+fn an_alpha_test_or_logic_op_enable_is_still_refused() {
+    for enable in RENDER_PIPELINE_TAGS_STILL_REFUSED {
+        assert!(
+            !RENDER_PIPELINE_TAGS_BENIGN.contains(&enable),
+            "{enable:#04x} enables a fixed-function stage this device does not \
+             implement and must never be treated as benign"
+        );
+        let b = render_pipeline_desc(
+            47,
+            &[
+                (enable, 1),
+                (PIPELINE_TAG_VERTEX_FUNC, 11),
+                (PIPELINE_TAG_FRAGMENT_FUNC, 12),
+            ],
+        );
+        let cap = crate::observe::FailCapture::start();
+        assert!(
+            decode_render_pipeline_descriptor(&b).is_err(),
+            "{enable:#04x} must refuse the pipeline"
+        );
+        // Named, not merely refused: the tag and its first value are what let a
+        // reader identify the next one without a debugger.
+        let line = cap
+            .lines()
+            .into_iter()
+            .find(|l| l.contains("pipeline_descriptor_field_dropped"))
+            .unwrap_or_else(|| panic!("{enable:#04x} refused without naming itself"));
+        assert!(line.contains(&format!("tag={enable:#04x}")), "{line}");
+    }
 }
 
 #[test]

--- a/crates/reims-vgpu/src/runtime/draw/mod.rs
+++ b/crates/reims-vgpu/src/runtime/draw/mod.rs
@@ -1361,14 +1361,25 @@ pub(crate) fn load_render_pipeline<M: HostMemory + HostOps>(
                 return None;
             }
         };
-    let Ok(p) = decode_render_pipeline_descriptor(&desc) else {
-        report.reason(
-            task_id,
-            pipeline_ref,
-            crate::observe::ladder_slug!("", desc_decode),
-            &format!("desc_len={}", desc.len()),
-        );
-        return None;
+    let p = match decode_render_pipeline_descriptor(&desc) {
+        Ok(p) => p,
+        Err(status) => {
+            // The decoder's own name for what it refused, carried through rather
+            // than collapsed into `desc_decode`. Without it this line said only
+            // that a 292-byte descriptor did not decode, and finding out *why*
+            // meant correlating its `t=` against an `OFF type7_pipeline_shape`
+            // line in the same millisecond — which is how the alpha-test and
+            // logic-op tags were found and is not a step the next reader should
+            // have to repeat.
+            use crate::observe::Decline;
+            report.reason(
+                task_id,
+                pipeline_ref,
+                crate::observe::ladder_slug!("", desc_decode),
+                &format!("desc_len={} decode={}", desc.len(), status.slug()),
+            );
+            return None;
+        }
     };
     // Both stages are required to build a pipeline, and the two are reported
     // apart because they are different guest mistakes — the compute sibling

--- a/crates/reims-vgpu/src/runtime/draw/tests.rs
+++ b/crates/reims-vgpu/src/runtime/draw/tests.rs
@@ -251,6 +251,45 @@ fn strided_window_extent_measures_padded_rows_and_refuses_unrepresentable_stride
     assert_eq!(strided_window_extent(64, 0, 4, 256), None);
     // Single-byte texels (the type-5 NV12 luma plane) take every stride.
     assert_eq!(strided_window_extent(64, 4, 1, 64), Some((256, 0)));
+    // The block-aware level form, on the geometry the gather refused for a
+    // whole session: a 64x64 BC3 level is 16 rows of 16 blocks. Tight rows
+    // report `bufferRowLength = 0`; a padded stride reports it in **texels**
+    // (Vulkan's unit even for compressed copies) and block-aligned, so 320
+    // bytes of stride over 16-byte blocks is 20 blocks = 80 texels. A stride
+    // that does not divide into whole blocks cannot describe a block row and
+    // refuses rather than rounding into a shifted image.
+    let bc3 = crate::contract::pixel_format::block_geometry(
+        crate::contract::pixel_format::MTL_FORMAT_BC3_RGBA,
+    )
+    .unwrap();
+    let level = |bpr: u64| crate::runtime::decode::resource::TextureLevelLayout {
+        offset: 0,
+        size: 4096,
+        row_stride: bpr,
+        width: 64,
+        height: 64,
+        depth: 1,
+    };
+    assert_eq!(
+        strided_level_extent(&level(256), bc3),
+        Some((4096, 0)),
+        "sixteen tight block rows of 256 bytes, not sixty-four texel rows"
+    );
+    assert_eq!(
+        strided_level_extent(&level(320), bc3),
+        Some((320 * 15 + 256, 80)),
+        "a padded block row reports its stride in block-aligned texels"
+    );
+    assert_eq!(
+        strided_level_extent(&level(250), bc3),
+        None,
+        "a stride below one tight block row is not a level"
+    );
+    assert_eq!(
+        strided_level_extent(&level(264), bc3),
+        None,
+        "a stride that is not whole blocks cannot describe a block row"
+    );
     assert_eq!(strided_window_extent(64, 4, 1, 96), Some((96 * 3 + 64, 96)));
 }
 
@@ -480,7 +519,15 @@ fn linear_volume_gather_carries_every_depth_plane() {
         height,
         depth,
     };
-    let (span, row_length) = strided_level_extent(&layout, 4).unwrap();
+    let (span, row_length) = strided_level_extent(
+        &layout,
+        pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
+    )
+    .unwrap();
     assert_eq!(span, row_stride * u64::from(height) * u64::from(depth));
     assert_eq!(row_length, 0);
 }
@@ -3121,6 +3168,180 @@ fn mrt_draw_request_type8_swizzled_view_rejected_as_color_rt() {
         )
         .is_none(),
         "swizzled type-8 must not resolve as color RT"
+    );
+}
+
+/// The six faces of a cube texture load in slice order, one face-stride apart.
+///
+/// The regression this pins is the missing car model: Asphalt 8's paint shader
+/// samples a BC3 cube environment map, `sampled_image_shape` refused `Cube`,
+/// and — because a failed record abandons the rest of its serialized pass —
+/// the one refusal cost 44 of the packet's 87 draws every frame.
+///
+/// Two halves, because they fail differently. The RGBA8 case checks *content*:
+/// each face is filled with its own byte, so a wrong stride shows as face N
+/// carrying face M's bytes rather than as a length mismatch. The BC3 case
+/// checks the *stride arithmetic itself* at the allocation boundary: a 64x64
+/// BC3 face is 16 block rows of 256 bytes — 4096, not the 16384 a texel-height
+/// stride would claim — so an allocation sized exactly for six faces passes and
+/// one byte less refuses on the sixth by name.
+#[cfg(feature = "backend-vulkan")]
+#[test]
+fn a_cube_texture_loads_six_faces_in_slice_order() {
+    use crate::contract::endian::{st16, st32, st64};
+    use crate::contract::pixel_format::{MTL_FORMAT_BC3_RGBA, MTL_FORMAT_RGBA8_UNORM};
+    use crate::runtime::decode::resource::{
+        list_object_entry_offset, LINEAR_DESC_HANDLE, LINEAR_DESC_SIZE, OBJECT_LIST_ENTRY_LEN,
+        OBJECT_TYPE_TEXTURE, RESOURCE_PAGE_SHIFT, TEXTURE_DESC_BASE_LEN, TEXTURE_DESC_HEIGHT,
+        TEXTURE_DESC_PIXEL_FORMAT, TEXTURE_DESC_ROW_STRIDE, TEXTURE_DESC_WIDTH,
+    };
+    use texture_view::{load_cube_faces, LinearLoadRefusal, NativeUploads};
+
+    // One writer for both cases: descriptor + object-list entry.
+    let install = |state: &mut DeviceState,
+                   host: &mut FakeHost,
+                   tex_ref: u32,
+                   w: u32,
+                   h: u32,
+                   bpr: u32,
+                   fmt: u16,
+                   alloc: u64,
+                   handle: u32| {
+        let mut desc = vec![0u8; TEXTURE_DESC_BASE_LEN];
+        st64(&mut desc[LINEAR_DESC_SIZE..], alloc);
+        st32(&mut desc[LINEAR_DESC_HANDLE..], handle);
+        st32(&mut desc[TEXTURE_DESC_ROW_STRIDE..], bpr);
+        st32(&mut desc[TEXTURE_DESC_WIDTH..], w);
+        st32(&mut desc[TEXTURE_DESC_HEIGHT..], h);
+        st16(&mut desc[TEXTURE_DESC_PIXEL_FORMAT..], fmt);
+        let desc_gva = 0x280u64;
+        write_task_gva_arm64e(host, &state.tasks[1], desc_gva, &desc);
+        let off = list_object_entry_offset(tex_ref, 256).unwrap();
+        let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
+        let packed = (OBJECT_TYPE_TEXTURE as u32) | ((TEXTURE_DESC_BASE_LEN as u32) << 8);
+        st32(&mut list_entry[0..], packed);
+        list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
+        write_task_gva_arm64e(host, &state.tasks[1], off, &list_entry);
+    };
+
+    // --- RGBA8 8x8: content proves the face order and the stride ------------
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    let (w, h, bpr) = (8u32, 8u32, 32u32);
+    let face_bytes = (bpr * h) as usize;
+    let handle = 8u32;
+    install(
+        &mut state,
+        &mut host,
+        7,
+        w,
+        h,
+        bpr,
+        MTL_FORMAT_RGBA8_UNORM,
+        (face_bytes as u64) * 6,
+        handle,
+    );
+    let data_gva = (handle as u64) << RESOURCE_PAGE_SHIFT;
+    for face in 0u8..6 {
+        let fill = vec![(face + 1) * 10; face_bytes];
+        write_task_gva_arm64e(
+            &mut host,
+            &state.tasks[1],
+            data_gva + (face as u64) * face_bytes as u64,
+            &fill,
+        );
+    }
+    let (bytes, format) = load_cube_faces(
+        &mut state,
+        &mut host,
+        1,
+        7,
+        NativeUploads::NONE,
+        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+    )
+    .expect("six RGBA8 faces load");
+    assert_eq!(
+        format.layout(),
+        crate::contract::pixel_format::TexelLayout::Rgba8
+    );
+    assert_eq!(bytes.len(), face_bytes * 6, "six tight faces, in one buffer");
+    for face in 0u8..6 {
+        let seg = &bytes[face as usize * face_bytes..(face as usize + 1) * face_bytes];
+        assert!(
+            seg.iter().all(|&b| b == (face + 1) * 10),
+            "face {face} must carry its own slice's bytes"
+        );
+    }
+
+    // --- BC3 64x64: the face stride is block rows, at the allocation edge ---
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    let bc_face = 256u64 * 16; // 16 block rows of 256 bytes: 4096, not 16384.
+    install(
+        &mut state,
+        &mut host,
+        9,
+        64,
+        64,
+        256,
+        MTL_FORMAT_BC3_RGBA,
+        bc_face * 6,
+        8,
+    );
+    let native_bc = NativeUploads {
+        block_compressed: true,
+        ..NativeUploads::NONE
+    };
+    let (bytes, format) = load_cube_faces(
+        &mut state,
+        &mut host,
+        1,
+        9,
+        native_bc,
+        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+    )
+    .expect("an allocation sized exactly for six BC3 faces loads");
+    assert_eq!(
+        format.layout(),
+        crate::contract::pixel_format::TexelLayout::Bc3Rgba
+    );
+    assert_eq!(bytes.len() as u64, bc_face * 6);
+
+    // One byte short of six faces: face five's span crosses the allocation and
+    // refuses by name, which is the failure mode a wrong stride must take —
+    // never shifted faces.
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    install(
+        &mut state,
+        &mut host,
+        9,
+        64,
+        64,
+        256,
+        MTL_FORMAT_BC3_RGBA,
+        bc_face * 6 - 1,
+        8,
+    );
+    assert!(
+        matches!(
+            load_cube_faces(
+                &mut state,
+                &mut host,
+                1,
+                9,
+                native_bc,
+                crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+            ),
+            Err(LinearLoadRefusal::SpanExceedsAllocation { .. })
+        ),
+        "the sixth face must refuse past the allocation, not read past it"
     );
 }
 
@@ -6080,8 +6301,9 @@ fn a_draw_skipped_after_an_engine_refusal_is_counted_with_the_vertices_it_cost()
             slot: 0,
             texture_ref: 7,
             // 64x64 BGRA8 at a tight stride is exactly one 16 KiB page of the
-            // rig's walkable task, so the CLEAR seed Store lands and the tail's
-            // `any_store` precondition is met.
+            // rig's walkable task. The eager CLEAR seed is off by default now,
+            // so nothing stores and the tail reports NoMetal — the counter this
+            // test is about ticks on that same tail either way.
             target_gva: StoreRig::gva(1),
             row_stride: 64 * 4,
             width: 64,
@@ -6103,8 +6325,9 @@ fn a_draw_skipped_after_an_engine_refusal_is_counted_with_the_vertices_it_cost()
     drop(cap);
 
     assert!(
-        matches!(st, EncodeStatus::Ok),
-        "the CLEAR seed Store landed, so the record stored: {st:?}"
+        matches!(st, EncodeStatus::NoMetal("draw_vk_nothing_stored")),
+        "with the eager seed off nothing stored, and the tail says so by name \
+         (exec's clear fallback is what lands the clear for this packet): {st:?}"
     );
     assert!(
         lines.iter().any(|l| {
@@ -6843,12 +7066,18 @@ fn a_depth_attachment_is_keyed_on_the_guest_texture_the_pass_bound() {
         "a stencil-carrying depth attachment is its own resident"
     );
 
-    // No depth texture in the pass descriptor: nothing to key a resident on, and
-    // the engine's transient fallback is what runs.
-    assert_eq!(
-        id(&req(0, 1024, 768), false),
-        None,
-        "an unbound depth attachment names no resident"
+    // No depth texture in the pass descriptor: the resident is keyed on the
+    // pass's own geometry instead of on a texture, so the records of one
+    // serialized pass still share a single depth attachment. This used to be
+    // `None`, which handed every record its own empty transient buffer and lost
+    // occlusion between them — see
+    // `an_anonymous_depth_attachment_is_chain_stable_per_geometry` for the
+    // stability half of the rule; here the point is only that the anonymous
+    // key stays out of the texture namespace.
+    let anonymous = id(&req(0, 1024, 768), false).expect("an unbound depth still keys a resident");
+    assert!(
+        matches!(anonymous, TargetIdentity::Anonymous { .. }),
+        "an unbound depth attachment must not invent a texture identity: {anonymous:?}"
     );
     assert_eq!(
         depth_chain_identity(
@@ -6862,8 +7091,9 @@ fn a_depth_attachment_is_keyed_on_the_guest_texture_the_pass_bound() {
             },
             false
         ),
-        None,
-        "and neither does a pass with no depth attachment at all"
+        Some(anonymous),
+        "an absent depth attachment keys the same pass-geometry resident as a \
+         ref-0 one: the two spellings mean the same pass shape"
     );
 }
 

--- a/crates/reims-vgpu/src/runtime/draw/texture_view.rs
+++ b/crates/reims-vgpu/src/runtime/draw/texture_view.rs
@@ -422,6 +422,19 @@ pub(crate) enum ViewSampleRefusal {
     BaseUndeclared { base: u16 },
     ViewUndeclared { view: u16 },
     WidthMismatch { base_bpp: u32, view_bpp: u32 },
+    /// The two formats occupy the same bytes per addressable unit but address a
+    /// different **grid** of texels with them — one is block-compressed and the
+    /// other is not.
+    ///
+    /// Distinct from [`Self::WidthMismatch`] because the two numbers that
+    /// variant prints would be *equal* here and read as a contradiction:
+    /// `BC3_RGBA` and `RGBA32Float` are both sixteen bytes a unit, and one of
+    /// them spends those bytes on sixteen texels. Reinterpreting either as the
+    /// other is not a view of one allocation.
+    GridMismatch {
+        base_compressed: bool,
+        view_compressed: bool,
+    },
 }
 
 impl std::fmt::Display for ViewSampleRefusal {
@@ -439,14 +452,36 @@ impl std::fmt::Display for ViewSampleRefusal {
                     "view_width_mismatch base_bpp={base_bpp} view_bpp={view_bpp}"
                 )
             }
+            Self::GridMismatch {
+                base_compressed,
+                view_compressed,
+            } => {
+                write!(
+                    f,
+                    "view_grid_mismatch base_compressed={base_compressed} \
+                     view_compressed={view_compressed}"
+                )
+            }
         }
     }
 }
 
 /// Pick the sample format for a type-8 view over base storage.
 ///
-/// Metal texture views require the view format to be bpp-compatible with the base.
-/// Unknown formats (no `bytes_per_pixel`) fail visibly. `None` override inherits base.
+/// Metal texture views require the view format to be storage-compatible with the
+/// base. Compatibility is compared as a whole [`pixel_format::BlockGeometry`] —
+/// the grid *and* the bytes — rather than as a bytes-per-texel, because a
+/// block-compressed format has no bytes-per-texel at all and comparing two
+/// `None`s would have admitted a `BC1`-as-`BC3` reinterpretation while refusing
+/// every compressed texture outright.
+///
+/// That refusal was not theoretical: before this took the block form, **every**
+/// BC texture failed here as `linear_load_view_bpp_mismatch` — with no view
+/// override in play, because the base alone has no texel width — so a compressed
+/// bind never reached the loader at all.
+///
+/// Unknown formats (no [`pixel_format::block_geometry`]) fail visibly. `None`
+/// override inherits base.
 ///
 /// Almost every caller only needs "may I", which is what this answers. A caller
 /// that has to *print* a refusal wants [`effective_view_sample_format_reasoned`]
@@ -462,14 +497,22 @@ pub(crate) fn effective_view_sample_format_reasoned(
     view_fmt: Option<u16>,
 ) -> Result<u16, ViewSampleRefusal> {
     let sample = view_fmt.unwrap_or(base_fmt);
-    let base_bpp = pixel_format::bytes_per_pixel(base_fmt)
+    let base_block = pixel_format::block_geometry(base_fmt)
         .ok_or(ViewSampleRefusal::BaseUndeclared { base: base_fmt })?;
-    let sample_bpp = pixel_format::bytes_per_pixel(sample)
+    let sample_block = pixel_format::block_geometry(sample)
         .ok_or(ViewSampleRefusal::ViewUndeclared { view: sample })?;
-    if base_bpp != sample_bpp {
+    if base_block.bytes != sample_block.bytes {
         return Err(ViewSampleRefusal::WidthMismatch {
-            base_bpp,
-            view_bpp: sample_bpp,
+            base_bpp: base_block.bytes,
+            view_bpp: sample_block.bytes,
+        });
+    }
+    // Equal bytes over a different grid is its own refusal — see
+    // [`ViewSampleRefusal::GridMismatch`].
+    if (base_block.width, base_block.height) != (sample_block.width, sample_block.height) {
+        return Err(ViewSampleRefusal::GridMismatch {
+            base_compressed: base_block.is_compressed(),
+            view_compressed: sample_block.is_compressed(),
         });
     }
     Ok(sample)
@@ -634,11 +677,83 @@ pub(crate) fn load_linear_texture_host<M: HostMemory + HostOps>(
         task_id,
         texture_ref,
         level,
+        0,
         format_override,
         native,
         site,
     )
     .ok()
+}
+
+/// Load all six faces of a cube texture, tightly packed face after face — the
+/// layer order `VkBufferImageCopy` consumes with `layerCount = 6`.
+///
+/// Metal stores a cube as a six-slice array, and this device's measured
+/// array-packing rule (see [`load_linear_texture_impl`]'s `face` parameter) puts
+/// each face one face-stride after the last. Each face rides the ordinary 2D
+/// loader, so every conversion arm — native BC blocks, BGRA8, the RGBA8 convert
+/// fallback — serves a cube exactly as it serves the equivalent 2D texture, and
+/// a divergence between the two is not expressible.
+///
+/// Level 0 only, which is what the sampled bind path uploads for every shape
+/// (the engine creates its sampled images with one mip). The faces must agree
+/// on their byte layout by construction — one descriptor, one format — so the
+/// per-face formats are asserted equal rather than reconciled.
+// The Vulkan bind path is the only caller; the Metal arm's cube support is
+// native and never reloads faces on the CPU, so ungated this is dead code
+// there — which the cross-compiled clippy run is what catches.
+#[cfg(feature = "backend-vulkan")]
+pub(crate) fn load_cube_faces<M: HostMemory + HostOps>(
+    state: &mut DeviceState,
+    host: &mut M,
+    task_id: u32,
+    texture_ref: u32,
+    native: NativeUploads,
+    site: crate::runtime::render_writeback::SettleSite,
+) -> Result<(Vec<u8>, SampledByteFormat), LinearLoadRefusal> {
+    /// Faces of a cube. Not configurable: five is not a cube and neither is
+    /// seven, and the engine refuses `cube` images whose layer count is not
+    /// exactly this.
+    const CUBE_FACES: u32 = 6;
+    let mut packed: Vec<u8> = Vec::new();
+    let mut format: Option<SampledByteFormat> = None;
+    for face in 0..CUBE_FACES {
+        let (bytes, byte_format) = load_linear_texture_impl(
+            state,
+            host,
+            task_id,
+            texture_ref,
+            0,
+            face,
+            None,
+            native,
+            site,
+        )?;
+        match format {
+            None => {
+                // Sized once, from the first face: the five remaining reads of
+                // one descriptor cannot legally differ in length.
+                packed.reserve_exact(bytes.len() * (CUBE_FACES as usize - 1));
+                format = Some(byte_format);
+            }
+            Some(first) => {
+                // One descriptor, one format — a disagreement here is this
+                // loader's own bug, not the guest's, so it is a refusal rather
+                // than a debug assertion that vanishes in release.
+                if first.layout() != byte_format.layout() {
+                    return Err(LinearLoadRefusal::RowConvertUnsupported {
+                        format: 0,
+                    });
+                }
+            }
+        }
+        packed.extend_from_slice(&bytes);
+    }
+    let format = format.ok_or(LinearLoadRefusal::ZeroExtent {
+        width: 0,
+        height: 0,
+    })?;
+    Ok((packed, format))
 }
 
 /// Which non-RGBA8 sampled layouts a caller of the linear loaders will carry.
@@ -667,6 +782,18 @@ pub(crate) struct NativeUploads {
     /// `f16_to_unorm8_lut`, which clamps to `[0, 1]` and quantizes to 256
     /// levels; see [`pixel_format::TexelLayout::cpu_loader_arm_is_lossy`].
     pub float16: bool,
+    /// Upload the guest's BC (DXT / S3TC) blocks verbatim as the matching
+    /// `VK_FORMAT_BC*_BLOCK`.
+    ///
+    /// Unlike the two above this is not a saved pass or an exactness question —
+    /// it is the **only** path. There is no CPU decompressor here and there will
+    /// not be one, so a host that clears this flag loses the texture and says
+    /// so; see [`pixel_format::TexelLayout::has_cpu_loader_arm`], which answers
+    /// `false` for every BC layout. Set from
+    /// `engine::supports_block_compressed_sampled`, which is one Vulkan feature
+    /// for the whole family. Desktop GPUs have it; Apple GPUs carry ASTC
+    /// instead and read `false`.
+    pub block_compressed: bool,
 }
 
 impl NativeUploads {
@@ -675,6 +802,7 @@ impl NativeUploads {
     pub const NONE: Self = Self {
         bgra8: false,
         float16: false,
+        block_compressed: false,
     };
 
     /// Native BGRA8 only — the answer this parameter carried when it was a
@@ -689,6 +817,7 @@ impl NativeUploads {
     pub const BGRA8: Self = Self {
         bgra8: true,
         float16: false,
+        block_compressed: false,
     };
 
     /// Every native layout the loaders can produce.
@@ -701,6 +830,7 @@ impl NativeUploads {
     pub const ALL: Self = Self {
         bgra8: true,
         float16: true,
+        block_compressed: true,
     };
 }
 
@@ -719,6 +849,15 @@ pub(crate) fn linear_native_upload_format(
     native: NativeUploads,
 ) -> Option<TexelLayout> {
     use pixel_format::SampledClass;
+    // The compressed families are answered before the sampled class, because
+    // that vocabulary has no block in it and because the answer here is not an
+    // optimisation: a BC bind is native or it is a refusal. `None` when the host
+    // cannot sample the family sends it to the convert path, which declines by
+    // name for a format with no CPU loader arm — which is what a refusal looks
+    // like on this rail.
+    if let Some(layout) = pixel_format::block_compressed_layout(sample_format) {
+        return native.block_compressed.then_some(layout);
+    }
     // The decode contract's sampled class is the one rule for "which channel
     // order and width is this"; it folds each sRGB format onto its linear
     // sibling's layout, which is right — they share a layout. The qualifier is
@@ -745,6 +884,12 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     task_id: u32,
     texture_ref: u32,
     level: u32,
+    // Array slice / cube face to read. Slices pack as contiguous images at each
+    // mip — the rule `blit_exec`'s array copies measured against live guest
+    // traffic (opcode 0x12c, slices 1 and 2 at exact one-image offsets) — so a
+    // face is the level's own read one face-stride further in. 0 is every
+    // pre-existing caller, and everything below is unchanged for it.
+    face: u32,
     format_override: Option<u16>,
     native: NativeUploads,
     site: crate::runtime::render_writeback::SettleSite,
@@ -803,8 +948,30 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
         .ok_or(R::SizeOverflow)?;
     // Every depth plane belongs to the level; only the final plane's final-row
     // padding lies outside the bytes this loader reads.
-    let span = layout.slice_read_span(tight).ok_or(R::SizeOverflow)?;
-    let end = layout.offset.saturating_add(span);
+    //
+    // Counted in rows of storage rather than rows of texels, so a
+    // block-compressed level does not claim four times its own extent and get
+    // refused against the allocation the guest sized correctly.
+    let storage_rows = pixel_format::tight_row_count(h, base_fmt).ok_or(R::FormatBppUnknown {
+        format: base_fmt,
+    })?;
+    // One face-stride per slice past the level base. The stride is a whole
+    // image *including* its final row's padding — the packing rule is
+    // contiguous images, so face N+1 starts where face N's allocation ends,
+    // not where its last read ends. Zero for face 0, which is every 2D caller.
+    let face_off = if face == 0 {
+        0
+    } else {
+        bpr.checked_mul(u64::from(storage_rows))
+            .and_then(|stride| stride.checked_mul(u64::from(planes)))
+            .and_then(|stride| stride.checked_mul(u64::from(face)))
+            .ok_or(R::SizeOverflow)?
+    };
+    let gva = gva.checked_add(face_off).ok_or(R::SizeOverflow)?;
+    let span = layout
+        .slice_read_span_rows(storage_rows, tight)
+        .ok_or(R::SizeOverflow)?;
+    let end = layout.offset.saturating_add(face_off).saturating_add(span);
     if tex.allocation_size != 0 && end > tex.allocation_size {
         return Err(R::SpanExceedsAllocation {
             end,
@@ -856,11 +1023,11 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     // `need_rgba` is the RGBA8 figure. The tight-row check is the same
     // agreement one step earlier — a source row that is not exactly one tight
     // row of the upload layout cannot be copied straight through.
-    if let Some(fmt) = linear_native_upload_format(sample_fmt, native).filter(|fmt| {
-        (tight as u64) == (w as u64).saturating_mul(fmt.bytes_per_texel() as u64)
-    }) {
+    if let Some(fmt) = linear_native_upload_format(sample_fmt, native)
+        .filter(|fmt| fmt.tight_row_bytes(w) == Some(tight))
+    {
         let row_bytes = tight as usize;
-        let rows = (h as usize)
+        let rows = (fmt.tight_row_count(h) as usize)
             .checked_mul(planes as usize)
             .ok_or(R::SizeOverflow)?;
         let out_len = row_bytes.checked_mul(rows).ok_or(R::SizeOverflow)?;
@@ -890,7 +1057,7 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     }
     let mut rgba = vec![0u8; need_rgba];
     let mut row = vec![0u8; tight as usize];
-    let rows = h.checked_mul(planes).ok_or(R::SizeOverflow)?;
+    let rows = storage_rows.checked_mul(planes).ok_or(R::SizeOverflow)?;
     for row_index in 0..rows {
         let row_gva = (row_index as u64)
             .checked_mul(bpr)
@@ -934,7 +1101,16 @@ where
     let tight = pixel_format::tight_row_bytes(width, sample_format).ok_or(R::FormatBppUnknown {
         format: sample_format,
     })?;
-    let rows = height.checked_mul(planes).ok_or(R::SizeOverflow)?;
+    // Rows of storage, not rows of texels: a BC level is a quarter as tall in
+    // blocks as it is in texels, rounded up. `tight_row_count` is the one
+    // spelling of that and it answers `height` for every uncompressed format,
+    // so this is the same read it always was for them.
+    let rows = pixel_format::tight_row_count(height, sample_format)
+        .ok_or(R::FormatBppUnknown {
+            format: sample_format,
+        })?
+        .checked_mul(planes)
+        .ok_or(R::SizeOverflow)?;
     let native_len = (tight as u64)
         .checked_mul(rows as u64)
         .and_then(host_alloc_len)
@@ -1006,6 +1182,166 @@ where
 mod texture_view_split_tests {
     use super::*;
     use crate::runtime::decode::resource::TextureViewDescriptor;
+
+    /// View compatibility is a whole storage grid, which is what lets a
+    /// compressed texture past this gate at all.
+    ///
+    /// The blocker this pins: the check compared `bytes_per_pixel`, and a BC
+    /// format has none — so **every** compressed texture was refused here as
+    /// `linear_load_view_bpp_mismatch` with no view override in play, because
+    /// the base format alone could not answer. A compressed bind never reached
+    /// the loader, and it would have read as "BC is unsupported" rather than as
+    /// this one gate.
+    ///
+    /// The two mismatch directions matter separately and the second is why this
+    /// is a grid and not a byte count: `BC3_RGBA` and `RGBA32Float` are both
+    /// sixteen bytes per addressable unit, and one of them spends them on
+    /// sixteen texels.
+    #[test]
+    fn a_view_is_compatible_by_storage_grid_not_by_texel_width() {
+        use crate::contract::pixel_format as pf;
+
+        // No override: the base format alone must pass, which is the case that
+        // was refusing every compressed texture.
+        assert_eq!(
+            effective_view_sample_format(pf::MTL_FORMAT_BC3_RGBA, None),
+            Some(pf::MTL_FORMAT_BC3_RGBA)
+        );
+        for &format in &[
+            pf::MTL_FORMAT_BC1_RGBA,
+            pf::MTL_FORMAT_BC1_RGBA_SRGB,
+            pf::MTL_FORMAT_BC4_R_SNORM,
+            pf::MTL_FORMAT_BC6H_RGB_FLOAT,
+            pf::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+        ] {
+            assert_eq!(
+                effective_view_sample_format(format, None),
+                Some(format),
+                "{format:#x} must pass its own compatibility gate"
+            );
+        }
+        // The transfer-function view of one allocation is compatible: same grid,
+        // same bytes.
+        assert_eq!(
+            effective_view_sample_format(
+                pf::MTL_FORMAT_BC3_RGBA,
+                Some(pf::MTL_FORMAT_BC3_RGBA_SRGB)
+            ),
+            Some(pf::MTL_FORMAT_BC3_RGBA_SRGB)
+        );
+        // Different weight class in the same grid: eight bytes a block is not
+        // sixteen.
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BC1_RGBA,
+                Some(pf::MTL_FORMAT_BC3_RGBA)
+            ),
+            Err(ViewSampleRefusal::WidthMismatch {
+                base_bpp: 8,
+                view_bpp: 16
+            })
+        ));
+        // Same bytes, different grid — the case a byte-count comparison would
+        // have admitted, and the reason `GridMismatch` exists.
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BC3_RGBA,
+                Some(pf::MTL_FORMAT_RGBA32_FLOAT)
+            ),
+            Err(ViewSampleRefusal::GridMismatch {
+                base_compressed: true,
+                view_compressed: false
+            })
+        ));
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_RGBA32_FLOAT,
+                Some(pf::MTL_FORMAT_BC3_RGBA)
+            ),
+            Err(ViewSampleRefusal::GridMismatch {
+                base_compressed: false,
+                view_compressed: true
+            })
+        ));
+        // And the uncompressed rule is unchanged in both directions.
+        assert_eq!(
+            effective_view_sample_format(
+                pf::MTL_FORMAT_BGRA8_UNORM,
+                Some(pf::MTL_FORMAT_RGBA8_UNORM)
+            ),
+            Some(pf::MTL_FORMAT_RGBA8_UNORM)
+        );
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BGRA8_UNORM,
+                Some(pf::MTL_FORMAT_RGBA16_FLOAT)
+            ),
+            Err(ViewSampleRefusal::WidthMismatch { .. })
+        ));
+    }
+
+    /// A BC bind is native or it is nothing, and the host capability is what
+    /// decides which.
+    ///
+    /// There is no CPU decompressor here, so unlike the BGRA8 and half-float
+    /// flags this one does not choose between a fast path and a slow one — it
+    /// chooses between the guest keeping its texture and losing it. That makes
+    /// the gate load-bearing rather than a performance switch, which is why it
+    /// is asserted in both directions: a `Some` on a host that cannot sample the
+    /// family would create an image in a format the driver never advertised.
+    #[test]
+    fn a_compressed_bind_is_native_or_refused() {
+        use crate::contract::pixel_format::{self as pf, TexelLayout};
+
+        let capable = NativeUploads {
+            block_compressed: true,
+            ..NativeUploads::BGRA8
+        };
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BC3_RGBA, capable),
+            Some(TexelLayout::Bc3Rgba)
+        );
+        // The sRGB spelling folds onto the same layout — identical blocks — and
+        // the qualifier is carried by `SampledByteFormat`'s source format.
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BC3_RGBA_SRGB, capable),
+            Some(TexelLayout::Bc3Rgba)
+        );
+        // Every family, so a member admitted to the contract and forgotten here
+        // fails rather than silently refusing at run time.
+        for format in [
+            pf::MTL_FORMAT_BC1_RGBA,
+            pf::MTL_FORMAT_BC2_RGBA,
+            pf::MTL_FORMAT_BC4_R_UNORM,
+            pf::MTL_FORMAT_BC5_RG_SNORM,
+            pf::MTL_FORMAT_BC6H_RGB_UFLOAT,
+            pf::MTL_FORMAT_BC7_RGBA_UNORM,
+        ] {
+            assert_eq!(
+                linear_native_upload_format(format, capable),
+                pf::block_compressed_layout(format),
+                "{format:#x} must reach the native rail on a capable host"
+            );
+            // A host without the family refuses, and `NativeUploads::BGRA8` is
+            // exactly such a host: the flag defaults off.
+            assert_eq!(
+                linear_native_upload_format(format, NativeUploads::BGRA8),
+                None,
+                "{format:#x} must not be bound on a host that cannot sample it"
+            );
+            assert_eq!(linear_native_upload_format(format, NativeUploads::NONE), None);
+        }
+        // The gate is per family, not per call: an uncompressed format is
+        // unaffected by it in either direction.
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BGRA8_UNORM, capable),
+            Some(TexelLayout::Bgra8)
+        );
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BGRA8_UNORM, NativeUploads::NONE),
+            None
+        );
+    }
 
     #[test]
     fn view_pixel_format_override_effective() {

--- a/crates/reims-vgpu/src/runtime/draw/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/draw/vulkan.rs
@@ -28,15 +28,21 @@ struct SampledImageShape {
 
 /// Map a translated SPIR-V sampled-image dimensionality onto the Vulkan image
 /// shape the sampled-draw path builds. `None` is a shape the path cannot yet
-/// express (`Cube` / `CubeArray`); the caller declines it by name so the gap
-/// stays visible instead of binding the wrong view type.
+/// express (`CubeArray`); the caller declines it by name so the gap stays
+/// visible instead of binding the wrong view type.
+///
+/// `Cube` maps to a six-layer cube image — the engine below has carried the
+/// whole cube rail (`CUBE_COMPATIBLE` creation, `CUBE` view, the
+/// layers-is-six and square-face validations) for as long as this function has
+/// been refusing to name it. What a cube bind additionally needs is six faces
+/// of bytes, which the caller loads through
+/// [`texture_view::load_cube_faces`] when this shape comes back; the shape
+/// alone must not be read as "the ladder's one-face bytes are fine".
 fn sampled_image_shape(
     kind: crate::runtime::spirv_bind::SampledImageKind,
 ) -> Option<SampledImageShape> {
     use crate::runtime::spirv_bind::SampledImageKind;
-    // Plain 2D, which every other shape is a single flag away from. `cube` is
-    // false in all of them: the two cube kinds decline below rather than
-    // reaching here, so nothing this function returns ever sets it.
+    // Plain 2D, which every other shape is a single flag away from.
     let d2 = SampledImageShape {
         arrayed: false,
         volume: false,
@@ -65,7 +71,15 @@ fn sampled_image_shape(
             ..d2
         },
         SampledImageKind::D3 => SampledImageShape { volume: true, ..d2 },
-        SampledImageKind::Cube | SampledImageKind::CubeArray => return None,
+        SampledImageKind::Cube => SampledImageShape {
+            cube: true,
+            layers: 6,
+            ..d2
+        },
+        // A cube array needs 6*n layers and n is the descriptor's array length,
+        // which this decoder does not read; no guest has been measured sending
+        // one. The refusal keeps the gap named.
+        SampledImageKind::CubeArray => return None,
     })
 }
 
@@ -122,9 +136,27 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
     let mut engine_refusal: Option<&'static str> = None;
     // Solid CLEAR seed Stores only when this record owns guest writeback
     // (last of a serialized chain, or unified always-writeback).
+    //
+    // The recipe capture for the clear-only exit is *outside* the landing gate:
+    // that exit hands the clear colour to the next record's seed whether or not
+    // this device eagerly writes it into guest pages, and capturing it inside
+    // the gate is how turning the eager write off would silently break record
+    // chaining too.
     crate::runtime::chain_phase::enter(crate::runtime::chain_phase::Phase::PrepSeed);
+    if writeback_guest {
+        if let Some(c0) = colors.first() {
+            if crate::contract::pass_action::store_action_publishes_single_sample(c0.store_action)
+                && (c0.load_action == MTL_LOAD_ACTION_CLEAR
+                    || c0.load_action == MTL_LOAD_ACTION_DONT_CARE)
+                && c0.width != 0
+                && c0.height != 0
+            {
+                color0_solid = Some((c0.width, c0.height, c0.clear_color));
+            }
+        }
+    }
     if writeback_guest && clear_seed_enabled() {
-        for (i, c) in colors.iter().enumerate() {
+        for c in colors.iter() {
             // Reports an out-of-contract value; the gate below is unchanged, and
             // it is the site that disagrees with this module's writeback loop
             // about what such a value means. See `super::store_action_in_contract`.
@@ -140,11 +172,6 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             if c.width == 0 || c.height == 0 {
                 continue;
             }
-            // Neither writer below takes a full-surface RGBA copy — the GVA
-            // landing repeats a single row and the type-11 landing builds its own
-            // image in the mapping's order — so the only reader of one is the
-            // clear-only exit, and it is the one place that builds it.
-            let solid = (i == 0).then_some((c.width, c.height, c.clear_color));
             // Which branch this loop actually takes, how many bytes it lands and
             // what the landing costs. `prep_seed_us` is 8.6 µs of a 41 µs chain
             // on the `blur=40` dial and rebuilding the images without their two
@@ -205,9 +232,6 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             };
             if ok {
                 any_store = true;
-                if i == 0 {
-                    color0_solid = solid;
-                }
                 crate::observe::line(format!(
                     "linux_clear_store mid={} gva={:#x} {}x{} pipe={} load={}",
                     c.mapping_id, c.target_gva, c.width, c.height, req.pipeline_ref, c.load_action
@@ -718,55 +742,61 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
         }
     }
 
+    // The skipped-draw census sits above the `any_store` split, because the
+    // split no longer decides whether a draw was skipped — only whether a CLEAR
+    // seed happened to land first. When the eager seed was unconditional this
+    // block lived inside the seeded arm, and turning the seed off (its default
+    // now) silently retired the only instrument that counts what an engine
+    // refusal costs the guest.
+    if req.vertex_count > 0 || req.indexed.is_some() {
+        // This used to end in the literal `(m2v pending)`, which was a
+        // hardcoded guess and was wrong. The tail is reached whenever the
+        // engine draw did not land, for any reason, and a translation still
+        // being in flight is only one of them — on a driven macos-26 boot
+        // the guess accounted for **none** of the 114 lines it printed.
+        // Pipeline 160 alone produced 105 of them, from t=36351 to
+        // t=112002, while its one translation was queued at t=36340 and
+        // reported `done ... ok` at t=36351. The real refusals were a
+        // sampled-texture validation check and the driver quarantine.
+        //
+        // `refused_by` is deliberately not spelled `reason=`: the census
+        // ranks fail-channel lines on that key, and the underlying slug is
+        // already counted once at its own emitter. Naming it twice would
+        // make one refusal read as two.
+        crate::observe::fail(format!(
+            "linux_clear_store draws_skipped reason=draws_skipped_after_engine_refusal \
+             pipe={} vtx={} refused_by={}",
+            req.pipeline_ref,
+            req.vertex_count,
+            engine_refusal.unwrap_or("engine_draw_not_attempted")
+        ));
+        // The line above dedupes on `(pipeline, slug)` and the count does
+        // not, so the two answer different questions and only this one can
+        // be added up. Reading the line count as the draw count understates
+        // it by however many times one pipeline was refused — which on a
+        // rail that composites the same layer every frame is the entire
+        // magnitude. Nothing else in the census counts a draw the engine
+        // refused, so "what did this refusal cost the guest" had no
+        // instrument at all; a bare zero here now means no draw was
+        // skipped, rather than meaning nobody was counting.
+        //
+        // The vertices are banded beside the draws because a skipped
+        // six-vertex full-screen quad and a skipped fifty-four-vertex pass
+        // are the same 1 in a draw count and are not the same loss.
+        //
+        // Deliberately **not** split by `engine_refusal` here. That slug is
+        // already this crate's vocabulary and is counted at its own
+        // emitter, so keying a census entry on it would merge two
+        // populations under one name and make one refusal read as two —
+        // the same reason `refused_by=` above is not spelled `reason=`.
+        // The split lives on the fail line; the magnitude lives here.
+        crate::runtime::drain::note_store_route("draws_skipped_after_engine_refusal");
+        crate::runtime::drain::note_store_route_n(
+            "draws_skipped_after_engine_refusal_vertices",
+            u64::from(req.vertex_count),
+        );
+    }
     if any_store {
-        if req.vertex_count > 0 || req.indexed.is_some() {
-            // This used to end in the literal `(m2v pending)`, which was a
-            // hardcoded guess and was wrong. The tail is reached whenever the
-            // engine draw did not land, for any reason, and a translation still
-            // being in flight is only one of them — on a driven macos-26 boot
-            // the guess accounted for **none** of the 114 lines it printed.
-            // Pipeline 160 alone produced 105 of them, from t=36351 to
-            // t=112002, while its one translation was queued at t=36340 and
-            // reported `done ... ok` at t=36351. The real refusals were a
-            // sampled-texture validation check and the driver quarantine.
-            //
-            // `refused_by` is deliberately not spelled `reason=`: the census
-            // ranks fail-channel lines on that key, and the underlying slug is
-            // already counted once at its own emitter. Naming it twice would
-            // make one refusal read as two.
-            crate::observe::fail(format!(
-                "linux_clear_store draws_skipped reason=draws_skipped_after_engine_refusal \
-                 pipe={} vtx={} refused_by={}",
-                req.pipeline_ref,
-                req.vertex_count,
-                engine_refusal.unwrap_or("engine_draw_not_attempted")
-            ));
-            // The line above dedupes on `(pipeline, slug)` and the count does
-            // not, so the two answer different questions and only this one can
-            // be added up. Reading the line count as the draw count understates
-            // it by however many times one pipeline was refused — which on a
-            // rail that composites the same layer every frame is the entire
-            // magnitude. Nothing else in the census counts a draw the engine
-            // refused, so "what did this refusal cost the guest" had no
-            // instrument at all; a bare zero here now means no draw was
-            // skipped, rather than meaning nobody was counting.
-            //
-            // The vertices are banded beside the draws because a skipped
-            // six-vertex full-screen quad and a skipped fifty-four-vertex pass
-            // are the same 1 in a draw count and are not the same loss.
-            //
-            // Deliberately **not** split by `engine_refusal` here. That slug is
-            // already this crate's vocabulary and is counted at its own
-            // emitter, so keying a census entry on it would merge two
-            // populations under one name and make one refusal read as two —
-            // the same reason `refused_by=` above is not spelled `reason=`.
-            // The split lives on the fail line; the magnitude lives here.
-            crate::runtime::drain::note_store_route("draws_skipped_after_engine_refusal");
-            crate::runtime::drain::note_store_route_n(
-                "draws_skipped_after_engine_refusal_vertices",
-                u64::from(req.vertex_count),
-            );
-        }
         // The one exit that hands the seed on: this record encoded no draw, so
         // the solid colour it landed *is* this chain's colour-0 content, and the
         // next record loads it as its seed. Built here rather than in the loop
@@ -3323,21 +3353,50 @@ pub(super) fn strided_window_extent(w: u32, h: u32, bpp: u64, bpr: u64) -> Optio
 }
 
 /// Byte window and Vulkan row pitch for one complete linear texture level.
-/// Depth planes are consecutive at `row_stride * height`; only the final
+/// Depth planes are consecutive at `row_stride * rows`; only the final
 /// plane's final-row padding is outside the sampled window.
+///
+/// Takes the layout's storage **grid** rather than a bytes-per-texel, so a
+/// block-compressed level is described in its own units: rows of blocks (a
+/// quarter of the texel height), a tight row of `blocks_across * block.bytes`,
+/// and a `bufferRowLength` converted back to **texels** — Vulkan's unit for
+/// that field even on compressed copies, where it must be a multiple of the
+/// block width. An uncompressed block is 1x1, for which every expression below
+/// reduces to exactly what [`strided_window_extent`] computes; that helper
+/// keeps its texel spelling because its other callers are rails a compressed
+/// format cannot reach (type-11/type-5 surfaces, whose formats have a
+/// bytes-per-texel by construction).
+///
+/// This is the arithmetic that kept BC textures off the zero-copy gather:
+/// with texel math a 2048x2048 BC3 level claimed four times its own rows and
+/// sixteen times its bytes, so the rail refused (`zc_lin_block_compressed`)
+/// and every bind fell to the CPU re-read + memcmp rung — measured at 53 % of
+/// the drain thread's whole second on a driven race, with the host GPU 6 %
+/// busy.
 pub(super) fn strided_level_extent(
     layout: &crate::runtime::decode::resource::TextureLevelLayout,
-    bpp: u64,
+    block: pixel_format::BlockGeometry,
 ) -> Option<(u64, u32)> {
-    let (last_plane, row_length_texels) = strided_window_extent(
-        layout.width,
-        layout.height,
-        bpp,
-        layout.row_stride,
-    )?;
+    let bytes = u64::from(block.bytes);
+    let bpr = layout.row_stride;
+    let tight = u64::from(block.blocks_across(layout.width)).checked_mul(bytes)?;
+    let rows = block.block_rows(layout.height);
+    if bpr < tight || bytes == 0 || !bpr.is_multiple_of(bytes) || rows == 0 {
+        return None;
+    }
+    let last_plane = bpr
+        .checked_mul(u64::from(rows.checked_sub(1)?))?
+        .checked_add(tight)?;
+    let row_length_texels = if bpr == tight {
+        0
+    } else {
+        u32::try_from(bpr / bytes)
+            .ok()?
+            .checked_mul(block.width)?
+    };
     let preceding_planes = u64::from(layout.planes() - 1)
-        .checked_mul(layout.row_stride)?
-        .checked_mul(u64::from(layout.height))?;
+        .checked_mul(bpr)?
+        .checked_mul(u64::from(rows))?;
     Some((preceding_planes.checked_add(last_plane)?, row_length_texels))
 }
 
@@ -4346,7 +4405,14 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
             (layout, format, components)
         }
     };
-    let bpp = native.bytes_per_texel();
+    // The block-compressed layouts ride this rail in their own units — see
+    // `strided_level_extent`, which speaks the layout's storage grid. The
+    // refusal that used to sit here ("falling to the CPU rail costs one upload
+    // per texture") was measured wrong on the workload that mattered: the CPU
+    // rung's *staleness check* re-reads and byte-compares the full span per
+    // **bind**, not per texture, and a driven Asphalt 8 race paid ~11 800 such
+    // binds a second — 53 % of the drain thread — for textures whose bytes
+    // never changed.
     let Some((gva, layout)) = tex.level_gva(0, state.page_shift) else {
         crate::runtime::drain::note_store_route("zc_lin_no_level_gva");
         return None;
@@ -4356,8 +4422,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
         crate::runtime::drain::note_store_route("zc_lin_no_extent");
         return None;
     }
-    let Some((span, row_length_texels)) = strided_level_extent(layout, bpp as u64)
-    else {
+    let Some((span, row_length_texels)) = strided_level_extent(layout, native.block()) else {
         crate::runtime::drain::note_store_route("zc_lin_unstrideable");
         return None;
     };
@@ -4871,11 +4936,17 @@ fn native_scratch_to_upload(
 ) -> Option<(Vec<u8>, TexelLayout)> {
     let native = native_uploads_for(sample_fmt);
     let bpr = bpr as usize;
+    // Both the row width and the row *count* are the upload layout's own, which
+    // for a block-compressed layout is a row of blocks and a quarter of the
+    // texel height. Spelled `tight_row_bytes` / `tight_row_count` rather than
+    // `w * bytes_per_texel` and `h` so the compressed and uncompressed families
+    // are one expression — the texel form is correct for one of them and short
+    // by four in each axis for the other.
     if let Some(fmt) = linear_native_upload_format(sample_fmt, native)
-        .filter(|fmt| tight == (w as u64).saturating_mul(fmt.bytes_per_texel() as u64))
+        .filter(|fmt| fmt.tight_row_bytes(w).map(u64::from) == Some(tight))
     {
         let row_bytes = tight as usize;
-        let rows = (h as usize).checked_mul(planes as usize)?;
+        let rows = (fmt.tight_row_count(h) as usize).checked_mul(planes as usize)?;
         let mut out = vec![0u8; row_bytes.checked_mul(rows)?];
         for row_index in 0..rows {
             let src = row_index.checked_mul(bpr)?;
@@ -4933,6 +5004,13 @@ fn native_scratch_to_upload(
 /// answer for — so keying on it is the same rule stated once, not a fast path
 /// that could disagree with the slow one.
 fn native_uploads_for(sample_format: u16) -> NativeUploads {
+    // A compressed format has to ask, and it is not in `narrows_to_unorm8`'s
+    // set: that set is the formats whose CPU arm is *lossy*, and a BC format has
+    // no CPU arm at all. Asked first so the keyed fast path below keeps meaning
+    // what its doc says it means.
+    if pixel_format::is_block_compressed(sample_format) {
+        return native_uploads_asking_host();
+    }
     if !pixel_format::narrows_to_unorm8(sample_format) {
         return NativeUploads::BGRA8;
     }
@@ -4955,6 +5033,11 @@ fn native_uploads_asking_host() -> NativeUploads {
         // would be two fields nobody could point at a host that needed them.
         float16: engine::supports_sampled_layout_linear_filter(TexelLayout::Rgba16Float)
             && engine::supports_sampled_layout_linear_filter(TexelLayout::Rg16Float),
+        // One flag for BC1 through BC7 because Vulkan gates them behind one
+        // feature — see `caps::device_features::DeviceFeatures::
+        // texture_compression_bc`. A per-family flag would be ten fields nobody
+        // could point at a host that needed them.
+        block_compressed: engine::supports_block_compressed_sampled(),
         ..NativeUploads::BGRA8
     }
 }
@@ -5022,7 +5105,18 @@ fn load_linear_guest_memoized<M: HostMemory + HostOps>(
     // an image the guest sized to `offset + read_span` exactly is refused here
     // and served by the general loader below, which uses the tighter rule. That
     // is a slower path, not lost work.
-    let span = bpr.checked_mul(h as u64)?.checked_mul(u64::from(planes))?;
+    // Rows of **storage**, not rows of texels. A block-compressed level is a
+    // quarter as tall in rows as it is in texels, so the texel form claimed four
+    // times this level's extent and refused it against the allocation the guest
+    // sized correctly: a 64x64 BC3 texture with `bpr=256` and `alloc=4096`
+    // scored 16 384 here and declined, which cost the whole sampled bind
+    // (`draw_prepare_texture_resolve_missing`, `reason=linear_sample`) with
+    // nothing naming the arithmetic. `tight_row_count` answers `h` for every
+    // uncompressed format, so this is the same span it always was for them.
+    let storage_rows = pixel_format::tight_row_count(h, declared_format)?;
+    let span = bpr
+        .checked_mul(u64::from(storage_rows))?
+        .checked_mul(u64::from(planes))?;
     let native_len = host_alloc_len(span)?;
     if tex.allocation_size != 0 && layout.offset.saturating_add(span) > tex.allocation_size {
         return None;
@@ -7416,6 +7510,69 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         })
                         .unwrap_or(source_planes);
                 }
+                // A cube bind replaces the ladder's bytes outright: everything
+                // above loaded exactly one image, and a cube is six. The reload
+                // costs one extra CPU read of the level per bind — cube maps on
+                // this workload are 64x64 BC3, 24 KiB — and the engine's
+                // content-keyed sampled cache absorbs the GPU upload, so the
+                // cost does not scale with draws. The identity is dropped with
+                // the old bytes: it named the one-face read, and carrying it
+                // over would let a memoized single face satisfy a six-face bind.
+                //
+                // A cube whose source is a render target stays refused by
+                // name: a resident holds one 2D image and cannot produce six
+                // faces, and binding face 0 six times is a wrong image rather
+                // than a fallback. A zero-copy gather source is *replaced*, not
+                // refused — its runs describe the same guest bytes the reload
+                // reads, just through a rail that can only express one image —
+                // which is how the first live cube bind actually arrived: an
+                // RGBA8 cube rode the gather and the reload is what serves it.
+                let (source, sampled_vk_format, byte_origin, bytes_identity, tw, th) = if !cube {
+                    (source, sampled_vk_format, byte_origin, bytes_identity, tw, th)
+                } else {
+                    if source_is_target {
+                        return Err(DrawError::DrawPreparation(
+                            DrawPreparationDecline::TextureDimensionUnsupported {
+                                stage: if frag_stage { "fragment" } else { "vertex" },
+                                index,
+                                texture_ref,
+                                binding: img_bind,
+                                kind: "Cube(resident source)".to_string(),
+                            },
+                        ));
+                    }
+                    match texture_view::load_cube_faces(
+                        state,
+                        host,
+                        req.task_id,
+                        texture_ref,
+                        native_uploads_asking_host(),
+                        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+                    ) {
+                        Ok((faces, byte_format)) => (
+                            crate::backend::vulkan::engine::SampledSource::Bytes(
+                                std::sync::Arc::new(faces),
+                            ),
+                            translate::pixel::vk_sampled_bytes(byte_format),
+                            crate::backend::vulkan::engine::SampledByteOrigin::LinearTexture,
+                            None,
+                            tw,
+                            th,
+                        ),
+                        Err(refusal) => {
+                            use crate::observe::Decline;
+                            return Err(DrawError::DrawPreparation(
+                                DrawPreparationDecline::TextureDimensionUnsupported {
+                                    stage: if frag_stage { "fragment" } else { "vertex" },
+                                    index,
+                                    texture_ref,
+                                    binding: img_bind,
+                                    kind: format!("Cube({})", refusal.slug()),
+                                },
+                            ));
+                        }
+                    }
+                };
                 // A Vulkan 1D image is defined to have height 1; the descriptor
                 // may report the LUT's texel count in either axis, so collapse
                 // to a single row and fold the other axis into the width the
@@ -7546,8 +7703,13 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                 cube: shape.cube,
                 one_dim: shape.one_dim,
                 multisampled: false,
+                // One texel per layer, because the byte-length validation
+                // charges every layer: a cube's neutral substitute is six
+                // texels, not one. `layers` is 1 for every other shape here, so
+                // the repeat is the identity for them.
                 source: crate::backend::vulkan::engine::SampledSource::Bytes(std::sync::Arc::new(
-                    crate::contract::pixel_format::solid_rgba8(1, 1, &[0.0; 4]),
+                    crate::contract::pixel_format::solid_rgba8(1, 1, &[0.0; 4])
+                        .repeat(shape.layers.max(1) as usize),
                 )),
                 byte_origin: crate::backend::vulkan::engine::SampledByteOrigin::Synthetic,
                 format: ash::vk::Format::R8G8B8A8_UNORM,
@@ -8432,6 +8594,23 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                                 .as_ref()
                                 .map(|d| (d.clear_depth as f32, d.load_action))
                                 .unwrap_or((1.0, MTL_LOAD_ACTION_CLEAR));
+                            // A record that continues a serialized render pass
+                            // shares the pass's depth attachment with the
+                            // records before it, so it LOADs whatever they
+                            // tested and wrote — the exact rule the record loop
+                            // already forces on every colour attachment at
+                            // `di > 0`, and depth was the attachment it missed.
+                            // Without it each record re-CLEARed (or re-created)
+                            // the depth buffer and inter-record occlusion was
+                            // lost. `honours_load` still gates on the resident
+                            // actually holding content, so a chain whose first
+                            // record failed degrades to CLEAR by name instead
+                            // of loading an undefined image.
+                            let load_action = if req.continues_render_pass {
+                                MTL_LOAD_ACTION_LOAD
+                            } else {
+                                load_action
+                            };
                             // `MTLLoadActionLoad` is carried through as the
                             // guest wrote it. Whether it can be *honoured* is
                             // not decidable here — it needs the depth resident's
@@ -8980,7 +9159,10 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
 /// lifetime is safe on portability-subset devices because the final record
 /// materializes guest bytes before the packet completes.
 /// The registry resident this draw's **depth** attachment renders into, if the
-/// guest's pass descriptor named a depth texture.
+/// guest's pass descriptor named a depth texture — and a **stable anonymous
+/// identity** when it did not, so a serialized pass's records still share one
+/// depth attachment. `None` is now only a pass with no colour extent to size a
+/// buffer by.
 ///
 /// The depth buffer is a guest resource with a guest lifetime. A pass descriptor
 /// binds `MTLRenderPassDepthAttachment.texture`, this device decodes its ref, and
@@ -9024,21 +9206,47 @@ pub(super) fn depth_chain_identity(
     req: &DrawEncodeRequest,
     with_stencil: bool,
 ) -> Option<crate::backend::vulkan::engine::TargetIdentity> {
-    let depth = req.depth_attach.as_ref()?;
-    if depth.texture_ref == 0 {
-        return None;
-    }
     let c0 = req.colors.first()?;
     let (width, height) = (c0.width, c0.height);
     if width == 0 || height == 0 {
         return None;
     }
-    Some(crate::backend::vulkan::engine::TargetIdentity::Texture {
-        ref_: depth.texture_ref,
-        width,
-        height,
-        generation: 0,
-        stencil: with_stencil,
+    if let Some(depth) = req.depth_attach.as_ref().filter(|d| d.texture_ref != 0) {
+        return Some(crate::backend::vulkan::engine::TargetIdentity::Texture {
+            ref_: depth.texture_ref,
+            width,
+            height,
+            generation: 0,
+            stencil: with_stencil,
+        });
+    }
+    // No named depth texture. This used to be `None`, which handed the engine a
+    // fresh transient buffer **per record** — and a serialized Metal render
+    // pass is one pass with one depth attachment, so a 3D scene split across
+    // records lost occlusion between them: a later record's geometry drew
+    // through an earlier record's, which on a live garage scene rendered the
+    // driver through the car body. `vk_alloc_sites` read the same story as an
+    // allocation storm: `transient_depth` at ~45 000 a session against a rail
+    // whose own doc expects it near zero.
+    //
+    // The identity is anonymous but **stable per pass geometry**: every term in
+    // the slot is a decoded pass value (colour extent, stencil aspect), so two
+    // records of one chain — and two passes of the same shape — resolve the
+    // same resident, and the registry's own geometry check recreates it when
+    // the shape changes. Contents never leak between passes the guest can
+    // observe: a pass's first record still carries the guest's own load action
+    // (CLEAR on every measured workload), and a guest asking LOAD on a depth
+    // buffer it never named is loading contents it never wrote — the same
+    // undefined-by-its-own-choice reading the generation-zero argument above
+    // rests on.
+    //
+    // The high bit keeps this out of the engine's other `Anonymous` slots,
+    // which count up from zero.
+    Some(crate::backend::vulkan::engine::TargetIdentity::Anonymous {
+        slot: (1u64 << 63)
+            | (u64::from(width) << 32)
+            | (u64::from(height) << 1)
+            | u64::from(with_stencil),
     })
 }
 
@@ -11788,14 +11996,71 @@ mod vulkan_split_tests {
         }
     }
 
+    /// A pass's records share one depth attachment, named or not.
+    ///
+    /// The regression this pins rendered the driver through the car: an
+    /// anonymous depth (`depth_attach` absent or ref 0) returned `None`, the
+    /// engine allocated a fresh transient depth **per record**, and a
+    /// serialized pass lost occlusion between its records —
+    /// `vk_alloc_sites transient_depth` at ~45 000 a session against a rail
+    /// documented as near-zero.
+    ///
+    /// The anonymous identity must be a pure function of decoded pass values
+    /// (extent, stencil aspect): stable across records and passes of one shape,
+    /// distinct across shapes, and out of the engine's counting `Anonymous`
+    /// slots.
     #[test]
-    fn sampled_image_shape_declines_cube_shapes_by_name() {
+    fn an_anonymous_depth_attachment_is_chain_stable_per_geometry() {
+        use crate::backend::vulkan::engine::TargetIdentity;
+        let req = |w: u32, h: u32| {
+            let mut r = DrawEncodeRequest::default();
+            r.colors.push(ColorRtRequest {
+                width: w,
+                height: h,
+                ..Default::default()
+            });
+            r
+        };
+        let a = depth_chain_identity(&req(1280, 720), false).expect("anonymous depth resolves");
+        let b = depth_chain_identity(&req(1280, 720), false).expect("same shape resolves");
+        assert_eq!(a, b, "one shape, one identity — that is the whole fix");
+        assert!(
+            matches!(a, TargetIdentity::Anonymous { slot } if slot >> 63 == 1),
+            "anonymous depth lives in the tagged half of the slot space: {a:?}"
+        );
+        // Different extent, different identity; same extent with a stencil
+        // aspect is a different image and so a different identity too.
+        assert_ne!(a, depth_chain_identity(&req(1920, 1080), false).unwrap());
+        assert_ne!(a, depth_chain_identity(&req(1280, 720), true).unwrap());
+        // A named depth texture keeps its own namespace, untouched by this.
+        let mut named = req(64, 64);
+        named.depth_attach = Some(crate::runtime::decode::render::DepthAttachment {
+            texture_ref: 42,
+            ..Default::default()
+        });
+        assert!(matches!(
+            depth_chain_identity(&named, false),
+            Some(TargetIdentity::Texture { ref_: 42, .. })
+        ));
+        // And no colour extent is still no identity: nothing sizes the buffer.
+        assert_eq!(depth_chain_identity(&DrawEncodeRequest::default(), false), None);
+    }
+
+    #[test]
+    fn sampled_image_shape_names_the_cube_and_declines_its_array() {
         use crate::runtime::spirv_bind::SampledImageKind;
 
-        // Cube sampling is not expressed on the sampled-draw path yet; the
-        // shape stays `None` so the caller declines it visibly rather than
-        // binding a 2D view under a cube sampler.
-        assert!(sampled_image_shape(SampledImageKind::Cube).is_none());
+        // A cube is a six-layer cube image, exactly — the engine refuses any
+        // other layer count for a cube — and it is not spelled as an array:
+        // `CUBE` and `TYPE_2D_ARRAY` are different view types and the flags
+        // drive that choice one-to-one.
+        let cube = sampled_image_shape(SampledImageKind::Cube).expect("cube is expressible");
+        assert_eq!(
+            (cube.cube, cube.arrayed, cube.volume, cube.one_dim, cube.layers),
+            (true, false, false, false, 6)
+        );
+        // A cube array needs 6*n layers and n is a descriptor field this
+        // decoder does not read; the refusal keeps that gap named.
         assert!(sampled_image_shape(SampledImageKind::CubeArray).is_none());
     }
     /// An MRT secondary attachment is named by ITS OWN guest pages.
@@ -11893,15 +12158,39 @@ mod vulkan_split_tests {
 /// process.
 ///
 /// Read once. The arms differ in what reaches the guest's pages, so a boot that
-/// flipped it midway would be two devices in one log — and the arm that does not
-/// write is an ablation whose damage is only visible in a photograph, so it has
-/// to hold for the whole boot the photograph is of.
+/// flipped it midway would be two devices in one log.
+///
+/// # The default is now OFF, and the argument is structural, not a timing
+///
+/// The eager seed pre-writes every writeback-owning record's full clear frame
+/// into guest pages before the engine runs — ~3.7 MB a pass, measured at
+/// **~550 ms of every drain-thread second** on a driven Asphalt 8 race, the
+/// single largest cost left on the rail after the BC gather landed. Both jobs
+/// it was doing are done elsewhere:
+///
+/// * **Success**: the record's own Store covers the identical extent
+///   (`store_gva_frame_direct` and the type-11 writeback both land the whole
+///   `width x height`), so every seeded byte was overwritten.
+/// * **Failure**: `runtime::exec`'s fallback applies the pass's clears through
+///   `apply_clear` whenever a packet lands zero draws — "for any draw-fail
+///   class, not only NoMetal", per its own comment — which is the case the
+///   seed's early landing was insurance for.
+///
+/// The chaining recipe (`color0_solid`) is captured outside this gate, so the
+/// clear-only exit still hands the next record its seed either way.
+///
+/// What the OFF arm genuinely gives up: a packet where an *early* record's
+/// engine draw succeeds and a *later* record fails leaves the target holding
+/// the early records' rendered content instead of the clear — which is more of
+/// the guest's work on screen, not less. `REIMS_VGPU_CLEAR_SEED=on` restores
+/// the old eager write for an A/B; damage from either arm is only visible in a
+/// photograph, so hold the arm for the whole boot the photograph is of.
 fn clear_seed_enabled() -> bool {
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| {
         let (state, value) = crate::env::read(crate::env::CLEAR_SEED);
-        let on = !matches!(state, crate::env::Switch::Off);
+        let on = matches!(state, crate::env::Switch::On);
         crate::observe::off(format!(
             "clear_seed on={on} switch={state:?} value={}",
             value.unwrap_or_else(|| "<unset>".into())

--- a/crates/reims-vgpu/src/runtime/objects/mod.rs
+++ b/crates/reims-vgpu/src/runtime/objects/mod.rs
@@ -657,8 +657,8 @@ pub fn device_desc_format_to_mtl(raw: u32) -> u16 {
 /// Unknown formats fail closed.
 pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
     use crate::contract::pixel_format::{
-        MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_R8_UNORM, MTL_FORMAT_RG8_UNORM, MTL_FORMAT_RGBA16_FLOAT,
-        MTL_FORMAT_RGBA8_UNORM,
+        MTL_FORMAT_BGR10A2_UNORM, MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_R8_UNORM,
+        MTL_FORMAT_RG8_UNORM, MTL_FORMAT_RGBA16_FLOAT, MTL_FORMAT_RGBA8_UNORM,
     };
     if pixel_format == 0 {
         return 0;
@@ -686,6 +686,30 @@ pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
         0x5247_4241 => MTL_FORMAT_RGBA8_UNORM,
         // 'RGhA' / half-float variants seen as AhGR in notes
         0x5247_6841 | 0x4168_4752 => MTL_FORMAT_RGBA16_FLOAT,
+        // 'l10r' — `kCVPixelFormatType_ARGB2101010LEPacked`. One single-plane
+        // 32-bit little-endian word per texel: two bits of alpha in the high
+        // bits, then ten each of red, green and blue, with blue in the low
+        // bits. That is `MTLPixelFormatBGR10A2Unorm`'s word exactly, which is
+        // also `VK_FORMAT_A2R10G10B10_UNORM_PACK32`'s — see
+        // `contract::pixel_format::MTL_FORMAT_BGR10A2_UNORM` and
+        // `backend::vulkan::translate::pixel`, which already paired those two.
+        //
+        // Two independent sources agree on it, which is why it is stated rather
+        // than proposed. A driven macos-13 x86/Vulkan boot running Asphalt 8
+        // declares its 1280x720 render surface with this FourCC and then binds a
+        // **type-5 reference-texture view** over the same allocation whose own
+        // `pixel_format` field reads `0x5e` — the guest naming `BGR10A2Unorm`
+        // itself, reported as `rt_type5_view_differs sid=117 view=1280x720
+        // fmt=0x5e ... base fmt=0x0`. The surface geometry closes it: the type-4
+        // record's `bytes_per_row` is 5120 over a width of 1280, which is four
+        // bytes a texel, and its `length` 0x384000 is that stride times 720.
+        //
+        // Before this arm the surface reached `draw::render_target`'s
+        // `rt_type4_base_format` as a zero — that resolve's typed refusal for a
+        // multi-plane or unknown-FourCC surface — so **every** draw of the frame
+        // failed and the game's window was black. One 100 s capture of it held
+        // 20 822 `draw_fail_clear_fallback` records and 0 successful draws.
+        0x6c31_3072 => MTL_FORMAT_BGR10A2_UNORM,
         // Single-plane R8 / RG8 OSTypes used as plane textures (not biplanar media fourcc).
         // 'L008' / common R8 fourccs are rare on type-4; MTL ordinals already handled above.
         // 'R8  ' / 'RG08' if ever seen as OSType:

--- a/crates/reims-vgpu/src/runtime/objects/tests.rs
+++ b/crates/reims-vgpu/src/runtime/objects/tests.rs
@@ -455,6 +455,58 @@ fn decode_type4_plane0() {
     );
 }
 
+/// An `'l10r'` render surface reaches a colour attachment, end to end.
+///
+/// The bug class: a guest game creates its render surface as a single-plane
+/// `kCVPixelFormatType_ARGB2101010LEPacked` IOSurface, this table answered 0 for
+/// it, and 0 out of this table is `draw::render_target`'s
+/// `rt_type4_base_format` refusal — so every draw of every frame failed and the
+/// window was black. Two tables had to answer for that to stop, and a test on
+/// either one alone would have passed while the window stayed black, so this
+/// walks the whole chain the resolve walks.
+///
+/// The geometry is the surface measured on the boot that found it: width 1280 at
+/// a 5120-byte row is four bytes a texel, which is what the packed word is, and
+/// it is the reading that says this FourCC is not a multi-plane media format
+/// wearing a colour name.
+#[test]
+fn an_l10r_surface_resolves_as_a_packed_ten_bit_colour_attachment() {
+    use crate::contract::pixel_format as pf;
+
+    const FOURCC_L10R: u32 = 0x6c31_3072;
+    let built = Type4Builder::new(0x384000, 0x100, FOURCC_L10R, 1).plane(0, 0, 1280, 720, 5120, 0);
+    let surf = decode_type4_surface(built.bytes()).expect("type4 decodes");
+    assert!(
+        !type4_is_multiplanar(&surf),
+        "a packed single-plane colour surface must not read as biplanar"
+    );
+
+    // Step one: the FourCC names a Metal format at all. A zero here is the
+    // refusal the resolve turns into a dropped colour attachment.
+    let mtl = iosurface_pixel_format_to_mtl(surf.pixel_format);
+    assert_eq!(mtl, pf::MTL_FORMAT_BGR10A2_UNORM, "'l10r' must name BGR10A2Unorm");
+
+    // Step two: that format is one this device will render into, which is what
+    // `translate::pixel::color_attachment` derives its answer from. Both steps
+    // were missing and either one alone leaves the frame black.
+    assert_eq!(
+        pf::render_target_bpp(mtl),
+        Some(4),
+        "a named format this device will not render into is still a black window"
+    );
+    // Step three: the frame can be landed in the guest's own pages by a copy
+    // that converts nothing, which is the only lossless route for a format whose
+    // channels do not sit on byte boundaries.
+    assert_eq!(
+        pf::store_texel_order(mtl),
+        Some(pf::TexelLayout::Bgr10a2Unorm)
+    );
+    // The row stride the surface declared is the tight stride for this format at
+    // this width, so the reading above is the surface's own and not an
+    // assumption about what a packed word costs.
+    assert_eq!(pf::tight_row_bytes(surf.width, mtl), Some(surf.bytes_per_row));
+}
+
 #[test]
 fn fourcc_420f_not_bgra_and_multiplanar() {
     assert_eq!(iosurface_pixel_format_to_mtl(IOSURFACE_FOURCC_420F), 0);

--- a/scripts/vgpu-dashboard/README.md
+++ b/scripts/vgpu-dashboard/README.md
@@ -1,0 +1,103 @@
+# vgpu-dashboard
+
+One page to launch a boot, pick USB devices to pass through, choose the network mode, and read the
+device's own censuses while it runs.
+
+```sh
+scripts/vgpu-dashboard/vgpu-dashboard.py            # prints a URL with a token; opens a browser
+scripts/vgpu-dashboard/vgpu-dashboard.py --port 8765 --no-browser
+scripts/vgpu-dashboard/vgpu-dashboard.py --selftest # read-only checks, no VM needed
+```
+
+Python stdlib only — this repo has no Python dependency and this is not the place to add one.
+
+## What it is
+
+An **instrument**. It observes host state and drives the scripts that already exist; it is
+deliberately not a second implementation of anything this repo owns:
+
+| Question | Who answers it |
+|---|---|
+| Which rails and snapshots exist? | `boot-x86.sh --list-rails` / `--list-snapshots` |
+| What USB devices are here, and what spec names each? | `boot-x86.sh --list-usb` → `vm/lib/usb-passthrough.sh` |
+| Where is the guest reachable? | `vm/guest-ip.sh`, `vm/guest-authorize.sh` |
+| What does the guest look like? | the host screenshot helper |
+| What did the device do? | `/tmp/reims-vgpu-fail.log` — the one thing parsed here, because nothing else parses it |
+
+So a rule that changes lands in the dashboard for free, and the dashboard cannot disagree with the
+boot script about what a spec means or which snapshot is current.
+
+## Reading the fail log is where a dashboard goes wrong
+
+Four traps from `AGENTS.md` are implemented rather than left to the reader, because each one fails in
+the direction that looks like a finding:
+
+- **The channel is split before anything is ranked.** `OFF` records carry `reason=` too — for
+  ordering and control-flow events that are not losses — so ranking `reason=` without splitting
+  inverts the queue. The UI shows fail-channel and off-channel counts separately and never sums them.
+- **Per-window and cumulative counters are different objects.** `store_routes`, `drain_duty`,
+  `gpu_span`, `window_publish` and `host_window_cadence` reset each interval, so a total is the
+  **sum** and `tail -1` reads three to four times low. `registry_pressure` and `display_vbl` are
+  high-waters — the device labels the former "(levels, not per-interval)" — where the **last** sample
+  is the answer and summing is the error. `CENSUS_REDUCE` carries which is which.
+- **Everything per-draw is joined by `t=`, never by line order.** Each census skips different
+  windows, so pairing by position drifts and pulls idle-desktop samples into a driven band; a harness
+  that did this read a driven boot at ~31 fps where banding by `t` reads 47-52. The shared band is
+  the intersection of the per-window censuses and is shown with the numbers.
+- **`present_hz` is never displayed alone.** It is a reading of the presenter *and* of the device's
+  publish rate, so it travels with `offered_hz` and with `busy_fence`/`busy_acquire`: both up is the
+  win, offered up alone means the presenter has become a ceiling, neither moving means the change
+  bought no frames.
+
+Two more it surfaces because a reading is worthless without them:
+
+- **Boot count**, from `vk_caps` (one per device creation). More than one means every ranking mixes
+  builds — `first_sight` latches per process, so a stale log inflates in a way that reads as a
+  finding. A device restart *inside* the parsed tail is detected too (`t=` going backwards) and the
+  older samples are dropped rather than blended.
+- **The workload regime**, from drain duty. ~0.00 on a bursty interaction probe, ~0.91 on a sustained
+  one, and only the sustained regime can turn a per-draw CPU saving into frames. A reading taken at
+  low duty is labelled *not rankable*.
+
+It also reports the **60 Hz / free-running population** a boot latched, because nothing per-draw is
+comparable across the two, and host **load average**, because every `us=` is wall clock.
+
+## The panic verdict outranks everything
+
+Each launched boot's stdout is captured to `vm/disks/run/dashboard-boot-<stamp>.log` and grepped for
+a guest kernel panic. `probe exit=0` is not a clean boot and neither is a live device — both read
+green on a boot whose guest died, which on some rails is roughly one driven boot in three.
+
+## Safety
+
+This server execs QEMU and the repo's scripts, so:
+
+- **Loopback only**, and not configurable otherwise. Every request needs the random token printed at
+  startup.
+- **Nothing reaches a shell.** Every child is an argv list. Rails, snapshots, bridges, MACs and RAM
+  sizes are matched against closed patterns; a USB spec is re-validated against the same three forms
+  the library accepts before it can go near a command line.
+- **Env knobs are an allowlist**, because an override may only *narrow* what the device does — it can
+  turn off a rail the host could have run, never turn on one the host reported it cannot.
+- **QMP is an allowlist** of input verbs. `qmp.py cmd` issues arbitrary QMP and is not exposed.
+- **Launches are POST-only**, so a browser prefetch cannot start a VM.
+- `capture` needs explicit confirmation: it writes a new snapshot into the rail.
+- Booting while another QEMU runs is **refused** by default. On `NET=bridge` a second guest collides
+  on the pinned `GUEST_MAC` with no diagnostic at all, and either way the measurement is contended.
+
+`--selftest` covers the host probes, both list parsers, log parsing and reduction, argv construction,
+and twelve rejection cases (shell metacharacters, path traversal, unknown devices, unlisted knobs,
+bad specs, `capture` without confirmation, bridge-on-arm64). It does **not** cover a live guest or
+anything on the arm64 pathway, and says so rather than passing quietly.
+
+## Bridged networking needs the host to be ready
+
+The dashboard assembles one verdict with its reasons instead of four badges to combine: bridge
+present, `/dev/net/tun` openable, a privileged `qemu-bridge-helper`, and an `allow` line in
+`/etc/qemu/bridge.conf`. If the running kernel has no module tree — a kernel upgrade without a
+reboot — it says so by name, because that state breaks every bridged netdev while `lsmod`, `modinfo`
+and `modprobe` all report something that reads like a missing package.
+
+After a bridged boot reaches the desktop, run **Authorize guest**: there is no `localhost:2222` on a
+bridge, and that step resolves the lease and points the `macos-vm` alias every probe types at this
+boot. See `vm/README.md`.

--- a/scripts/vgpu-dashboard/index.html
+++ b/scripts/vgpu-dashboard/index.html
@@ -1,0 +1,776 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>reims-vgpu control</title>
+<style>
+  :root {
+    --bg: #08090c; --bg2: #0d0f14; --panel: #11141b; --panel2: #161a23;
+    --line: #232937; --line2: #2e3648;
+    --text: #dfe4ee; --dim: #8b93a7; --faint: #5b6478;
+    --ok: #3ddc97; --warn: #f5b656; --bad: #ff6b6b; --info: #5eb3ff;
+    --gpu: #b28dff; --accent: #37d3c4;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background:
+      radial-gradient(1200px 600px at 12% -10%, #12212b 0%, transparent 60%),
+      radial-gradient(900px 500px at 100% 0%, #1a1430 0%, transparent 55%),
+      var(--bg);
+    color: var(--text); font-family: var(--sans); font-size: 14px; line-height: 1.5;
+    min-height: 100vh;
+  }
+  a { color: var(--info); }
+  code, .mono { font-family: var(--mono); }
+
+  /* ---------- header ---------- */
+  header {
+    position: sticky; top: 0; z-index: 20;
+    display: flex; flex-wrap: wrap; gap: 14px; align-items: center;
+    padding: 12px 20px; border-bottom: 1px solid var(--line);
+    background: rgba(8,9,12,.86); backdrop-filter: blur(12px);
+  }
+  .brand { display: flex; align-items: baseline; gap: 10px; }
+  .brand b { font-size: 16px; letter-spacing: .2px; }
+  .brand span { color: var(--faint); font-family: var(--mono); font-size: 11px; }
+  .spacer { flex: 1 1 auto; }
+  .badges { display: flex; flex-wrap: wrap; gap: 7px; }
+
+  .badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 9px; border-radius: 999px; font-size: 11.5px;
+    font-family: var(--mono); border: 1px solid var(--line2);
+    background: var(--panel2); color: var(--dim); white-space: nowrap;
+  }
+  .badge b { color: var(--text); font-weight: 600; }
+  .badge.ok    { border-color: #1d5c46; background: #0e2a22; color: var(--ok); }
+  .badge.warn  { border-color: #6b5220; background: #2a2110; color: var(--warn); }
+  .badge.bad   { border-color: #6e2b2b; background: #2b1414; color: var(--bad); }
+  .badge.gpu   { border-color: #453a6b; background: #1c1730; color: var(--gpu); }
+  .badge.info  { border-color: #24486e; background: #0f1e2e; color: var(--info); }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex: none; }
+  .dot.pulse { animation: pulse 1.6s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: .25 } }
+
+  /* ---------- layout ---------- */
+  main { padding: 18px 20px 60px; max-width: 1680px; margin: 0 auto; }
+  .grid { display: grid; gap: 16px; grid-template-columns: repeat(12, 1fr); }
+  .col4 { grid-column: span 4; } .col5 { grid-column: span 5; }
+  .col6 { grid-column: span 6; } .col7 { grid-column: span 7; }
+  .col8 { grid-column: span 8; } .col12 { grid-column: span 12; }
+  @media (max-width: 1250px) { .col4,.col5,.col6,.col7,.col8 { grid-column: span 12; } }
+
+  .panel {
+    background: linear-gradient(180deg, var(--panel2), var(--panel));
+    border: 1px solid var(--line); border-radius: 12px; overflow: hidden;
+  }
+  .panel > h2 {
+    margin: 0; padding: 11px 14px; font-size: 12px; letter-spacing: .09em;
+    text-transform: uppercase; color: var(--dim); font-weight: 600;
+    border-bottom: 1px solid var(--line);
+    display: flex; align-items: center; gap: 9px;
+  }
+  .panel > h2 .hint { text-transform: none; letter-spacing: 0; color: var(--faint); font-weight: 400; }
+  .body { padding: 14px; }
+  .body.tight { padding: 10px; }
+
+  /* ---------- form ---------- */
+  .row { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 11px; }
+  .field { display: flex; flex-direction: column; gap: 4px; flex: 1 1 140px; min-width: 0; }
+  .field > label { font-size: 11px; color: var(--faint); text-transform: uppercase; letter-spacing: .06em; }
+  select, input[type=text] {
+    background: #0a0c11; color: var(--text); border: 1px solid var(--line2);
+    border-radius: 7px; padding: 7px 9px; font-family: var(--mono); font-size: 12.5px;
+    width: 100%; min-width: 0;
+  }
+  select:focus, input:focus { outline: none; border-color: var(--accent); }
+  button {
+    background: var(--panel2); color: var(--text); border: 1px solid var(--line2);
+    border-radius: 8px; padding: 8px 14px; font-size: 13px; font-weight: 500;
+    cursor: pointer; font-family: var(--sans);
+  }
+  button:hover:not(:disabled) { border-color: var(--accent); color: #fff; }
+  button:disabled { opacity: .4; cursor: not-allowed; }
+  button.primary { background: linear-gradient(180deg,#1a6f63,#12564e); border-color: #23887a; color: #eafff9; }
+  button.primary:hover:not(:disabled) { background: linear-gradient(180deg,#1f8577,#16665c); }
+  button.danger  { background: #3a1a1a; border-color: #6e2b2b; color: #ffd9d9; }
+  button.danger:hover:not(:disabled) { background: #4a2020; }
+  button.mini { padding: 4px 9px; font-size: 11.5px; }
+  .actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+
+  .knob { display: flex; align-items: flex-start; gap: 9px; padding: 8px 0; border-top: 1px dashed var(--line); }
+  .knob:first-child { border-top: none; }
+  .knob input { margin-top: 3px; flex: none; accent-color: var(--accent); }
+  .knob .kb { min-width: 0; }
+  .knob .kb b { font-size: 12.5px; font-weight: 600; }
+  .knob .kb p { margin: 2px 0 0; font-size: 11.5px; color: var(--faint); line-height: 1.45; }
+
+  /* ---------- usb ---------- */
+  .usb-list { display: grid; gap: 8px; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
+  .usb {
+    border: 1px solid var(--line2); border-radius: 9px; padding: 9px 11px;
+    background: #0b0d13; cursor: pointer; display: flex; gap: 9px; align-items: flex-start;
+  }
+  .usb:hover { border-color: var(--line2); background: #0e1118; }
+  .usb.sel { border-color: var(--accent); background: #0c1a1a; box-shadow: inset 0 0 0 1px #37d3c433; }
+  .usb.locked { opacity: .55; cursor: not-allowed; }
+  .usb input { margin-top: 2px; flex: none; accent-color: var(--accent); }
+  .usb .name { font-size: 12.5px; font-weight: 600; }
+  .usb .specs { font-family: var(--mono); font-size: 10.5px; color: var(--faint); margin-top: 3px; }
+  .usb .flag { font-size: 10.5px; margin-top: 4px; }
+  .flag.bad { color: var(--bad); } .flag.warn { color: var(--warn); } .flag.ok { color: var(--ok); }
+
+  /* ---------- metrics ---------- */
+  .tiles { display: grid; gap: 9px; grid-template-columns: repeat(auto-fit, minmax(136px, 1fr)); }
+  .tile { background: #0b0d13; border: 1px solid var(--line); border-radius: 9px; padding: 9px 11px; }
+  .tile .k { font-size: 10.5px; color: var(--faint); text-transform: uppercase; letter-spacing: .05em; }
+  .tile .v { font-family: var(--mono); font-size: 20px; font-weight: 600; margin-top: 2px; letter-spacing: -.5px; }
+  .tile .u { font-size: 11px; color: var(--faint); margin-left: 3px; font-family: var(--sans); }
+  .tile .s { font-size: 10.5px; color: var(--faint); margin-top: 2px; }
+  .tile.pair { grid-column: span 2; }
+  .tile.pair .v { font-size: 17px; }
+  .v.ok { color: var(--ok); } .v.warn { color: var(--warn); } .v.bad { color: var(--bad); }
+  .v.gpu { color: var(--gpu); } .v.info { color: var(--info); }
+
+  .note {
+    font-size: 11.5px; color: var(--dim); background: #0a0f17; border-left: 2px solid var(--info);
+    padding: 7px 10px; border-radius: 0 6px 6px 0; margin-top: 10px; line-height: 1.5;
+  }
+  .note.warn { border-left-color: var(--warn); background: #14100a; }
+  .note.bad  { border-left-color: var(--bad); background: #150c0c; }
+  .note b { color: var(--text); }
+
+  pre.log {
+    margin: 0; font-family: var(--mono); font-size: 11px; line-height: 1.5;
+    white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow: auto;
+    background: #070810; border: 1px solid var(--line); border-radius: 8px; padding: 10px;
+    color: var(--dim);
+  }
+  pre.log.tall { max-height: 460px; }
+  table.reasons { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+  table.reasons td { padding: 3px 0; border-bottom: 1px solid #171b25; }
+  table.reasons td.n { text-align: right; font-family: var(--mono); color: var(--text); width: 60px; }
+  table.reasons td.r { font-family: var(--mono); color: var(--dim); word-break: break-all; }
+
+  .kv { display: grid; grid-template-columns: auto 1fr; gap: 3px 12px; font-size: 12px; }
+  .kv dt { color: var(--faint); font-size: 11.5px; }
+  .kv dd { margin: 0; font-family: var(--mono); font-size: 11.5px; word-break: break-all; }
+
+  .pad { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; max-width: 260px; }
+  #shot { width: 100%; border-radius: 8px; border: 1px solid var(--line); display: block; }
+  .toast {
+    position: fixed; right: 18px; bottom: 18px; z-index: 50; display: flex;
+    flex-direction: column; gap: 8px; max-width: 460px;
+  }
+  .toast > div {
+    background: var(--panel2); border: 1px solid var(--line2); border-left: 3px solid var(--info);
+    border-radius: 8px; padding: 9px 12px; font-size: 12px; box-shadow: 0 10px 30px #0009;
+  }
+  .toast > div.bad { border-left-color: var(--bad); }
+  .toast > div.ok { border-left-color: var(--ok); }
+  .toast .mono { font-size: 11px; color: var(--dim); display: block; margin-top: 3px; word-break: break-all; }
+</style>
+
+<header>
+  <div class="brand"><b>reims-vgpu</b> <span id="pathway">…</span></div>
+  <div class="spacer"></div>
+  <div class="badges" id="hdr-badges"></div>
+</header>
+
+<main>
+  <div class="grid">
+
+    <!-- ========================= LAUNCH ========================= -->
+    <section class="panel col5">
+      <h2>Launch <span class="hint" id="launch-hint"></span></h2>
+      <div class="body">
+        <div class="row">
+          <div class="field"><label>Boot class</label>
+            <select id="boot_class"></select></div>
+          <div class="field"><label>Display device</label>
+            <select id="device"></select></div>
+        </div>
+        <div class="row">
+          <div class="field"><label>Rail (guest OS line)</label>
+            <select id="rail"></select></div>
+          <div class="field"><label>Snapshot</label>
+            <select id="snapshot"></select></div>
+        </div>
+        <div class="row">
+          <div class="field"><label>Network</label>
+            <select id="net"></select></div>
+          <div class="field"><label>Bridge</label>
+            <select id="bridge"></select></div>
+        </div>
+        <div class="row">
+          <div class="field"><label>RAM</label><input type="text" id="ram" placeholder="16G"></div>
+          <div class="field"><label>Cores</label><input type="text" id="cpu_cores" placeholder="16"></div>
+          <div class="field"><label>Guest MAC</label><input type="text" id="guest_mac" placeholder="pinned default"></div>
+        </div>
+
+        <div id="knobs"></div>
+
+        <div class="knob">
+          <input type="checkbox" id="fresh_log" checked>
+          <div class="kb"><b>Truncate the fail log first</b>
+            <p>The device appends and never truncates, so a log you did not just create may hold
+               several boots of several builds — and because <code>first_sight</code> latches per
+               process, a stale log inflates in a way that reads as a finding rather than as noise.</p></div>
+        </div>
+
+        <div id="net-note"></div>
+
+        <div class="actions" style="margin-top:12px">
+          <button class="primary" id="btn-boot">Boot</button>
+          <button class="danger" id="btn-stop">Stop VM</button>
+          <button class="mini" id="btn-dry">Show command</button>
+        </div>
+        <pre class="log" id="dry" style="margin-top:10px; display:none"></pre>
+      </div>
+    </section>
+
+    <!-- ========================= USB ========================= -->
+    <section class="panel col7">
+      <h2>USB passthrough <span class="hint" id="usb-hint"></span></h2>
+      <div class="body">
+        <div class="row" style="margin-bottom:9px">
+          <div class="field" style="flex:0 0 190px"><label>Spec form to pass</label>
+            <select id="usb_form">
+              <option value="busport">BUS-PORT — pinned to the socket</option>
+              <option value="vidpid">VID:PID — follows the device</option>
+              <option value="busaddr">BUS.ADDR — this boot only</option>
+            </select></div>
+          <div class="field"><label>&nbsp;</label>
+            <div class="actions">
+              <button class="mini" id="usb-none">Clear</button>
+              <span id="usb-count" style="font-size:11.5px;color:var(--faint)"></span>
+            </div></div>
+        </div>
+        <div class="usb-list" id="usb-list"></div>
+        <div class="note" id="usb-note"></div>
+      </div>
+    </section>
+
+    <!-- ========================= TELEMETRY ========================= -->
+    <section class="panel col8">
+      <h2>Live telemetry <span class="hint" id="tele-hint"></span></h2>
+      <div class="body">
+        <div class="tiles" id="tiles"></div>
+        <div id="tele-notes"></div>
+      </div>
+    </section>
+
+    <!-- ========================= HOST ========================= -->
+    <section class="panel col4">
+      <h2>Host &amp; device</h2>
+      <div class="body">
+        <dl class="kv" id="hostkv"></dl>
+        <div id="host-notes"></div>
+      </div>
+    </section>
+
+    <!-- ========================= DRIVE ========================= -->
+    <section class="panel col4">
+      <h2>Drive the guest <span class="hint">host-side; no guest tooling</span></h2>
+      <div class="body">
+        <div class="pad">
+          <button class="mini" data-key="ret">Return</button>
+          <button class="mini" data-key="esc">Esc</button>
+          <button class="mini" data-key="meta_l-q">⌘Q</button>
+          <button class="mini" data-key="up">↑</button>
+          <button class="mini" data-key="down">↓</button>
+          <button class="mini" data-key="tab">Tab</button>
+        </div>
+        <div class="actions" style="margin-top:10px">
+          <button class="mini" id="btn-size">Display size</button>
+          <button class="mini" id="btn-shot">Screenshot</button>
+        </div>
+        <div class="note">QMP <code>shot</code>/<code>screendump</code> is not used and stays
+          disabled: with the host-owned window and QEMU at <code>-display none</code> the frame
+          never crosses into QEMU's address space, so a screendump shows something other than what
+          the window shows.</div>
+        <img id="shot" style="display:none; margin-top:10px" alt="guest screenshot">
+      </div>
+    </section>
+
+    <!-- ========================= PROBES ========================= -->
+    <section class="panel col8">
+      <h2>Probes</h2>
+      <div class="body" id="probes"></div>
+    </section>
+
+    <!-- ========================= LOG ========================= -->
+    <section class="panel col6">
+      <h2>Fail channel <span class="hint" id="chan-hint"></span></h2>
+      <div class="body">
+        <div id="chan-note"></div>
+        <table class="reasons" id="fail-reasons"></table>
+        <pre class="log" id="fail-recent" style="margin-top:10px"></pre>
+      </div>
+    </section>
+
+    <section class="panel col6">
+      <h2>Boot stdout <span class="hint">the panic verdict outranks a probe's exit</span></h2>
+      <div class="body">
+        <div id="boot-note"></div>
+        <pre class="log tall" id="boot-stdout"></pre>
+      </div>
+    </section>
+
+  </div>
+</main>
+<div class="toast" id="toast"></div>
+
+<script>
+"use strict";
+const TOKEN = new URLSearchParams(location.search).get("token") || "";
+let STATE = null;
+let USB_SEL = new Set();
+let dirty = false;               // once a human edits a field, stop re-defaulting it
+
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+const num = (v, d = 1) => (v === null || v === undefined ? "—" : Number(v).toFixed(d));
+
+function toast(msg, kind = "", detail = "") {
+  const el = document.createElement("div");
+  el.className = kind;
+  el.innerHTML = esc(msg) + (detail ? `<span class="mono">${esc(detail)}</span>` : "");
+  $("toast").appendChild(el);
+  setTimeout(() => el.remove(), kind === "bad" ? 14000 : 6000);
+}
+
+async function api(path, opts = {}) {
+  const sep = path.includes("?") ? "&" : "?";
+  const res = await fetch(path + sep + "token=" + encodeURIComponent(TOKEN), {
+    ...opts,
+    headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
+  });
+  const type = res.headers.get("Content-Type") || "";
+  if (type.startsWith("image/")) return res.blob();
+  const data = await res.json().catch(() => ({ error: "unparseable response" }));
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+/* ---------- form helpers ---------- */
+function fill(sel, values, current) {
+  const el = $(sel);
+  const want = current ?? el.value;
+  el.innerHTML = values.map((v) => {
+    const [val, label] = Array.isArray(v) ? v : [v, v];
+    return `<option value="${esc(val)}">${esc(label)}</option>`;
+  }).join("");
+  if (values.some((v) => (Array.isArray(v) ? v[0] : v) === want)) el.value = want;
+}
+
+/* ---------- header ---------- */
+function renderHeader(s) {
+  $("pathway").textContent = `${s.pathway} · ${s.repo_root}`;
+  const b = [];
+  const caps = s.log.vk_caps;
+  if (caps) {
+    b.push(`<span class="badge gpu"><span class="dot"></span><b>${esc(caps.name || "GPU")}</b></span>`);
+    b.push(`<span class="badge">mem <b>${esc(caps.memory || "?")}</b></span>`);
+    const imp = caps.host_pointer_import || "?";
+    b.push(`<span class="badge ${imp === "supported" ? "ok" : "warn"}">import <b>${esc(imp)}</b></span>`);
+  }
+  const q = s.qemu || [];
+  b.push(q.length
+    ? `<span class="badge ok"><span class="dot pulse"></span>VM up <b>${q.length}</b> · net <b>${esc(q[0].net)}</b>${q[0].usb_passthrough ? ` · usb <b>${q[0].usb_passthrough}</b>` : ""}</span>`
+    : `<span class="badge">no VM running</span>`);
+
+  if (s.boot && s.boot.panic)
+    b.push(`<span class="badge bad"><span class="dot"></span>GUEST KERNEL PANIC</span>`);
+
+  const load = s.host.load;
+  if (load) {
+    const hot = load["1m"] > (load.cpus || 8) * 0.5;
+    b.push(`<span class="badge ${hot ? "warn" : ""}">load <b>${num(load["1m"], 2)}</b>/${load.cpus}</span>`);
+  }
+  if (s.log.boots !== null && s.log.boots > 1)
+    b.push(`<span class="badge warn">log holds <b>${s.log.boots}</b> boots</span>`);
+  $("hdr-badges").innerHTML = b.join("");
+}
+
+/* ---------- host panel ---------- */
+function renderHost(s) {
+  const caps = s.log.vk_caps || {};
+  const rows = [
+    ["uname", s.host.uname],
+    ["kernel modules", s.host.kernel.module_tree_present ? "present" : "MISSING for the running kernel"],
+    ["/dev/net/tun", s.host.tun.ok ? "opens" : `refused — ${s.host.tun.error}`],
+    ["bridge helper", s.net.helper.path ? `${s.net.helper.path} (${s.net.helper.how})` : "none privileged"],
+    ["bridge ACL", s.net.acl.readable ? (s.net.acl.allows ? "allows" : "does NOT allow") : "unreadable"],
+    ["vulkan", caps.api ? `api ${caps.api} · baseline ${caps.baseline} · ${caps.memory_signal || ""}` : "—"],
+    ["fail log", `${s.log.path} · ${(s.log.size / 1e6).toFixed(1)} MB · ${s.log.boots ?? "?"} boot(s)`],
+  ];
+  $("hostkv").innerHTML = rows.map(([k, v]) => `<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`).join("");
+
+  let notes = "";
+  const k = s.host.kernel;
+  if (!k.module_tree_present) {
+    notes += `<div class="note bad"><b>No module tree for the running kernel
+      (${esc(k.release)}).</b> Nothing can be loaded — <code>tun</code> included — so bridged
+      networking cannot start. Installed: ${esc((k.installed_trees || []).join(", "))}.</div>`;
+    if (k.cached_package) {
+      // `tun` declares no dependencies, so the single .ko out of the cached
+      // package loads standalone and the reboot is avoidable.
+      notes += `<div class="note warn"><b>No reboot needed — the running kernel's own
+        <code>tun</code> is still in the package cache.</b> Run these, then click Boot:
+        <pre class="log" style="margin-top:6px">${esc(k.cached_package.commands.join("\n"))}</pre>
+        Undo with <code>${esc(k.cached_package.undo)}</code>.</div>`;
+    } else {
+      notes += `<div class="note warn">Reboot into an installed kernel to get
+        <code>tun</code> back.</div>`;
+    }
+  }
+  $("host-notes").innerHTML = notes;
+}
+
+/* ---------- launch panel ---------- */
+function renderLaunch(s) {
+  fill("boot_class", s.boot_classes, dirty ? undefined : "testing");
+  fill("device", s.devices, dirty ? undefined : s.devices[0]);
+  fill("net", s.net.modes, dirty ? undefined : (s.pathway === "x86" ? "bridge" : "user"));
+  fill("bridge", (s.net.bridges || []).map((b) => b.name).concat(
+    (s.net.bridges || []).length ? [] : ["virbr0"]), dirty ? undefined : "virbr0");
+
+  const rails = s.rails.rails || [];
+  fill("rail", rails.length ? rails : [["", "(no rails)"]],
+    dirty ? undefined : (s.rails.default || rails[0]));
+
+  if (!$("knobs").dataset.built) {
+    $("knobs").innerHTML = Object.entries(s.env_knobs).map(([key, spec]) => {
+      const on = spec.values.find((v) => v !== "") || "on";
+      return `<div class="knob">
+        <input type="checkbox" id="knob_${esc(key)}" data-knob="${esc(key)}" data-on="${esc(on)}">
+        <div class="kb"><b>${esc(spec.label)}</b> <code style="font-size:11px;color:var(--faint)">${esc(key)}=${esc(on)}</code>
+          <p>${esc(spec.note)}</p></div></div>`;
+    }).join("");
+    $("knobs").dataset.built = "1";
+  }
+
+  const nb = [];
+  if ($("net").value === "bridge") {
+    if (s.net.bridge_ready) {
+      nb.push(`<div class="note"><b>Bridged.</b> The guest takes a DHCP lease on
+        <code>${esc($("bridge").value)}</code>, so there is no <code>localhost:2222</code>.
+        Run <b>Authorize guest</b> after the desktop appears — it resolves the lease and points
+        the <code>macos-vm</code> alias every probe types at this boot.</div>`);
+    } else {
+      nb.push(`<div class="note bad"><b>Bridged networking cannot start on this host.</b><ul style="margin:5px 0 0 16px;padding:0">`
+        + s.net.blockers.map((x) => `<li>${esc(x)}</li>`).join("")
+        + `</ul>Pick <code>user</code> to boot now.</div>`);
+    }
+  } else if ($("net").value === "user") {
+    nb.push(`<div class="note"><b>SLIRP.</b> Guest reachable at
+      <code>localhost:${2222}</code> via hostfwd, no host setup needed. Pass
+      <code>NET=user</code> to Authorize guest so it targets the forwarded port.</div>`);
+  } else {
+    nb.push(`<div class="note warn"><b>No NIC.</b> Nothing can ssh in; device counters still work.</div>`);
+  }
+  if ((s.qemu || []).length)
+    nb.push(`<div class="note warn"><b>A VM is already running.</b> Booting a second one contends
+      for the machine, and on a bridge the two collide on the pinned <code>GUEST_MAC</code> with no
+      diagnostic at all. Stop it first.</div>`);
+  $("net-note").innerHTML = nb.join("");
+
+  const boot = s.boot || {};
+  $("btn-boot").disabled = !!boot.running;
+  $("launch-hint").textContent = boot.running
+    ? `running · pid ${boot.pid} · ${num(boot.elapsed, 0)}s`
+    : (boot.returncode !== null && boot.returncode !== undefined ? `last exit ${boot.returncode}` : "");
+}
+
+async function loadSnapshots() {
+  const rail = $("rail").value;
+  if (!rail) { fill("snapshot", [["", "(rail default)"]]); return; }
+  try {
+    const s = await api("/api/snapshots?rail=" + encodeURIComponent(rail));
+    fill("snapshot", [["", "(rail's current)"]].concat(s.snapshots || []));
+  } catch (e) { fill("snapshot", [["", "(unavailable)"]]); }
+}
+
+/* ---------- usb panel ---------- */
+function renderUsb(s) {
+  const devs = (s.usb.devices || []);
+  const form = $("usb_form").value;
+  const key = (d) => form === "vidpid" ? d.vidpid : form === "busaddr" ? d.busaddr : d.busport;
+
+  $("usb-list").innerHTML = devs.map((d) => {
+    const spec = key(d);
+    const sel = USB_SEL.has(spec);
+    const locked = d.writable === false;
+    const flags = [];
+    if (locked) flags.push(`<div class="flag bad">✕ ${esc(d.node)} is not writable by you — libusb
+      cannot claim the interface. Needs a udev rule.</div>`);
+    else if (d.writable) flags.push(`<div class="flag ok">✓ node writable</div>`);
+    if (d.looks_like_hub) flags.push(`<div class="flag warn">⚠ looks like a hub</div>`);
+    return `<label class="usb ${sel ? "sel" : ""} ${locked ? "locked" : ""}">
+      <input type="checkbox" data-spec="${esc(spec)}" ${sel ? "checked" : ""} ${locked ? "disabled" : ""}>
+      <div style="min-width:0">
+        <div class="name">${esc(d.description)}</div>
+        <div class="specs">${esc(d.busport)} &nbsp;·&nbsp; ${esc(d.vidpid)} &nbsp;·&nbsp; ${esc(d.busaddr)}</div>
+        ${flags.join("")}
+      </div></label>`;
+  }).join("") || `<div style="color:var(--faint);font-size:12px">No USB devices enumerated.</div>`;
+
+  $("usb-count").textContent = USB_SEL.size ? `${USB_SEL.size} selected` : "";
+  $("usb-hint").textContent = `${devs.length} on host`;
+
+  const notes = [`<b>${form === "busport" ? "BUS-PORT" : form === "vidpid" ? "VID:PID" : "BUS.ADDR"}</b> — `
+    + (form === "busport"
+      ? "pinned to the physical socket, so it survives a replug and separates two identical devices. Prefer this."
+      : form === "vidpid"
+        ? "matches the descriptor, so it follows the device between ports — but is ambiguous between two identical devices."
+        : "names one device exactly, right now. ADDR is reassigned on replug and on some hub resets.")
+    + ` A passed-through device is detached from the host driver for the life of the boot: pass the keyboard you are typing on and you do not get it back until the VM exits.`];
+  if (s.pathway !== "x86")
+    notes.push(`<b>This pathway cannot resolve specs</b> — the resolver reads <code>/sys</code> and an Apple host has none.`);
+  $("usb-note").innerHTML = notes.join("<br><br>");
+}
+
+/* ---------- telemetry ---------- */
+function renderTelemetry(s) {
+  const m = s.metrics || {};
+  const p = m.present, cpu = m.cpu, gpu = m.gpu, wl = m.workload;
+  const t = [];
+
+  if (p) {
+    const gapBad = p.presenter_is_ceiling;
+    t.push(`<div class="tile pair">
+      <div class="k">present_hz / offered_hz</div>
+      <div class="v ${gapBad ? "warn" : "ok"}">${num(p.present_hz)} <span class="u">/</span> ${num(p.offered_hz)}<span class="u">Hz</span></div>
+      <div class="s">${gapBad ? "presenter is a ceiling — check busy_fence" : "presenting everything offered"}
+        · fence ${p.busy_fence ?? "—"} · acquire ${p.busy_acquire ?? "—"}</div></div>`);
+    t.push(`<div class="tile"><div class="k">population</div>
+      <div class="v ${p.population === "paced-60" ? "info" : "gpu"}" style="font-size:15px">${esc(p.population || "—")}</div>
+      <div class="s">${p.population === "paced-60" ? "latched 16.67 ms" : "latched 0 — work-limited"}</div></div>`);
+  }
+  if (wl) t.push(`<div class="tile"><div class="k">regime</div>
+    <div class="v ${wl.regime === "sustained" ? "ok" : wl.regime === "bursty" ? "warn" : "bad"}" style="font-size:15px">${esc(wl.regime)}</div>
+    <div class="s">duty ${num(wl.duty, 2)} · ${wl.rankable ? "rankable" : "not rankable"}</div></div>`);
+  if (cpu) t.push(`<div class="tile"><div class="k">cpu per draw</div>
+    <div class="v">${num(cpu.us_per_draw, 2)}<span class="u">µs</span></div>
+    <div class="s">${(cpu.draws ?? 0).toLocaleString()} draws · ${cpu.samples} win</div></div>`);
+  if (gpu) t.push(`<div class="tile"><div class="k">gpu per draw</div>
+    <div class="v gpu">${num(gpu.us_per_draw, 2)}<span class="u">µs</span></div>
+    <div class="s">${(gpu.draw_n ?? 0).toLocaleString()} draws · ${gpu.samples} win</div></div>`);
+  if (m.per_draw_total_us !== undefined) t.push(`<div class="tile"><div class="k">cpu + gpu per draw</div>
+    <div class="v info">${num(m.per_draw_total_us, 2)}<span class="u">µs</span></div><div class="s">the score</div></div>`);
+  if (m.vbl) t.push(`<div class="tile"><div class="k">vbl grid</div>
+    <div class="v">${num(m.vbl.grid_hz)}<span class="u">Hz</span></div>
+    <div class="s">window ${num(m.vbl.window_hz)}Hz</div></div>`);
+  if (m.pressure) t.push(`<div class="tile"><div class="k">registry peak</div>
+    <div class="v">${m.pressure.peak ?? "—"}</div>
+    <div class="s">${m.pressure.peak_mib ?? "—"} MiB · levels</div></div>`);
+  if (m.publish) t.push(`<div class="tile"><div class="k">fresh frames</div>
+    <div class="v">${(m.publish.fresh ?? 0).toLocaleString()}</div>
+    <div class="s">same_key ${(m.publish.same_key ?? 0).toLocaleString()}</div></div>`);
+
+  $("tiles").innerHTML = t.join("") ||
+    `<div style="color:var(--faint);font-size:12px">No census in the parsed tail — boot the VM.</div>`;
+
+  const band = m.band || {};
+  $("tele-hint").textContent = band.span_ms
+    ? `${(band.span_ms / 1000).toFixed(0)}s band · ${band.tags.length} censuses joined by t=`
+    : "";
+
+  const n = [];
+  n.push(`<div class="note"><b>present_hz is never read alone.</b> The presenter passes everything
+    at the shipping depth, so it equals <code>offered_hz</code>, which is the device's own publish
+    rate: both up is the win, offered up alone means the presenter has become a ceiling, neither
+    moving means the change bought no frames.</div>`);
+  if (band.span_ms) n.push(`<div class="note"><b>Joined by <code>t=</code>, not by line order.</b>
+    Every census skips different windows, so pairing them by position drifts and pulls idle-desktop
+    samples into a driven band. Shared band here: ${(band.span_ms / 1000).toFixed(0)}s across
+    <code>${esc(band.tags.join(", "))}</code>.</div>`);
+  if (wl && !wl.rankable) n.push(`<div class="note warn"><b>Not a rankable measurement.</b> Drain
+    duty is ${num(wl.duty, 2)}, so this is an ${esc(wl.regime)} device. Only the sustained regime can
+    turn a per-draw CPU saving into frames — run the sustained-animation probe before comparing
+    anything.</div>`);
+  if (s.log.boots !== null && s.log.boots > 1) n.push(`<div class="note bad"><b>This log holds
+    ${s.log.boots} boots.</b> Every ranking above may mix builds. Truncate the log and boot again.</div>`);
+  if (s.log.boot_boundary_in_tail) n.push(`<div class="note warn"><b>A device restart was found
+    inside the parsed tail</b> — <code>t=</code> went backwards. Samples before it were dropped so the
+    band is one boot's.</div>`);
+  const load = s.host.load;
+  if (load && load["1m"] > (load.cpus || 8) * 0.5) n.push(`<div class="note warn"><b>The machine is
+    busy (load ${num(load["1m"], 2)}).</b> Every <code>us=</code> here is wall clock, so treat the
+    timings as upper bounds and reason from counts.</div>`);
+  $("tele-notes").innerHTML = n.join("");
+}
+
+/* ---------- channels, probes, boot log ---------- */
+function renderChannels(s) {
+  const c = s.log.counts || {};
+  $("chan-hint").textContent = `${c.fail ?? 0} fail · ${c.off ?? 0} off, in the parsed tail`;
+  $("chan-note").innerHTML = `<div class="note"><b>The channel is split before anything is ranked.</b>
+    <code>OFF</code> records carry <code>reason=</code> too — for ordering and control-flow events
+    that are not losses — so ranking without splitting inverts the queue. Only fail-channel reasons
+    are listed here.</div>`;
+  const rows = s.log.fail_reasons || [];
+  $("fail-reasons").innerHTML = rows.length
+    ? rows.map(([r, n]) => `<tr><td class="n">${n}</td><td class="r">${esc(r)}</td></tr>`).join("")
+    : `<tr><td class="r" style="color:var(--ok)">no fail-channel reasons in the parsed tail</td></tr>`;
+  $("fail-recent").textContent = (s.log.fail_recent || []).join("\n") || "(nothing on the fail channel)";
+}
+
+function renderProbes(s) {
+  const st = s.probe_status || {};
+  $("probes").innerHTML = Object.entries(s.probes).map(([name, spec]) => {
+    const r = st[name];
+    const running = r && r.running;
+    const badge = !r ? "" : running
+      ? `<span class="badge ok"><span class="dot pulse"></span>running ${num(r.elapsed, 0)}s</span>`
+      : `<span class="badge ${r.returncode === 0 ? "ok" : "bad"}">exit ${r.returncode}</span>`;
+    return `<div style="border-top:1px dashed var(--line);padding:10px 0">
+      <div style="display:flex;gap:9px;align-items:center;flex-wrap:wrap">
+        <button class="mini" data-probe="${esc(name)}" ${running ? "disabled" : ""}>${esc(spec.label)}</button>
+        ${badge}
+      </div>
+      <p style="margin:5px 0 0;font-size:11.5px;color:var(--faint)">${esc(spec.note)}</p>
+      ${r && r.tail ? `<pre class="log" style="margin-top:7px;max-height:150px">${esc(r.tail)}</pre>` : ""}
+    </div>`;
+  }).join("");
+}
+
+function renderBootLog(s) {
+  const b = s.boot || {};
+  $("boot-stdout").textContent = b.stdout_tail || "(no boot launched from this dashboard)";
+  $("boot-note").innerHTML = b.panic
+    ? `<div class="note bad"><b>Guest kernel panic in this boot's stdout.</b> This verdict outranks
+       any probe's exit status and a live device — both read green on a boot whose guest died.
+       A rail that panics on a third of its boots is not a rail that passes.</div>`
+    : (b.log ? `<div class="note"><b>Full log:</b> <code>${esc(b.log)}</code></div>` : "");
+}
+
+/* ---------- config + refresh ---------- */
+function collectConfig() {
+  const env = {};
+  document.querySelectorAll("[data-knob]").forEach((el) => {
+    if (el.checked) env[el.dataset.knob] = el.dataset.on;
+  });
+  const cfg = {
+    pathway: STATE.pathway,
+    boot_class: $("boot_class").value,
+    device: $("device").value,
+    rail: $("rail").value || undefined,
+    snapshot: $("snapshot").value || undefined,
+    net: $("net").value,
+    bridge: $("net").value === "bridge" ? $("bridge").value : undefined,
+    usb: [...USB_SEL],
+    env,
+    fresh_log: $("fresh_log").checked,
+  };
+  ["ram", "cpu_cores", "guest_mac"].forEach((k) => { if ($(k).value.trim()) cfg[k] = $(k).value.trim(); });
+  if (cfg.boot_class === "capture") cfg.confirm_capture = true;
+  return cfg;
+}
+
+async function refresh() {
+  try {
+    const bridge = $("bridge").value || "virbr0";
+    STATE = await api("/api/state?bridge=" + encodeURIComponent(bridge));
+    renderHeader(STATE); renderHost(STATE); renderLaunch(STATE);
+    renderUsb(STATE); renderTelemetry(STATE); renderChannels(STATE);
+    renderProbes(STATE); renderBootLog(STATE);
+    if (!$("snapshot").options.length) await loadSnapshots();
+  } catch (e) { toast("state refresh failed", "bad", e.message); }
+}
+
+/* ---------- wiring ---------- */
+["boot_class", "device", "rail", "snapshot", "net", "bridge", "ram", "cpu_cores", "guest_mac"]
+  .forEach((id) => $(id).addEventListener("change", () => {
+    dirty = true;
+    if (id === "rail") loadSnapshots();
+    if (id === "net" || id === "bridge") renderLaunch(STATE);
+  }));
+
+$("usb_form").addEventListener("change", () => { USB_SEL.clear(); renderUsb(STATE); });
+$("usb-none").addEventListener("click", () => { USB_SEL.clear(); renderUsb(STATE); });
+$("usb-list").addEventListener("change", (ev) => {
+  const box = ev.target.closest("input[data-spec]");
+  if (!box) return;
+  if (box.checked) USB_SEL.add(box.dataset.spec); else USB_SEL.delete(box.dataset.spec);
+  renderUsb(STATE);
+});
+
+$("btn-dry").addEventListener("click", async () => {
+  try {
+    const r = await api("/api/boot-argv?cfg=" + encodeURIComponent(JSON.stringify(collectConfig())));
+    $("dry").style.display = "block";
+    $("dry").textContent = r.shell;
+  } catch (e) { toast("cannot build that command", "bad", e.message); }
+});
+
+$("btn-boot").addEventListener("click", async () => {
+  const cfg = collectConfig();
+  if (cfg.boot_class === "capture" &&
+      !confirm("Capture writes a NEW SNAPSHOT into the rail on clean guest shutdown. Continue?")) return;
+  try {
+    const r = await api("/api/boot", { method: "POST", body: JSON.stringify(cfg) });
+    toast("boot started", "ok", `pid ${r.pid}`);
+    refresh();
+  } catch (e) { toast("boot refused", "bad", e.message); }
+});
+
+$("btn-stop").addEventListener("click", async () => {
+  if (!confirm("Stop the VM? A --testing boot discards its clone on exit.")) return;
+  try {
+    const r = await api("/api/stop", { method: "POST", body: "{}" });
+    toast("stop issued", "ok", (r.actions || []).join(" · "));
+    refresh();
+  } catch (e) { toast("stop failed", "bad", e.message); }
+});
+
+document.querySelectorAll("[data-key]").forEach((btn) => btn.addEventListener("click", async () => {
+  try {
+    const r = await api("/api/qmp", { method: "POST",
+      body: JSON.stringify({ action: "key", args: [btn.dataset.key.replace("-", "+")] }) });
+    toast(`key ${btn.dataset.key}`, r.rc === 0 ? "ok" : "bad", (r.stderr || "").slice(-200));
+  } catch (e) { toast("qmp failed", "bad", e.message); }
+}));
+
+$("btn-size").addEventListener("click", async () => {
+  try {
+    const r = await api("/api/qmp", { method: "POST", body: JSON.stringify({ action: "size", args: [] }) });
+    toast("display size", r.rc === 0 ? "ok" : "bad", (r.stdout || r.stderr || "").trim().slice(-200));
+  } catch (e) { toast("qmp failed", "bad", e.message); }
+});
+
+$("btn-shot").addEventListener("click", async () => {
+  try {
+    const blob = await api("/api/screenshot");
+    $("shot").src = URL.createObjectURL(blob);
+    $("shot").style.display = "block";
+  } catch (e) { toast("screenshot failed", "bad", e.message); }
+});
+
+$("probes").addEventListener("click", async (ev) => {
+  const btn = ev.target.closest("[data-probe]");
+  if (!btn) return;
+  const env = {};
+  if ($("net").value) env.NET = $("net").value;
+  if ($("net").value === "bridge") env.BRIDGE = $("bridge").value;
+  try {
+    const r = await api("/api/probe", { method: "POST",
+      body: JSON.stringify({ name: btn.dataset.probe, env }) });
+    toast(`probe ${btn.dataset.probe} started`, "ok", `pid ${r.pid}`);
+    refresh();
+  } catch (e) { toast("probe refused", "bad", e.message); }
+});
+
+if (!TOKEN) {
+  document.body.innerHTML =
+    '<main><section class="panel col12"><h2>No token</h2><div class="body">' +
+    'Open the URL this server printed on startup — it carries the token.</div></section></main>';
+} else {
+  refresh();
+  setInterval(refresh, 4000);
+}
+</script>

--- a/scripts/vgpu-dashboard/vgpu-dashboard.py
+++ b/scripts/vgpu-dashboard/vgpu-dashboard.py
@@ -1,0 +1,1739 @@
+#!/usr/bin/env python3
+"""vgpu-dashboard.py — a local control panel for the reims-vgpu VM pathways.
+
+Launch a boot, pick USB devices to pass through, choose the network mode, and
+watch the device's own censuses while it runs — in one page, instead of six
+terminals and a remembered set of env knobs.
+
+    scripts/vgpu-dashboard/vgpu-dashboard.py            # then open the printed URL
+    scripts/vgpu-dashboard/vgpu-dashboard.py --port 8765
+    scripts/vgpu-dashboard/vgpu-dashboard.py --selftest # API smoke test, no browser
+
+WHAT THIS IS AND IS NOT. It is an *instrument*: it observes host state and drives
+the existing scripts. It is deliberately not a second implementation of any rule
+this repo already owns. Rails come from `boot-x86.sh --list-rails`, USB specs
+from `boot-x86.sh --list-usb` (which calls vm/lib/usb-passthrough.sh), the guest
+address from `vm/guest-ip.sh`, screenshots from the host helper. When one of
+those changes, this dashboard changes with it and cannot disagree with it. The
+one thing it does parse itself is the fail log, because nothing else does.
+
+READING THE FAIL LOG IS WHERE A DASHBOARD GOES WRONG, so the four traps that
+`AGENTS.md` records are implemented here rather than left to the reader:
+
+  * The channel comes first. `OFF ` records carry `reason=` too, for ordering
+    and control-flow events that are not losses, so ranking `reason=` without
+    splitting the channel inverts the queue. `_fail_channel_lines` does the
+    split; the UI shows the two counts separately and never sums them.
+  * Per-window and cumulative counters are different objects. `store_routes`
+    resets every census interval, so a boot total is the SUM of its samples and
+    `tail -1` reads three to four times low. `registry_pressure` is the
+    opposite — the device labels it "(levels, not per-interval)" and the last
+    sample IS the answer. Summing that one is the error. Each series is tagged
+    with which it is and reduced accordingly.
+  * `present_hz` alone says nothing. It is a reading of the presenter AND of the
+    device's publish rate, so it is always reported beside `offered_hz`, with
+    `busy_fence`/`busy_acquire` next to them: both up is a win, offered up alone
+    means the presenter has become a ceiling.
+  * A log may hold several boots of several builds. `vk_caps` appears once per
+    device creation, so counting it is the boot count, and more than one means
+    every ranking below mixes builds. The UI says so loudly, because
+    `first_sight` latches per process and a stale log inflates in a way that
+    reads as a finding rather than as noise.
+
+Boots are also scored the way the repo scores them: a guest kernel panic is
+grepped out of the boot's own stdout and OUTRANKS a probe's exit status, and the
+60 Hz / free-running population a boot latched is surfaced from `present_hz`,
+because per-draw numbers are not comparable across the two.
+
+SAFETY. This server execs QEMU and the repo's scripts, so it binds 127.0.0.1
+only and every request must carry the random token printed at startup. Nothing
+is ever passed to a shell: every child is an argv list, and a USB spec is
+re-validated against the same three forms the library accepts before it is
+allowed near a command line. Requests that would launch something are POST-only
+so a stray browser prefetch cannot start a VM.
+
+Stdlib only, on purpose — this repo has no Python dependency and this is not the
+place to introduce one.
+"""
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import os
+import re
+import secrets
+import shlex
+import shutil
+import signal
+import socket
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+
+FAIL_LOG = Path(os.environ.get("REIMS_VGPU_FAIL_LOG", "/tmp/reims-vgpu-fail.log"))
+
+# How much of the tail to parse for live metrics. The log is append-only and
+# routinely reaches a gigabyte on a long boot, so it is never read whole: the
+# censuses are 1 Hz, which makes a few megabytes several minutes of history and
+# a full read a stall. Boot counting is the one question that needs the whole
+# file, and it is cached (see `_boot_count`).
+LOG_TAIL_BYTES = int(os.environ.get("REIMS_VGPU_DASH_TAIL", 6 << 20))
+
+# The census tags this dashboard understands, and — the load-bearing half — how
+# each series must be reduced. "window" resets every interval, so a boot total is
+# the sum and the last sample is one window. "levels" is a cumulative high-water
+# where the last sample IS the answer and summing is meaningless. Getting this
+# backwards is the single easiest way to publish a wrong number, so it is data
+# here rather than a habit at each call site.
+CENSUS_REDUCE = {
+    "host_window_cadence": "window",
+    "drain_duty": "window",
+    "gpu_span": "window",
+    "window_publish": "window",
+    "store_routes": "window",
+    "display_vbl": "levels",
+    "registry_pressure": "levels",
+    "vk_caps": "levels",
+}
+
+# A macOS guest that latched a 16 666 666 ns frame period paces at exactly 60 Hz
+# for its whole life; one that latched 0 free-runs and is work-limited at
+# 95-117 Hz. The gap between them is empty on every boot on record, so a single
+# threshold classifies a boot — and per-draw numbers are not comparable across
+# the two populations, which is why the UI labels every reading with it.
+PACED_HZ_CEILING = 75.0
+
+
+def _run(argv, timeout=30, cwd=None, env=None):
+    """Run an argv list and capture it. Never a shell — nothing here interpolates."""
+    merged = dict(os.environ)
+    if env:
+        merged.update({k: str(v) for k, v in env.items()})
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd or REPO_ROOT),
+            env=merged,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "argv": argv,
+            "rc": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "timeout": False,
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "argv": argv,
+            "rc": None,
+            "stdout": exc.stdout or "",
+            "stderr": (exc.stderr or "") + f"\n[timed out after {timeout}s]",
+            "timeout": True,
+        }
+    except FileNotFoundError as exc:
+        return {"argv": argv, "rc": None, "stdout": "", "stderr": str(exc), "timeout": False}
+
+
+# --------------------------------------------------------------------- host state
+
+def host_pathway():
+    """Which boot script this host can actually run.
+
+    Not a preference: boot-x86.sh needs KVM and boot-arm64.sh needs HVF, so the
+    host decides and the UI must not offer the other one as if it would work.
+    """
+    system = os.uname().sysname
+    if system == "Darwin":
+        return "arm64"
+    return "x86"
+
+
+def kernel_module_state():
+    """Whether a module can load at all, which gates bridge networking.
+
+    `tun` is a module on every distro kernel that has it, so it loads on demand —
+    and CANNOT when the running kernel's module tree is absent, which is what a
+    kernel upgrade without a reboot leaves behind. That state breaks every
+    bridged netdev while lsmod/modinfo/modprobe all report something that reads
+    like a missing package, so the diagnosis is worth surfacing by name.
+    """
+    release = os.uname().release
+    tree = Path("/lib/modules") / release
+    installed = sorted(p.name for p in Path("/lib/modules").glob("*")) if Path("/lib/modules").is_dir() else []
+    return {
+        "release": release,
+        "module_tree_present": tree.is_dir(),
+        "installed_trees": installed,
+        # Computed here rather than in the page, so the UI renders one fact
+        # instead of re-deriving a packaging rule in JavaScript.
+        "cached_package": cached_kernel_package(release),
+    }
+
+
+def cached_kernel_package(release):
+    """The package-cache archive holding the RUNNING kernel's own modules, if kept.
+
+    A kernel replaced on disk usually leaves its package behind in the cache, and
+    that archive carries the module tree for the kernel still running. `tun`
+    declares no dependencies, so one `.ko` out of it loads with `insmod` — no
+    depmod, no restored tree, no reboot. Returns None unless the archive is
+    actually there: a hint naming a file nobody has is worse than no hint.
+
+    Arch spells the release `7.1.8-arch1-3` as `7.1.8.arch1-3` in the package
+    name. On packaging this does not recognise, it simply finds nothing.
+    """
+    cache = Path("/var/cache/pacman/pkg")
+    if not cache.is_dir():
+        return None
+    matches = sorted(cache.glob(f"linux-{release.replace('-arch', '.arch')}-*.pkg.tar.zst"))
+    if not matches:
+        return None
+    module = f"usr/lib/modules/{release}/kernel/drivers/net/tun.ko.zst"
+    return {
+        "package": str(matches[0]),
+        "module_path_in_package": module,
+        "commands": [
+            'd=$(mktemp -d)',
+            f'bsdtar -C "$d" -xf {matches[0]} {module}',
+            f'unzstd "$d/{module}" -o "$d/tun.ko"',
+            'sudo insmod "$d/tun.ko"',
+        ],
+        "undo": "sudo rmmod tun",
+    }
+
+
+def tun_available():
+    """Open /dev/net/tun rather than stat it.
+
+    The node existing is not the check: a missing tun driver leaves the node in
+    place and fails the OPEN with ENODEV, which is exactly the state that makes
+    `-netdev bridge` die inside the helper with no explanation.
+    """
+    try:
+        fd = os.open("/dev/net/tun", os.O_RDWR)
+    except OSError as exc:
+        return {"ok": False, "error": f"{exc.strerror} ({exc.errno})"}
+    os.close(fd)
+    return {"ok": True, "error": None}
+
+
+def bridges():
+    """Host bridges, with whether each is a plausible target.
+
+    A bridge with no guest attached reports DOWN/NO-CARRIER; that is normal and
+    not a failure, so it is reported as a fact rather than as a warning.
+    """
+    out = _run(["ip", "-j", "link", "show", "type", "bridge"], timeout=5)
+    found = []
+    if out["rc"] == 0 and out["stdout"].strip():
+        try:
+            for link in json.loads(out["stdout"]):
+                found.append({
+                    "name": link.get("ifname"),
+                    "operstate": link.get("operstate"),
+                    "flags": link.get("flags", []),
+                })
+        except json.JSONDecodeError:
+            pass
+    addrs = {}
+    out4 = _run(["ip", "-j", "-4", "addr", "show"], timeout=5)
+    if out4["rc"] == 0 and out4["stdout"].strip():
+        try:
+            for link in json.loads(out4["stdout"]):
+                for info in link.get("addr_info", []):
+                    if info.get("family") == "inet":
+                        addrs.setdefault(link.get("ifname"), []).append(
+                            f"{info.get('local')}/{info.get('prefixlen')}")
+        except json.JSONDecodeError:
+            pass
+    for br in found:
+        br["addresses"] = addrs.get(br["name"], [])
+    return found
+
+
+def bridge_helper():
+    """Locate a qemu-bridge-helper that can actually enslave a tap.
+
+    Mirrors what boot-x86.sh resolves, and for the same reason: a helper that
+    cannot get CAP_NET_ADMIN fails inside QEMU with an exit status and no
+    explanation, so the UI should say which file was rejected and why before a
+    boot is attempted.
+    """
+    candidates = [
+        REPO_ROOT / "vendor/qemu/build/qemu-bridge-helper",
+        Path("/usr/lib/qemu/qemu-bridge-helper"),
+        Path("/usr/libexec/qemu-bridge-helper"),
+        Path("/usr/local/libexec/qemu-bridge-helper"),
+        Path("/usr/lib/x86_64-linux-gnu/qemu/qemu-bridge-helper"),
+    ]
+    unprivileged = None
+    for path in candidates:
+        if not (path.is_file() and os.access(path, os.X_OK)):
+            continue
+        try:
+            st = path.stat()
+        except OSError:
+            continue
+        if (st.st_mode & 0o4000) and st.st_uid == 0:
+            return {"path": str(path), "privileged": True, "how": "setuid root", "rejected": None}
+        getcap = shutil.which("getcap")
+        if getcap:
+            cap = _run([getcap, str(path)], timeout=5)
+            if "cap_net_admin" in (cap["stdout"] or ""):
+                return {"path": str(path), "privileged": True, "how": "cap_net_admin", "rejected": None}
+        unprivileged = unprivileged or str(path)
+    return {"path": None, "privileged": False, "how": None, "rejected": unprivileged}
+
+
+def bridge_acl(bridge):
+    """What /etc/qemu/bridge.conf says about this bridge.
+
+    The helper is the authority — it honours allow/deny/all and follows
+    `include` lines — so this reads the obvious file and reports, rather than
+    becoming a second copy of the rule that can disagree with the first.
+    """
+    conf = Path("/etc/qemu/bridge.conf")
+    if not conf.is_file():
+        return {"file": str(conf), "readable": False, "allows": None, "lines": []}
+    try:
+        lines = [ln.strip() for ln in conf.read_text().splitlines() if ln.strip()]
+    except OSError:
+        return {"file": str(conf), "readable": False, "allows": None, "lines": []}
+    allows = any(
+        re.fullmatch(rf"allow\s+({re.escape(bridge)}|all)", ln) for ln in lines
+    )
+    return {"file": str(conf), "readable": True, "allows": allows, "lines": lines}
+
+
+def load_average():
+    """Load, because every `us=` number this device reports is wall clock.
+
+    A driven boot taken while a build or a second VM runs measures the harness as
+    much as the device — it has been measured to halve throughput and invert the
+    ranking between the two largest costs — and the log looks perfectly healthy
+    either way. Counts survive contention; timings do not.
+    """
+    try:
+        one, five, fifteen = os.getloadavg()
+    except OSError:
+        return None
+    return {"1m": round(one, 2), "5m": round(five, 2), "15m": round(fifteen, 2),
+            "cpus": os.cpu_count()}
+
+
+# ------------------------------------------------------------------ the fail log
+
+# `key=N` and `key=N.N`. Some census fields are a pair — `resample_peak_ms=60007/2000`,
+# `slab_mib=1025/1264` — where the first number is the reading and the second is
+# the cap it is measured against; both are kept, the second as `<key>_cap`.
+_KV = re.compile(r"([a-z_][a-z_0-9]*)=(-?[0-9]+(?:\.[0-9]+)?)(?:/(-?[0-9]+(?:\.[0-9]+)?))?")
+_TAG = re.compile(r"^(OFF )?([a-z_][a-z_0-9]*)\b")
+
+# The full-scan cache. `vk_caps` is emitted once per device creation, at the
+# START of each boot, so a tail window of any practical size does not contain it
+# on a long-running boot — the structural facts about the host GPU have to come
+# from the same pass that counts boots, or they come back empty.
+_scan_cache = {"mtime": None, "size": None, "count": None, "vk_caps_line": None}
+
+
+def _tail_text(path, nbytes):
+    """Last nbytes of the log, starting at a line boundary."""
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > nbytes:
+                fh.seek(size - nbytes)
+                fh.readline()          # discard the partial first line
+            data = fh.read()
+    except OSError:
+        return "", 0
+    return data.decode("utf-8", "replace"), size
+
+
+def _split_channel(line):
+    """(channel, tag) for one record.
+
+    A fail-channel record begins with its own event name; an off-channel one
+    begins with the literal `OFF `. This is the split that has to happen before
+    anything ranks `reason=`, because OFF records carry `reason=` too — for
+    ordering and control-flow events that are not losses — and ranking without
+    it inverts the queue.
+    """
+    match = _TAG.match(line)
+    if not match:
+        return None, None
+    return ("off" if match.group(1) else "fail"), match.group(2)
+
+
+def _scan_log(path):
+    """One full pass for the two questions a tail cannot answer.
+
+    BOOT COUNT, from `vk_caps` — one line per device creation. More than one
+    means every ranking below mixes builds, and because `first_sight` latches per
+    process a stale log inflates in a way that reads as a finding rather than as
+    noise: a stale log ranked naively once named two documented healthy-zero
+    decoders as firing ~96 000 times between them, where a clean driven boot put
+    both at zero.
+
+    THE NEWEST `vk_caps` LINE, because it is the host's own report of what it
+    supports — GPU, memory topology, whether the host-pointer import is live —
+    and it is written at boot start, far outside any tail window.
+
+    Cached on (mtime, size): a gigabyte scan is ~1 s and the answer only changes
+    when the file does.
+    """
+    try:
+        st = path.stat()
+    except OSError:
+        return {"count": None, "vk_caps_line": None}
+    if (_scan_cache["mtime"], _scan_cache["size"]) == (st.st_mtime, st.st_size):
+        return {"count": _scan_cache["count"], "vk_caps_line": _scan_cache["vk_caps_line"]}
+    count = 0
+    newest = None
+    try:
+        with path.open("rb") as fh:
+            tail = b""
+            for chunk in iter(lambda: fh.read(1 << 22), b""):
+                buf = tail + chunk
+                count += buf.count(b"vk_caps") - tail.count(b"vk_caps")
+                idx = buf.rfind(b"vk_caps")
+                if idx != -1:
+                    start = buf.rfind(b"\n", 0, idx) + 1
+                    end = buf.find(b"\n", idx)
+                    if end != -1:
+                        newest = buf[start:end].decode("utf-8", "replace")
+                # Carry the last partial line so a tag split across a chunk
+                # boundary is neither missed nor double-counted.
+                cut = buf.rfind(b"\n") + 1
+                tail = buf[cut:]
+    except OSError:
+        return {"count": None, "vk_caps_line": None}
+    _scan_cache.update(mtime=st.st_mtime, size=st.st_size, count=count, vk_caps_line=newest)
+    return {"count": count, "vk_caps_line": newest}
+
+
+def _parse_vk_caps(line):
+    """The host capability line, keeping its string fields.
+
+    `_KV` sees only numbers, and the interesting half here is words — the GPU
+    name is quoted, and `memory=discrete` / `host_pointer_import=supported` are
+    the two that decide which memory rails a boot even exercises.
+    """
+    if not line:
+        return None
+    caps = {"raw": line[:600]}
+    caps.update({k: v for k, v, _cap in _KV.findall(line)})
+    for key in ("memory", "memory_signal", "host_pointer_import", "type", "api", "baseline"):
+        match = re.search(rf"\b{key}=([^\s]+)", line)
+        if match:
+            caps[key] = match.group(1)
+    match = re.search(r'\bname="([^"]*)"', line)
+    if match:
+        caps["name"] = match.group(1)
+    return caps
+
+
+def _sum_window(samples):
+    """Sum a per-window series. `t` is a clock, not a quantity, so it is skipped
+    and the band is reported separately."""
+    totals = {}
+    for sample in samples:
+        for key, value in sample.items():
+            if key == "t":
+                continue
+            totals[key] = totals.get(key, 0) + value
+    return totals
+
+
+def _band(entry, t_lo, t_hi):
+    """The samples of one per-window series that fall inside a shared `t` band.
+
+    This is the join that has to be by timestamp rather than by line ordinal.
+    `drain_duty`, `gpu_span`, `window_publish` and `store_routes` each skip
+    different windows, so pairing them by position drifts and pulls idle-desktop
+    samples into a driven band — a harness that did it read a driven boot at
+    ~31 fps where banding by `t` reads 47-52. Every rate quoted from a bad join
+    is wrong in the direction that looks like a device problem.
+    """
+    if entry is None:
+        return None
+    inside = [
+        smp for smp in entry["_samples"]
+        if smp.get("t") is not None and t_lo <= smp["t"] <= t_hi
+    ]
+    if not inside:
+        return None
+    return {"samples": len(inside), "sum": _sum_window(inside), "last": inside[-1]}
+
+
+def parse_log(tail_bytes=None):
+    """Parse the tail into per-tag series, reduced the way each tag demands."""
+    tail_bytes = tail_bytes or LOG_TAIL_BYTES
+    text, total = _tail_text(FAIL_LOG, tail_bytes)
+    scan = _scan_log(FAIL_LOG)
+    if not text:
+        return {
+            "present": FAIL_LOG.exists(),
+            "path": str(FAIL_LOG),
+            "size": total,
+            "boots": None,
+            "series": {},
+            "fail_reasons": [],
+            "off_reasons": [],
+            "fail_recent": [],
+            "counts": {"fail": 0, "off": 0},
+            "vk_caps": None,
+            "boot_boundary_in_tail": False,
+        }
+
+    series = {}
+    fail_reasons = {}
+    off_reasons = {}
+    fail_recent = []
+    counts = {"fail": 0, "off": 0}
+
+    for line in text.splitlines():
+        channel, tag = _split_channel(line)
+        if channel is None:
+            continue
+        counts[channel] += 1
+
+        reason = None
+        rmatch = re.search(r"\breason=([a-z_0-9]+)", line)
+        if rmatch:
+            reason = rmatch.group(1)
+        if channel == "fail":
+            if reason:
+                fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+            fail_recent.append(line[:400])
+        elif reason:
+            off_reasons[reason] = off_reasons.get(reason, 0) + 1
+
+        if tag in CENSUS_REDUCE:
+            fields = {}
+            for key, value, cap in _KV.findall(line):
+                fields[key] = float(value) if "." in value else int(value)
+                if cap:
+                    fields[key + "_cap"] = float(cap) if "." in cap else int(cap)
+            series.setdefault(tag, []).append(fields)
+
+    reduced = {}
+    boot_boundary_in_tail = False
+    for tag, samples in series.items():
+        mode = CENSUS_REDUCE[tag]
+        # `t` is milliseconds since THIS device's creation, so it restarts at ~0
+        # on every boot. A log holding several boots can therefore put two boots
+        # inside one tail window, and banding across that boundary mixes builds
+        # while every number stays plausible. Keep only the final run in which
+        # `t` never goes backwards — that is the newest boot.
+        cut = 0
+        for i in range(1, len(samples)):
+            prev, cur = samples[i - 1].get("t"), samples[i].get("t")
+            if prev is not None and cur is not None and cur < prev:
+                cut = i
+        if cut:
+            boot_boundary_in_tail = True
+            samples = samples[cut:]
+        entry = {
+            "mode": mode,
+            "samples": len(samples),
+            "last": samples[-1],
+            "t_lo": samples[0].get("t"),
+            "t_hi": samples[-1].get("t"),
+            # Kept so metrics() can re-band them against the other tags. Every
+            # census carries `t=` and each one SKIPS DIFFERENT WINDOWS, so a
+            # cross-tag ratio taken over each tag's own full range silently
+            # compares different spans of time.
+            "_samples": samples,
+        }
+        entry["sum"] = _sum_window(samples) if mode == "window" else None
+        reduced[tag] = entry
+
+    return {
+        "present": True,
+        "path": str(FAIL_LOG),
+        "size": total,
+        "tail_bytes": min(tail_bytes, total),
+        "boots": scan["count"],
+        "series": reduced,
+        "fail_reasons": sorted(fail_reasons.items(), key=lambda kv: -kv[1])[:15],
+        "off_reasons": sorted(off_reasons.items(), key=lambda kv: -kv[1])[:15],
+        "fail_recent": fail_recent[-40:],
+        "counts": counts,
+        "vk_caps": _parse_vk_caps(scan["vk_caps_line"]),
+        # True when the parsed tail straddled a device restart and older samples
+        # were dropped. Surfaced so a reading is never silently a two-boot blend.
+        "boot_boundary_in_tail": boot_boundary_in_tail,
+    }
+
+
+def metrics(parsed):
+    """The handful of readings this repo actually ranks a change on.
+
+    Everything per-draw is computed over ONE `t` band shared by every per-window
+    census involved, never over each tag's own range — see `_band`. The band is
+    reported alongside the numbers so a narrow overlap is visible rather than
+    implied.
+    """
+    out = {}
+    series = parsed.get("series", {})
+    windowed = {
+        tag: entry for tag, entry in series.items()
+        if entry["mode"] == "window" and entry.get("t_lo") is not None
+    }
+
+    # The shared band is the intersection of the per-window censuses: the latest
+    # start and the earliest end. Anything outside it is a span some census did
+    # not observe.
+    if windowed:
+        t_lo = max(entry["t_lo"] for entry in windowed.values())
+        t_hi = min(entry["t_hi"] for entry in windowed.values())
+        if t_hi < t_lo:
+            t_lo = t_hi = None
+    else:
+        t_lo = t_hi = None
+    out["band"] = {
+        "t_lo": t_lo,
+        "t_hi": t_hi,
+        "span_ms": (t_hi - t_lo) if (t_lo is not None and t_hi is not None) else None,
+        "tags": sorted(windowed),
+    }
+    joined = t_lo is not None and t_hi is not None and t_hi > t_lo
+
+    def banded(tag):
+        if not joined:
+            return None
+        return _band(series.get(tag), t_lo, t_hi)
+
+    cadence = series.get("host_window_cadence")
+    if cadence:
+        last = cadence["last"]
+        present_hz = last.get("present_hz")
+        offered_hz = last.get("offered_hz")
+        band = banded("host_window_cadence")
+        out["present"] = {
+            "present_hz": present_hz,
+            "offered_hz": offered_hz,
+            "busy_fence": last.get("busy_fence"),
+            "busy_acquire": last.get("busy_acquire"),
+            # `present_hz` is NEVER a reading on its own: the presenter passes
+            # everything at the shipping depth, so it equals `offered_hz`, which
+            # is the device's own publish rate. Both up is the win; offered up
+            # alone means the presenter has become a ceiling again (check the two
+            # busy counters, which are 0 at the shipping depth); neither moving
+            # means the change bought no frames whatever else it bought.
+            "presenter_is_ceiling": (
+                present_hz is not None and offered_hz is not None
+                and offered_hz > 0 and (offered_hz - present_hz) / offered_hz > 0.05
+            ),
+            # A macOS guest latches its frame period once, for its life: exactly
+            # 60 Hz if the kernel handed it 16 666 666 ns, or work-limited
+            # 95-117 Hz if it latched 0 and free-runs. The gap between the two is
+            # empty on every boot on record, and NOTHING per-draw is comparable
+            # across them — so the population is a label on every reading here.
+            "population": (
+                None if present_hz is None
+                else ("paced-60" if present_hz <= PACED_HZ_CEILING else "free-running")
+            ),
+            "presents_banded": (band or {}).get("sum", {}).get("presents"),
+        }
+
+    drain = banded("drain_duty")
+    if drain:
+        draws = drain["sum"].get("draws", 0)
+        out["cpu"] = {
+            "duty": drain["last"].get("duty"),
+            "draws": draws,
+            "busy_us": drain["sum"].get("busy_us"),
+            "us_per_draw": round(drain["sum"].get("busy_us", 0) / draws, 2) if draws else None,
+            "tranches": drain["sum"].get("tranches"),
+            "skipped": drain["sum"].get("skipped"),
+            "samples": drain["samples"],
+        }
+
+    gpu = banded("gpu_span")
+    if gpu:
+        draw_n = gpu["sum"].get("draw_n", 0)
+        out["gpu"] = {
+            "busy_us": gpu["sum"].get("busy_us"),
+            "draw_n": draw_n,
+            # Half the score, and on an integrated-GPU pathway the LARGER half:
+            # frames track the sum of CPU and GPU per draw roughly linearly, so
+            # ranking a change on `us/draw` alone scores half of it. This half
+            # also carries a wider boot-to-boot spread (~12 % against ~4 %), so
+            # a GPU arm needs more boots than a CPU one.
+            "us_per_draw": round(gpu["sum"].get("busy_us", 0) / draw_n, 2) if draw_n else None,
+            "samples": gpu["samples"],
+        }
+
+    if out.get("cpu") and out.get("gpu"):
+        cpu_us = out["cpu"].get("us_per_draw")
+        gpu_us = out["gpu"].get("us_per_draw")
+        if cpu_us is not None and gpu_us is not None:
+            out["per_draw_total_us"] = round(cpu_us + gpu_us, 2)
+
+    publish = banded("window_publish")
+    if publish:
+        out["publish"] = {
+            "fresh": publish["sum"].get("fresh"),
+            "same_key": publish["sum"].get("same_key"),
+            "no_window": publish["sum"].get("no_window"),
+            "no_frame": publish["sum"].get("no_frame"),
+            "samples": publish["samples"],
+        }
+
+    # --- levels series: the LAST sample is the answer, summing is the error ----
+    vbl = series.get("display_vbl")
+    if vbl:
+        last = vbl["last"]
+        out["vbl"] = {
+            "grid_hz": last.get("grid_hz"),
+            "window_hz": last.get("window_hz"),
+            "delivered": last.get("delivered"),
+            "not_enabled": last.get("not_enabled"),
+        }
+
+    pressure = series.get("registry_pressure")
+    if pressure:
+        last = pressure["last"]
+        out["pressure"] = {
+            "peak": last.get("peak"),
+            "peak_mib": last.get("peak_mib"),
+            "resample_peak_ms": last.get("resample_peak_ms"),
+            "resample_window_ms": last.get("resample_peak_ms_cap"),
+            "slab_mib": last.get("slab_mib"),
+            "slab_mib_cap": last.get("slab_mib_cap"),
+        }
+
+    # An undriven boot measures an idle device, and its counters are
+    # self-consistent and well-formed while saying nothing about throughput. The
+    # drain worker's duty is the discriminator: ~0.00 on a bursty interaction
+    # probe, ~0.91 on a sustained one. Only the sustained regime can turn a
+    # per-draw CPU saving into frames, so a reading taken at low duty must not be
+    # ranked against one taken high.
+    duty = (out.get("cpu") or {}).get("duty")
+    if duty is not None:
+        out["workload"] = {
+            "duty": duty,
+            "regime": (
+                "idle" if duty < 0.10
+                else "bursty" if duty < 0.50
+                else "sustained"
+            ),
+            "rankable": duty >= 0.50,
+        }
+
+    # `store_routes` splits must add up, and that identity is the cheapest way to
+    # catch a bad read of the series. Reported when the three parts are present.
+    routes = banded("store_routes")
+    if routes:
+        total = routes["sum"]
+        parts = ("no_state", "texture", "linear")
+        if all(key in total for key in parts) and "unknown_object" in total:
+            summed = sum(total[key] for key in parts)
+            out["store_routes_identity"] = {
+                "no_state+texture+linear": summed,
+                "unknown_object": total["unknown_object"],
+                "holds": summed == total["unknown_object"],
+            }
+    return out
+
+
+# ---------------------------------------------------------------- repo interfaces
+# Everything below asks an existing script rather than reimplementing it, so a
+# change to a rule lands here for free and cannot be contradicted by this file.
+
+BOOT_SCRIPT = {"x86": "vm/boot-x86.sh", "arm64": "vm/boot-arm64.sh"}
+
+# The QEMU command line every sweep in this repo matches. Bracketing one
+# character is load-bearing: `pgrep -f` matches whole command lines, and the
+# shell running the pattern has the pattern in ITS command line, so an
+# unbracketed pattern matches the process issuing it. Here the pattern goes to
+# pgrep/pkill as an argv element rather than through a shell, but it is kept
+# bracketed anyway so a copy of it into a terminal is safe.
+QEMU_PATTERN = {
+    "x86": r"qemu-system-x86_6[4].*reims-vgpu",
+    "arm64": r"qemu-system-aarch6[4].*reims-vgpu",
+}
+
+
+# Both list headers read `... (current -> LABEL):`, and an unset `current`
+# prints the literal `(unset)`. A greedy `(\S+)` capture takes the trailing
+# `):` with it and turns "unset" into a label named `(unset)):` — which then
+# shows up in a UI as a selectable snapshot. Anchor on the closing `):`.
+_CURRENT = re.compile(r"current -> (.*?)\):\s*$")
+
+
+def _parse_current(line):
+    match = _CURRENT.search(line)
+    if not match:
+        return None
+    label = match.group(1).strip()
+    return None if label in ("(unset)", "") else label
+
+
+def _parse_labels(stdout):
+    """Indented single-token lines are the labels; the header is not indented."""
+    labels, default = [], None
+    for line in (stdout or "").splitlines():
+        found = _parse_current(line)
+        if found:
+            default = found
+            continue
+        match = re.match(r"^\s{2,}(\S+)\s*$", line)
+        if match:
+            labels.append(match.group(1))
+    return labels, default
+
+
+def list_rails(pathway):
+    """Rails and the default, from the boot script's own --list-rails."""
+    script = BOOT_SCRIPT[pathway]
+    out = _run([str(REPO_ROOT / script), "--list-rails"], timeout=20)
+    rails, default = _parse_labels(out["stdout"])
+    return {"rails": rails, "default": default, "rc": out["rc"], "stderr": out["stderr"][-400:]}
+
+
+def list_snapshots(pathway, rail):
+    """Snapshots within one rail. A rail is a plain label, never a path — the
+    boot script enforces that too, and passing it as one argv element means a
+    label containing a slash cannot become a second argument."""
+    script = BOOT_SCRIPT[pathway]
+    out = _run([str(REPO_ROOT / script), "--rail", rail, "--list-snapshots"], timeout=20)
+    labels, default = _parse_labels(out["stdout"])
+    return {"snapshots": labels, "default": default, "rc": out["rc"]}
+
+
+# The three spec forms vm/lib/usb-passthrough.sh accepts. Re-validated here
+# before a spec is allowed onto a command line: the library is the authority on
+# what a spec MEANS, but this process is the one handing bytes to exec, and it
+# must not pass through anything it has not itself recognised.
+USB_SPEC_FORMS = (
+    re.compile(r"^[0-9a-fA-F]{4}:[0-9a-fA-F]{4}$"),
+    re.compile(r"^[0-9]+\.[0-9]+$"),
+    re.compile(r"^[0-9]+-[0-9]+(\.[0-9]+)*$"),
+)
+
+
+def valid_usb_spec(spec):
+    return isinstance(spec, str) and any(form.match(spec) for form in USB_SPEC_FORMS)
+
+
+def list_usb(pathway):
+    """Host USB devices, parsed out of the boot script's --list-usb table.
+
+    The table is produced by vm/lib/usb-passthrough.sh, so the spec forms shown
+    here are by construction the ones a boot will accept. Writability of the
+    /dev/bus/usb node is added per row because it is the difference between a
+    device that passes through and one that fails inside the guest's driver
+    probe, and it is the single most common reason a first attempt does nothing.
+    """
+    script = BOOT_SCRIPT[pathway]
+    out = _run([str(REPO_ROOT / script), "--list-usb"], timeout=20)
+    devices = []
+    for line in (out["stdout"] or "").splitlines():
+        parts = line.split(None, 3)
+        if len(parts) < 4 or parts[0] == "VID:PID" or ":" not in parts[0]:
+            continue
+        vidpid, busaddr, busport, desc = parts[0], parts[1], parts[2], parts[3]
+        if not valid_usb_spec(vidpid):
+            continue
+        node, writable = None, None
+        m = re.match(r"^(\d+)\.(\d+)$", busaddr)
+        if m:
+            node = "/dev/bus/usb/%03d/%03d" % (int(m.group(1)), int(m.group(2)))
+            writable = os.access(node, os.R_OK | os.W_OK)
+        devices.append({
+            "vidpid": vidpid,
+            "busaddr": busaddr,
+            "busport": busport,
+            "description": desc.strip(),
+            "node": node,
+            "writable": writable,
+            # A hub is listed because the table lists it, but passing one is
+            # almost never what someone means, so it is flagged rather than
+            # hidden — hiding it would be this file inventing a rule.
+            "looks_like_hub": "hub" in desc.lower(),
+        })
+    return {"devices": devices, "rc": out["rc"], "stderr": out["stderr"][-400:]}
+
+
+def qemu_processes(pathway):
+    """Live QEMU processes for this pathway, with start time and elapsed.
+
+    A boot measured next to another VM measures the contention, and two guests on
+    one bridge collide on the pinned MAC in silence, so knowing what is already
+    running is a precondition for both launching and believing a number.
+    """
+    out = _run(["pgrep", "-af", QEMU_PATTERN[pathway]], timeout=5)
+    procs = []
+    for line in (out["stdout"] or "").splitlines():
+        pid, _, cmd = line.partition(" ")
+        if not pid.isdigit():
+            continue
+        info = _run(["ps", "-o", "lstart=,etime=", "-p", pid], timeout=5)
+        started, elapsed = "", ""
+        if info["rc"] == 0 and info["stdout"].strip():
+            fields = info["stdout"].strip().rsplit(None, 1)
+            if len(fields) == 2:
+                started, elapsed = fields[0].strip(), fields[1].strip()
+        # The netdev in the command line is the ground truth for how this guest
+        # is reachable, and it is more reliable than remembering what was asked
+        # for: a boot that fell back, or an older binary, says so here.
+        net = "unknown"
+        if "-netdev bridge" in cmd:
+            net = "bridge"
+        elif "-netdev user" in cmd:
+            net = "user"
+        elif "-nic none" in cmd:
+            net = "none"
+        procs.append({
+            "pid": int(pid),
+            "started": started,
+            "elapsed": elapsed,
+            "net": net,
+            "usb_passthrough": cmd.count("usb-host,"),
+            "cmd": cmd[:2000],
+        })
+    return procs
+
+
+# --------------------------------------------------------------------- launching
+
+# Env knobs this UI is allowed to set. An allowlist rather than a passthrough,
+# because an override may only NARROW what the device does: a switch can turn off
+# a rail the host could have run, but it can never turn on one the host reported
+# it cannot — binding an extension a host does not advertise fails
+# vkCreateDevice, and importing a handle type it declines is undefined behavior
+# inside the driver. Every entry here is a documented narrowing or a
+# verification aid, and the UI cannot invent a new one.
+ENV_KNOBS = {
+    "REIMS_VGPU_GUEST_IMPORT": {
+        "values": ["", "off"],
+        "label": "Guest host-pointer import",
+        "note": "off takes a capable host to the disabled_by_env rung, which is how the "
+                "copying rails get exercised without hunting for hardware that lacks the "
+                "extension. Compare the two boots on their PIXELS, not only their counters.",
+    },
+    "REIMS_VGPU_GATHER_AUDIT_ALL": {
+        "values": ["", "on"],
+        "label": "Audit every vouched bind",
+        "note": "Judges every zero-copy bind instead of 1 in 64. Never quote a timing from "
+                "such a boot — the fold re-reads the very windows the cache exists to avoid.",
+    },
+    "REIMS_VGPU_PRESENT_DEPTH": {
+        "values": ["", "off"],
+        "label": "Presents in flight",
+        "note": "off drops to one present in flight, the old ~41 fps clamp. An ablation arm.",
+    },
+    "TRACE": {
+        "values": ["", "1"],
+        "label": "QEMU trace log",
+        "note": "Device trace events to the run dir. Costs throughput; not for a timed boot.",
+    },
+}
+
+BOOT_CLASSES = ("testing", "interactive", "capture")
+X86_DEVICES = ("reims-vgpu-pci", "vmware-svga")
+ARM64_DEVICES = ("reims-vgpu-mmio", "apple-gfx-mmio")
+NET_MODES = ("bridge", "user", "none")
+
+_boot_state = {
+    "proc": None,
+    "argv": None,
+    "env": None,
+    "log_path": None,
+    "started": None,
+    "returncode": None,
+    "config": None,
+}
+_boot_lock = threading.Lock()
+
+
+def build_boot_argv(cfg):
+    """Turn a UI config into an argv list and an env dict, or raise ValueError.
+
+    Validation is total: every field is checked against a closed set, and a USB
+    spec must match one of the three forms before it can reach a command line.
+    Nothing is interpolated into a string anywhere on this path.
+    """
+    pathway = cfg.get("pathway") or host_pathway()
+    if pathway not in BOOT_SCRIPT:
+        raise ValueError(f"unknown pathway {pathway!r}")
+
+    argv = [str(REPO_ROOT / BOOT_SCRIPT[pathway])]
+
+    boot_class = cfg.get("boot_class", "testing")
+    if boot_class not in BOOT_CLASSES:
+        raise ValueError(f"unknown boot class {boot_class!r}")
+    # `capture` mutates the rail by writing a new snapshot on clean shutdown, so
+    # it is never reachable by default from a web form: the caller has to say so.
+    if boot_class == "capture" and not cfg.get("confirm_capture"):
+        raise ValueError("boot class 'capture' writes a new snapshot into the rail; "
+                         "it needs confirm_capture=true")
+    argv.append(f"--{boot_class}")
+
+    device = cfg.get("device")
+    allowed = X86_DEVICES if pathway == "x86" else ARM64_DEVICES
+    if device:
+        if device not in allowed:
+            raise ValueError(f"device {device!r} is not one of {allowed}")
+        argv += ["--device", device]
+
+    rail = cfg.get("rail")
+    if rail:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", rail):
+            raise ValueError(f"rail {rail!r} is not a plain label")
+        argv += ["--rail", rail]
+
+    snapshot = cfg.get("snapshot")
+    if snapshot:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", snapshot):
+            raise ValueError(f"snapshot {snapshot!r} is not a plain label")
+        argv += ["--snapshot", snapshot]
+
+    for spec in cfg.get("usb", []):
+        if not valid_usb_spec(spec):
+            raise ValueError(f"USB spec {spec!r} is not VID:PID, BUS.ADDR or BUS-PORT")
+        argv += ["--usb", spec]
+
+    env = {}
+    net = cfg.get("net")
+    if net:
+        if net not in NET_MODES:
+            raise ValueError(f"unknown net mode {net!r}")
+        if net == "bridge" and pathway == "arm64":
+            raise ValueError("the arm64 pathway has no bridge mode: virbr0 and "
+                             "qemu-bridge-helper do not exist on an Apple host")
+        env["NET"] = net
+    bridge = cfg.get("bridge")
+    if bridge:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,14}", bridge):
+            raise ValueError(f"bridge {bridge!r} is not an interface name")
+        env["BRIDGE"] = bridge
+
+    for key, value in (cfg.get("env") or {}).items():
+        if key not in ENV_KNOBS:
+            raise ValueError(f"{key} is not a settable knob here")
+        if value not in ENV_KNOBS[key]["values"]:
+            raise ValueError(f"{key}={value!r} is not one of {ENV_KNOBS[key]['values']}")
+        if value:
+            env[key] = value
+
+    for key, pattern in (("RAM", r"^[0-9]{1,3}[MG]$"),
+                         ("CPU_CORES", r"^[0-9]{1,2}$"),
+                         ("CPU_THREADS", r"^[0-9]{1,2}$"),
+                         ("GUEST_MAC", r"^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")):
+        value = cfg.get(key.lower())
+        if value:
+            if not re.match(pattern, str(value)):
+                raise ValueError(f"{key}={value!r} is malformed")
+            env[key] = str(value)
+
+    return pathway, argv, env
+
+
+def start_boot(cfg):
+    """Launch a boot in the background, capturing its stdout to a file.
+
+    THE STDOUT FILE IS NOT A CONVENIENCE. A guest kernel panic can land after a
+    probe has finished and reported success, so `probe exit=0` and a live device
+    both read green on a boot whose guest died. The boot script prints
+    `capture-then-revert (guest kernel panic)` on its own stdout, and grepping
+    that is the verdict that outranks the probe's.
+    """
+    with _boot_lock:
+        proc = _boot_state["proc"]
+        if proc is not None and proc.poll() is None:
+            raise RuntimeError(f"a boot is already running under this dashboard (pid {proc.pid})")
+
+        pathway, argv, env = build_boot_argv(cfg)
+
+        # Two guests at once is not an error we can rule out from here — the user
+        # may want it — but it is never what someone clicking Boot means, and on a
+        # bridge the second one collides on the pinned MAC in total silence.
+        running = qemu_processes(pathway)
+        if running and not cfg.get("allow_concurrent"):
+            pids = ", ".join(str(p["pid"]) for p in running)
+            raise RuntimeError(
+                f"QEMU is already running for the {pathway} pathway (pid {pids}). "
+                "On NET=bridge a second guest collides on the pinned GUEST_MAC with no "
+                "diagnostic, and either way the measurement is contended. Stop it first, "
+                "or pass allow_concurrent with its own GUEST_MAC.")
+
+        # A boot's readings are only its own if the log is only its own: the
+        # device appends and never truncates, and a stale log inflates in a way
+        # that reads as a finding. Removing it is what makes the boot count 1.
+        if cfg.get("fresh_log", True):
+            try:
+                FAIL_LOG.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                raise RuntimeError(f"could not remove {FAIL_LOG}: {exc}") from exc
+            _scan_cache.update(mtime=None, size=None, count=None, vk_caps_line=None)
+
+        run_dir = REPO_ROOT / ("vm/disks/run" if pathway == "x86" else "vm/guest/run")
+        run_dir.mkdir(parents=True, exist_ok=True)
+        log_path = run_dir / f"dashboard-boot-{time.strftime('%Y%m%d-%H%M%S')}.log"
+        handle = log_path.open("wb")
+
+        merged = dict(os.environ)
+        merged.update(env)
+        child = subprocess.Popen(
+            argv,
+            cwd=str(REPO_ROOT),
+            env=merged,
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            # Its own process group, so stopping the boot can signal the whole
+            # tree rather than only the script that spawned QEMU.
+            start_new_session=True,
+        )
+        handle.close()
+        _boot_state.update(
+            proc=child, argv=argv, env=env, log_path=str(log_path),
+            started=time.time(), returncode=None, config=cfg,
+        )
+        return {"pid": child.pid, "argv": argv, "env": env, "log": str(log_path)}
+
+
+PANIC_MARKERS = ("guest kernel panic", "Debugger called: <panic>")
+
+
+def boot_status():
+    """What the launched boot is doing, including the panic verdict.
+
+    `probe exit=0` is not a clean boot and neither is a live device — both read
+    green on a boot whose guest panicked, which on some rails is roughly one
+    driven boot in three. The panic grep outranks them.
+    """
+    with _boot_lock:
+        proc = _boot_state["proc"]
+        log_path = _boot_state["log_path"]
+        state = {
+            "running": proc is not None and proc.poll() is None,
+            "pid": proc.pid if proc else None,
+            "returncode": proc.poll() if proc else None,
+            "argv": _boot_state["argv"],
+            "env": _boot_state["env"],
+            "log": log_path,
+            "started": _boot_state["started"],
+            "elapsed": round(time.time() - _boot_state["started"], 1) if _boot_state["started"] else None,
+            "config": _boot_state["config"],
+        }
+    tail, panic = "", False
+    if log_path and Path(log_path).is_file():
+        tail, _ = _tail_text(Path(log_path), 64 << 10)
+        low = tail.lower()
+        panic = any(marker.lower() in low for marker in PANIC_MARKERS)
+    state["stdout_tail"] = tail[-8000:]
+    state["panic"] = panic
+    return state
+
+
+def stop_boot(pathway):
+    """Stop the dashboard's boot, then sweep any QEMU left for this pathway.
+
+    Both halves are needed: the boot script outlives its QEMU in some paths and
+    QEMU outlives its script in others, and a survivor is what makes the next
+    boot measure the previous build.
+    """
+    results = []
+    with _boot_lock:
+        proc = _boot_state["proc"]
+    if proc is not None and proc.poll() is None:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            results.append(f"SIGTERM to process group {os.getpgid(proc.pid)}")
+        except (ProcessLookupError, PermissionError) as exc:
+            results.append(f"could not signal the boot group: {exc}")
+        for _ in range(50):
+            if proc.poll() is not None:
+                break
+            time.sleep(0.2)
+        if proc.poll() is None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                results.append("SIGKILL to process group")
+            except (ProcessLookupError, PermissionError):
+                pass
+    # `pkill` with the pattern as an argv element: no shell means the bracket is
+    # belt-and-braces rather than the thing preventing self-slaughter.
+    sweep = _run(["pkill", "-f", QEMU_PATTERN[pathway]], timeout=10)
+    results.append(f"pkill -f {QEMU_PATTERN[pathway]} rc={sweep['rc']}")
+    time.sleep(0.5)
+    return {"actions": results, "still_running": qemu_processes(pathway)}
+
+
+# ----------------------------------------------------------------- guest actions
+
+QMP_PY = REPO_ROOT / "scripts/qmp/qmp.py"
+
+# QMP verbs this UI exposes, with how many numeric arguments each takes. An
+# allowlist: `qmp.py cmd` can issue arbitrary QMP, which is not something a web
+# form should reach.
+QMP_ACTIONS = {
+    "size": 0, "click": 2, "move": 2, "key": None, "type": None, "wheel": None,
+}
+
+
+def qmp_action(action, args):
+    if action not in QMP_ACTIONS:
+        raise ValueError(f"{action!r} is not an exposed QMP action")
+    argv = [sys.executable, str(QMP_PY), action]
+    arity = QMP_ACTIONS[action]
+    if arity == 0:
+        if args:
+            raise ValueError(f"{action} takes no arguments")
+    elif arity is None:
+        # Free-form verbs (key names, typed text, wheel counts). Passed as
+        # separate argv elements, so nothing here can become a second command.
+        for arg in args:
+            if not isinstance(arg, str) or len(arg) > 200:
+                raise ValueError("argument must be a string under 200 chars")
+            argv.append(arg)
+    else:
+        if len(args) != arity:
+            raise ValueError(f"{action} takes {arity} arguments")
+        for arg in args:
+            if not re.fullmatch(r"-?[0-9]{1,6}", str(arg)):
+                raise ValueError(f"{arg!r} is not a coordinate")
+            argv.append(str(arg))
+    return _run(argv, timeout=30)
+
+
+def screenshot(pathway, out_path):
+    """Host-side PNG of the live QEMU window.
+
+    QMP `shot`/`screendump` is NOT the route and is disabled on purpose: with the
+    host-owned window and QEMU at `-display none` the frame never crosses into
+    QEMU's address space, so a screendump shows something other than what the
+    window shows.
+    """
+    helper = (
+        "scripts/screenshot-when-kde-plasma-host/screenshot-when-kde-plasma-host.sh"
+        if pathway == "x86" else
+        "scripts/screenshot-when-macos-host/screenshot-when-macos-host.sh"
+    )
+    path = REPO_ROOT / helper
+    if not path.is_file():
+        return {"rc": None, "stdout": "", "stderr": f"no screenshot helper at {helper}"}
+    if pathway == "x86":
+        return _run([str(path), "-o", str(out_path)], timeout=60)
+    return _run([str(path), str(out_path)], timeout=60)
+
+
+# Probes the dashboard can start, with the flags each actually takes. Listed
+# explicitly rather than globbed, because a probe's argv is part of its contract
+# and a wrong flag reads as a device result.
+PROBES = {
+    "guest-authorize": {
+        "argv": ["vm/guest-authorize.sh"],
+        "label": "Authorize guest (key + ssh alias)",
+        "note": "Resolves the boot's endpoint, installs the ssh key into the COW clone, and "
+                "points `macos-vm` at it. Every other probe needs this first.",
+        "timeout": 480,
+    },
+    "guest-ip": {
+        "argv": ["vm/guest-ip.sh", "--wait", "0"],
+        "label": "Guest IP (bridge lease)",
+        "note": "Reads the DHCP lease for the pinned MAC. Exit 3 means no lease yet.",
+        "timeout": 30,
+    },
+    "window-drag": {
+        "argv": ["scripts/window-drag-probe/window-drag-probe.sh", "--seconds", "25", "--app", "Safari"],
+        "label": "Window drag (interaction)",
+        "note": "Real window-server compositing. Bursty: most of its wall clock is guest "
+                "animation, so it measures the gaps between its bursts.",
+        "timeout": 300,
+    },
+    "sustained-animation": {
+        "argv": ["scripts/sustained-animation-probe/sustained-animation-probe.sh"],
+        "label": "Sustained animation (throughput)",
+        "note": "The only regime whose drain duty is high enough to turn a per-draw CPU "
+                "saving into frames. Use this to rank a throughput change.",
+        "timeout": 300,
+    },
+    "wait-for-desktop": {
+        "argv": ["scripts/app-sweep-probe/wait-for-desktop.sh"],
+        "label": "Wait for desktop",
+        "note": "sshd answers well before the desktop composites. Also collects crash "
+                "reports and REFUSES to log in when WindowServer has aborted.",
+        "timeout": 480,
+    },
+}
+
+_probe_state = {}
+_probe_lock = threading.Lock()
+
+
+def start_probe(name, extra_env=None):
+    spec = PROBES.get(name)
+    if spec is None:
+        raise ValueError(f"{name!r} is not an exposed probe")
+    with _probe_lock:
+        prior = _probe_state.get(name)
+        if prior and prior["proc"].poll() is None:
+            raise RuntimeError(f"probe {name} is already running (pid {prior['proc'].pid})")
+        argv = [str(REPO_ROOT / spec["argv"][0])] + spec["argv"][1:]
+        run_dir = REPO_ROOT / "vm/disks/run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        log_path = run_dir / f"dashboard-probe-{name}-{time.strftime('%Y%m%d-%H%M%S')}.log"
+        handle = log_path.open("wb")
+        merged = dict(os.environ)
+        for key, value in (extra_env or {}).items():
+            if key not in ("NET", "BRIDGE"):
+                raise ValueError(f"{key} may not be set for a probe here")
+            merged[key] = str(value)
+        child = subprocess.Popen(
+            argv, cwd=str(REPO_ROOT), env=merged,
+            stdout=handle, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        handle.close()
+        _probe_state[name] = {"proc": child, "log": str(log_path), "started": time.time()}
+        return {"pid": child.pid, "log": str(log_path), "argv": argv}
+
+
+def probe_status():
+    out = {}
+    with _probe_lock:
+        items = list(_probe_state.items())
+    for name, state in items:
+        tail = ""
+        if Path(state["log"]).is_file():
+            tail, _ = _tail_text(Path(state["log"]), 32 << 10)
+        out[name] = {
+            "running": state["proc"].poll() is None,
+            "pid": state["proc"].pid,
+            "returncode": state["proc"].poll(),
+            "elapsed": round(time.time() - state["started"], 1),
+            "log": state["log"],
+            "tail": tail[-4000:],
+        }
+    return out
+
+
+# ------------------------------------------------------------------------ the API
+
+def api_state(bridge_name="virbr0"):
+    """One call that answers everything the page needs to render."""
+    pathway = host_pathway()
+    kernel = kernel_module_state()
+    tun = tun_available()
+    helper = bridge_helper()
+    acl = bridge_acl(bridge_name)
+    parsed = parse_log()
+
+    # Whether a bridged boot can work AT ALL, assembled once here so the UI shows
+    # one verdict with its reasons rather than four independent badges the reader
+    # has to combine.
+    blockers = []
+    if pathway != "x86":
+        blockers.append("the arm64 pathway has no bridge mode (no virbr0, no bridge helper on macOS)")
+    if not tun["ok"]:
+        detail = f"/dev/net/tun will not open: {tun['error']}"
+        if not kernel["module_tree_present"]:
+            detail += (f" — the running kernel {kernel['release']} has no module tree, so no module "
+                       f"can load. Installed: {', '.join(kernel['installed_trees'])}.")
+            detail += (" The running kernel's own tun module is still in the package cache, so this "
+                       "does not need a reboot — see Host & device."
+                       if kernel["cached_package"] else " A reboot is the fix.")
+        blockers.append(detail)
+    if not any(br["name"] == bridge_name for br in bridges()):
+        blockers.append(f"no bridge named {bridge_name}: sudo virsh --connect qemu:///system net-start default")
+    if not helper["privileged"]:
+        blockers.append(
+            f"no privileged qemu-bridge-helper"
+            + (f" ({helper['rejected']} is present but unprivileged)" if helper["rejected"] else ""))
+    if acl["readable"] and acl["allows"] is False:
+        blockers.append(f"{acl['file']} has no 'allow {bridge_name}' line")
+
+    return {
+        "pathway": pathway,
+        "repo_root": str(REPO_ROOT),
+        "host": {
+            "kernel": kernel,
+            "tun": tun,
+            "load": load_average(),
+            "uname": " ".join(os.uname()),
+        },
+        "net": {
+            "bridges": bridges(),
+            "helper": helper,
+            "acl": acl,
+            "bridge_ready": not blockers,
+            "blockers": blockers,
+            "modes": list(NET_MODES),
+        },
+        "rails": list_rails(pathway),
+        "usb": list_usb(pathway),
+        "devices": list(X86_DEVICES if pathway == "x86" else ARM64_DEVICES),
+        "boot_classes": list(BOOT_CLASSES),
+        "env_knobs": ENV_KNOBS,
+        "probes": {name: {"label": spec["label"], "note": spec["note"]}
+                   for name, spec in PROBES.items()},
+        "qemu": qemu_processes(pathway),
+        "boot": boot_status(),
+        "probe_status": probe_status(),
+        "log": {
+            "path": parsed["path"],
+            "present": parsed["present"],
+            "size": parsed["size"],
+            "boots": parsed["boots"],
+            "boot_boundary_in_tail": parsed.get("boot_boundary_in_tail"),
+            "counts": parsed["counts"],
+            "fail_reasons": parsed["fail_reasons"],
+            "off_reasons": parsed["off_reasons"],
+            "fail_recent": parsed["fail_recent"],
+            "vk_caps": parsed["vk_caps"],
+            "series": {tag: {k: v for k, v in entry.items() if k != "_samples"}
+                       for tag, entry in parsed["series"].items()},
+        },
+        "metrics": metrics(parsed),
+        "now": time.time(),
+    }
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    server_version = "vgpu-dashboard"
+    token = None
+    index_html = None
+
+    def log_message(self, fmt, *args):   # quieter than the default access log
+        if os.environ.get("REIMS_VGPU_DASH_VERBOSE"):
+            sys.stderr.write("dash: " + (fmt % args) + "\n")
+
+    # ---- plumbing ----------------------------------------------------------
+    def _authorized(self, query):
+        supplied = query.get("token", [None])[0] or self.headers.get("X-Dash-Token")
+        return supplied is not None and secrets.compare_digest(supplied, self.token)
+
+    def _send(self, code, body, content_type="application/json"):
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body, default=str).encode()
+        elif isinstance(body, str):
+            body = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        # This page is a control surface for a local process; nothing about it
+        # should be cached or embedded anywhere.
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except BrokenPipeError:
+            pass
+
+    def _body_json(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0:
+            return {}
+        if length > (1 << 20):
+            raise ValueError("request body too large")
+        raw = self.rfile.read(length)
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"body is not JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("body must be a JSON object")
+        return parsed
+
+    # ---- routes ------------------------------------------------------------
+    def do_GET(self):
+        url = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(url.query)
+        path = url.path
+
+        if path == "/" or path == "/index.html":
+            if not self._authorized(query):
+                return self._send(403, "Forbidden: open the URL this server printed, token included.",
+                                  "text/plain; charset=utf-8")
+            return self._send(200, self.index_html, "text/html; charset=utf-8")
+
+        if not self._authorized(query):
+            return self._send(403, {"error": "bad or missing token"})
+
+        try:
+            if path == "/api/state":
+                bridge = query.get("bridge", ["virbr0"])[0]
+                return self._send(200, api_state(bridge))
+            if path == "/api/snapshots":
+                rail = query.get("rail", [""])[0]
+                if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", rail or ""):
+                    return self._send(400, {"error": "rail must be a plain label"})
+                return self._send(200, list_snapshots(host_pathway(), rail))
+            if path == "/api/boot-argv":
+                # Dry run: show exactly what would be executed, so a launch is
+                # never a surprise and a config can be copied to a terminal.
+                cfg = json.loads(query.get("cfg", ["{}"])[0])
+                pathway, argv, env = build_boot_argv(cfg)
+                return self._send(200, {
+                    "pathway": pathway, "argv": argv, "env": env,
+                    "shell": " ".join(
+                        [f"{k}={shlex.quote(v)}" for k, v in sorted(env.items())]
+                        + [shlex.quote(a) for a in argv]),
+                })
+            if path == "/api/screenshot":
+                out = REPO_ROOT / "vm/disks/run/dashboard-screenshot.png"
+                result = screenshot(host_pathway(), out)
+                if result["rc"] != 0 or not out.is_file():
+                    return self._send(503, {"error": "capture failed", **result})
+                return self._send(200, out.read_bytes(), "image/png")
+            return self._send(404, {"error": f"no route {path}"})
+        except ValueError as exc:
+            return self._send(400, {"error": str(exc)})
+        except Exception as exc:                       # noqa: BLE001 - report, never 500 silently
+            return self._send(500, {"error": f"{type(exc).__name__}: {exc}"})
+
+    def do_POST(self):
+        url = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(url.query)
+        if not self._authorized(query):
+            return self._send(403, {"error": "bad or missing token"})
+        try:
+            body = self._body_json()
+            path = url.path
+            if path == "/api/boot":
+                return self._send(200, start_boot(body))
+            if path == "/api/stop":
+                return self._send(200, stop_boot(host_pathway()))
+            if path == "/api/qmp":
+                return self._send(200, qmp_action(body.get("action", ""), body.get("args", [])))
+            if path == "/api/probe":
+                return self._send(200, start_probe(body.get("name", ""), body.get("env")))
+            return self._send(404, {"error": f"no route {path}"})
+        except ValueError as exc:
+            return self._send(400, {"error": str(exc)})
+        except RuntimeError as exc:
+            return self._send(409, {"error": str(exc)})
+        except Exception as exc:                       # noqa: BLE001
+            return self._send(500, {"error": f"{type(exc).__name__}: {exc}"})
+
+
+class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+# ------------------------------------------------------------------------- driver
+
+def selftest():
+    """Exercise every read-only path against the real host and report.
+
+    Deliberately never launches a boot: the point is that a checkout can verify
+    the dashboard's own plumbing — parsing, host probes, argv construction,
+    validation — without a VM, an Apple host or a reboot. What it cannot cover is
+    a live guest, and it says so rather than passing quietly.
+    """
+    failures = []
+
+    def check(name, fn):
+        try:
+            value = fn()
+            print(f"  ok    {name}")
+            return value
+        except Exception as exc:                       # noqa: BLE001
+            print(f"  FAIL  {name}: {type(exc).__name__}: {exc}")
+            failures.append(name)
+            return None
+
+    print("host probes")
+    check("host_pathway", host_pathway)
+    check("kernel_module_state", kernel_module_state)
+    check("tun_available", tun_available)
+    check("bridges", bridges)
+    check("bridge_helper", bridge_helper)
+    check("bridge_acl", lambda: bridge_acl("virbr0"))
+    check("load_average", load_average)
+
+    print("repo interfaces")
+    pathway = host_pathway()
+    rails = check("list_rails", lambda: list_rails(pathway))
+    if rails and rails["rails"]:
+        check("list_snapshots", lambda: list_snapshots(pathway, rails["rails"][0]))
+    usb = check("list_usb", lambda: list_usb(pathway))
+    check("qemu_processes", lambda: qemu_processes(pathway))
+
+    print("log parsing")
+    parsed = check("parse_log", parse_log)
+    if parsed:
+        check("metrics", lambda: metrics(parsed))
+        # The two reduce modes must not be confused: a per-window series carries
+        # a sum, a levels series must not.
+        def reduce_modes():
+            for tag, entry in parsed["series"].items():
+                if entry["mode"] == "window" and entry["sum"] is None:
+                    raise AssertionError(f"{tag} is per-window but has no sum")
+                if entry["mode"] == "levels" and entry["sum"] is not None:
+                    raise AssertionError(f"{tag} is a levels series but was summed")
+            return True
+        check("reduce modes are honoured", reduce_modes)
+
+    print("argv construction")
+    def good():
+        _, argv, env = build_boot_argv({
+            "pathway": "x86", "boot_class": "testing", "device": "reims-vgpu-pci",
+            "rail": "macos-13", "net": "bridge", "usb": ["5-1.2", "046d:c099", "1.4"],
+            "env": {"REIMS_VGPU_GUEST_IMPORT": "off"}, "ram": "16G",
+        })
+        assert "--usb" in argv and argv.count("--usb") == 3, argv
+        assert env["NET"] == "bridge" and env["REIMS_VGPU_GUEST_IMPORT"] == "off", env
+        return True
+    check("valid config builds", good)
+
+    rejections = [
+        ("shell metacharacter in rail", {"rail": "a; rm -rf /"}),
+        ("path in rail", {"rail": "../../etc"}),
+        ("bad usb spec", {"usb": ["not-a-spec"]}),
+        ("usb spec with a semicolon", {"usb": ["046d:c099; id"]}),
+        ("unknown device", {"device": "nvidia-please"}),
+        ("unknown net mode", {"net": "wifi"}),
+        ("unlisted env knob", {"env": {"PATH": "/tmp"}}),
+        ("bad value for a known knob", {"env": {"REIMS_VGPU_GUEST_IMPORT": "yes-please"}}),
+        ("capture without confirmation", {"boot_class": "capture"}),
+        ("malformed MAC", {"guest_mac": "zz:zz"}),
+        ("malformed RAM", {"ram": "16 gigs"}),
+        ("bridge on arm64", {"pathway": "arm64", "net": "bridge"}),
+    ]
+    for label, cfg in rejections:
+        cfg = {"pathway": cfg.get("pathway", "x86"), "boot_class": cfg.get("boot_class", "testing"), **cfg}
+        try:
+            build_boot_argv(cfg)
+            print(f"  FAIL  rejects {label}: it was ACCEPTED")
+            failures.append(f"rejects {label}")
+        except ValueError:
+            print(f"  ok    rejects {label}")
+
+    print("usb spec validator")
+    for spec, want in (("046d:c099", True), ("046D:C099", True), ("5.3", True),
+                       ("5-1.2", True), ("5-1", True), ("nonsense", False),
+                       ("", False), ("046d:c099 ; ls", False), ("../x", False)):
+        got = valid_usb_spec(spec)
+        if got == want:
+            print(f"  ok    {spec!r} -> {got}")
+        else:
+            print(f"  FAIL  {spec!r} -> {got}, wanted {want}")
+            failures.append(f"spec {spec!r}")
+
+    print("qmp action validator")
+    for action, args, ok in (("size", [], True), ("click", ["10", "20"], True),
+                             ("click", ["10"], False), ("cmd", ["quit"], False),
+                             ("click", ["x", "y"], False)):
+        try:
+            argv = [sys.executable, str(QMP_PY), action]
+            if action not in QMP_ACTIONS:
+                raise ValueError("not exposed")
+            arity = QMP_ACTIONS[action]
+            if arity == 0 and args:
+                raise ValueError("takes none")
+            if isinstance(arity, int) and arity > 0:
+                if len(args) != arity:
+                    raise ValueError("arity")
+                for arg in args:
+                    if not re.fullmatch(r"-?[0-9]{1,6}", str(arg)):
+                        raise ValueError("not a coordinate")
+            accepted = True
+        except ValueError:
+            accepted = False
+        if accepted == ok:
+            print(f"  ok    {action}{args} -> {'accept' if accepted else 'reject'}")
+        else:
+            print(f"  FAIL  {action}{args} -> {'accept' if accepted else 'reject'}")
+            failures.append(f"qmp {action}")
+
+    print("full state assembly")
+    state = check("api_state", lambda: api_state("virbr0"))
+    if state:
+        check("state is JSON-serialisable", lambda: json.dumps(state, default=str))
+
+    print()
+    print("NOT COVERED by this selftest, and not claimed:")
+    print("  - a live guest (boot, DHCP lease, ssh, probes, screenshot)")
+    print("  - anything on the arm64 pathway, which needs an Apple host")
+    if usb and not any(d["writable"] for d in usb["devices"]):
+        print("  - a passthrough-eligible USB device: no /dev/bus/usb node here is writable")
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} check(s): {', '.join(failures)}")
+        return 1
+    print("all read-only checks passed")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="reims-vgpu control dashboard")
+    ap.add_argument("--port", type=int, default=int(os.environ.get("REIMS_VGPU_DASH_PORT", 8787)))
+    # Bound to loopback and not configurable to anything else from the command
+    # line. This server execs QEMU and the repo's scripts; a token on a LAN
+    # socket is a much weaker thing than a token on a loopback socket, and there
+    # is no use case here that needs the weaker one.
+    ap.add_argument("--selftest", action="store_true", help="run read-only checks and exit")
+    ap.add_argument("--no-browser", action="store_true", help="do not try to open a browser")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    index = HERE / "index.html"
+    if not index.is_file():
+        print(f"vgpu-dashboard: missing {index}", file=sys.stderr)
+        return 1
+
+    Handler.token = secrets.token_urlsafe(24)
+    Handler.index_html = index.read_text()
+
+    try:
+        httpd = Server(("127.0.0.1", args.port), Handler)
+    except OSError as exc:
+        print(f"vgpu-dashboard: cannot bind 127.0.0.1:{args.port}: {exc}", file=sys.stderr)
+        return 1
+
+    url = f"http://127.0.0.1:{args.port}/?token={Handler.token}"
+    # The token is only ever printed here, so this banner must reach the terminal
+    # even when stdout is a pipe or a log file — a buffered URL is a server
+    # nobody can open.
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except (AttributeError, OSError):
+        pass
+    print("reims-vgpu dashboard")
+    print(f"  pathway   {host_pathway()}")
+    print(f"  repo      {REPO_ROOT}")
+    print(f"  fail log  {FAIL_LOG}")
+    print()
+    print(f"  {url}")
+    print()
+    print("  Loopback only, and every request needs that token. Ctrl-C to stop.", flush=True)
+    if not args.no_browser and os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        opener = shutil.which("xdg-open") or shutil.which("open")
+        if opener and not args.no_browser:
+            subprocess.Popen([opener, url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nvgpu-dashboard: stopping (the VM, if any, keeps running)")
+    finally:
+        httpd.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vm/README.md
+++ b/vm/README.md
@@ -25,8 +25,99 @@ vm/boot-x86.sh --device reims-vgpu-pci --testing --rail macos-11   # a specific 
 Both scripts use a snapshot-revert lifecycle (testing vs interactive classes; testing hard kill).
 QMP is a per-boot unix socket under the run dir for that pathway (`scripts/qmp/qmp.py`).
 
-**Networking** is typically QEMU SLIRP with SSH hostfwd. Guest disks, IPSWs, OpenCore blobs, and
-runtime clones are **gitignored** - private and large; never commit them.
+Guest disks, IPSWs, OpenCore blobs, and runtime clones are **gitignored** - private and large;
+never commit them.
+
+## A dashboard for all of the above
+
+`scripts/vgpu-dashboard/vgpu-dashboard.py` puts the boot classes, rails, snapshots, network modes,
+USB device picker, env knobs, probes and the device's own live censuses on one local page. It drives
+the scripts documented here rather than reimplementing them, so it cannot disagree with them about
+what a spec means or which snapshot is current.
+
+```sh
+scripts/vgpu-dashboard/vgpu-dashboard.py            # prints a URL carrying a one-off token
+scripts/vgpu-dashboard/vgpu-dashboard.py --selftest # read-only checks, no VM needed
+```
+
+Loopback-only and token-gated, because it execs QEMU. See that directory's README for what it
+parses out of the fail log and which reading traps it implements.
+
+## Networking
+
+`vm/boot-x86.sh` defaults to **`NET=bridge`**: the guest joins the host bridge named by `BRIDGE`
+(default `virbr0`, libvirt's `default` network) through `qemu-bridge-helper` and takes a real DHCP
+lease, so it is a peer on the bridge's subnet rather than a client behind SLIRP's NAT. host→guest,
+guest→host and guest→guest all work, which SLIRP structurally cannot do.
+
+| Mode | Guest address | Reach it at | Needs |
+|---|---|---|---|
+| `NET=bridge` (x86 default) | DHCP lease on `$BRIDGE` | `vm/guest-ip.sh` | `tun`, a bridge, a privileged `qemu-bridge-helper`, an `allow` line in `/etc/qemu/bridge.conf` |
+| `NET=user` | none (behind NAT) | `localhost:$SSH_PORT` | nothing |
+| `NET=none` | none | nothing | nothing |
+
+**The SSH endpoint moves with the mode, and that is the part that breaks a harness silently.** A
+bridge has no hostfwd, so `localhost:2222` reaches nothing while every probe under `scripts/` still
+types `ssh macos-vm`. Two scripts close that gap and a probe run needs the second one:
+
+```bash
+vm/guest-ip.sh                      # the guest's address, from the lease for its pinned MAC
+vm/guest-ip.sh --ssh-target         # user@ip, ready for ssh
+vm/guest-authorize.sh               # installs the key AND points `macos-vm` at this boot
+vm/guest-authorize.sh --write-ssh-config   # ...and adds the Include to ~/.ssh/config, once
+```
+
+`guest-authorize.sh` writes `vm/disks/run/ssh-config` (in-workspace, replaced per boot) holding the
+`macos-vm` alias for whichever endpoint this boot actually has. `ssh macos-vm` finds it only once
+`~/.ssh/config` includes that file, which is what `--write-ssh-config` does; without it the script
+prints the one line to add and exits non-zero rather than leaving the probes to fail at their first
+hop. Pass `NET=user` to `guest-authorize.sh` when the boot used SLIRP — its default matches
+`boot-x86.sh`'s, so a plain boot needs nothing.
+
+**`vm/boot-arm64.sh` has no bridge mode** and still defaults to `NET=user`. `virbr0` is a
+libvirt-on-Linux object and `qemu-bridge-helper` speaks `SIOCBRADDIF` over `linux/if_bridge.h`;
+neither exists on the Apple host that pathway requires. The macOS equivalent is QEMU's
+`-netdev vmnet-bridged`, which needs its own entitlement and root, and is not wired up.
+
+**A bridge shows `DOWN`/`NO-CARRIER` until a guest attaches.** That is normal and not the failure;
+only "does not exist" is. Bring libvirt's up with
+`sudo virsh --connect qemu:///system net-start default`.
+
+**Two concurrent boots on one bridge collide on the pinned MAC.** `GUEST_MAC` is fixed so the lease
+is stable across reverts, which also means two live guests claim one address. Under `NET=user` a
+stale VM announced itself by holding `hostfwd`'s port and failing the next boot loudly; on a bridge
+there is no such signal, so kill the previous QEMU before booting (see `## Verification` in
+`AGENTS.md`) or give the second boot its own `GUEST_MAC`.
+
+## USB passthrough
+
+Both boot scripts take `--usb SPEC` (repeatable) and `USB_PASSTHROUGH="SPEC SPEC ..."`, resolved by
+`vm/lib/usb-passthrough.sh` — one owner, so the two pathways cannot drift. `--list-usb` prints every
+host device with all three spec forms:
+
+```bash
+vm/boot-x86.sh --list-usb
+vm/boot-x86.sh --device reims-vgpu-pci --testing --usb 5-1.2          # by physical port
+vm/boot-x86.sh --device reims-vgpu-pci --testing --usb 046d:c099      # by descriptor
+USB_PASSTHROUGH="5-1.2 7-1.1" vm/boot-x86.sh --testing
+```
+
+| Spec | Example | Pins | Loses |
+|---|---|---|---|
+| `BUS-PORT` | `5-1.2` | the physical socket — survives replug, separates identical twins | nothing; **prefer this** |
+| `VID:PID` | `046d:c099` | the descriptor — follows the device between ports | ambiguous between two identical devices |
+| `BUS.ADDR` | `5.3` | one device exactly, right now | `ADDR` is reassigned on replug and on some hub resets |
+
+Each spec is resolved against `/sys/bus/usb/devices` before QEMU starts, so a typo, an unplugged
+device, or a `/dev/bus/usb` node this user cannot write is a **named refusal with the fix** rather
+than a guest that silently never sees the device. The device is announced with its manufacturer and
+product strings, because a passed-through device is detached from the host driver for the life of
+the boot — pass the keyboard you are typing on and you do not get it back until the VM exits.
+
+Passed-through devices share the `qemu-xhci` the boot already builds for `usb-kbd`/`usb-tablet`, so
+the guest sees one USB topology. **arm64 cannot resolve specs**: the resolver reads `/sys`, that
+pathway is always macOS, and QEMU's `hostbus`/`hostaddr` are libusb's numbering rather than IOKit's.
+It refuses by name; the Apple-host resolver is an honest gap.
 
 ## Rails
 

--- a/vm/boot-arm64.sh
+++ b/vm/boot-arm64.sh
@@ -53,6 +53,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# USB passthrough spec parsing is shared with boot-x86.sh; see that file's
+# header for why the rule has one owner rather than a copy per boot script.
+# shellcheck source=vm/lib/usb-passthrough.sh
+. "$REPO_ROOT/vm/lib/usb-passthrough.sh"
 
 # --- Configuration (override via env or flags) ----------------------------------
 # Guest bundle provisioned by scripts/vmapple-provision (large + private, gitignored).
@@ -85,6 +89,32 @@ RAIL_LABEL="${RAIL:-}"   # empty = follow rails/current; else a rail name
 SNAPSHOT_LABEL=""        # empty = follow the rail's snapshots/current
 LIST_RAILS=0
 LIST_SNAPSHOTS=0
+LIST_USB=0
+
+# --- USB passthrough ----------------------------------------------------------
+# Same three spec forms as boot-x86.sh (VID:PID, BUS.ADDR, BUS-PORT), resolved
+# by the shared library above. See vm/lib/usb-passthrough.sh for what each form
+# pins and what the host gives up.
+#
+# TWO THINGS DIFFER ON THIS PATHWAY, and both are host-side rather than guest-
+# side. First, the `vmapple` machine builds its own qemu-xhci and attaches
+# usb-kbd and usb-tablet to it (hw/vmapple/vmapple.c, under defaults_enabled()),
+# so there is no controller id this script can name — a `-device usb-host` with
+# no `bus=` lands on that single USB bus, which is what we want. Second, the
+# resolver reads /sys/bus/usb/devices, which does not exist on a macOS host;
+# this pathway runs under HVF and is therefore always macOS, so a spec is
+# refused by name rather than silently resolving to nothing. Passing a device
+# through on an Apple host needs a sysfs-free resolver that nobody has written,
+# and QEMU's own hostbus/hostaddr properties are libusb's numbering, not
+# IOKit's — so this is an honest gap and not a rail to route around.
+USB_SPECS=()
+USB_SPEC_COUNT=0
+if [ -n "${USB_PASSTHROUGH:-}" ]; then
+  # Deliberately unquoted: this knob is a whitespace-separated list.
+  # shellcheck disable=SC2206
+  USB_SPECS=($USB_PASSTHROUGH)
+  for _ in $USB_PASSTHROUGH; do USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); done
+fi
 GFX_DEVICE="apple-gfx-mmio"  # apple-gfx-mmio | reims-vgpu-mmio
 
 usage() {
@@ -103,6 +133,11 @@ usage: vm/boot-arm64.sh [--device apple-gfx-mmio|reims-vgpu-mmio] [--testing|--i
   --snapshot LABEL       snapshot WITHIN that rail. Default: the rail's own
                          \`snapshots/current\`. A bare --snapshot (no label) is
                          the old spelling of --capture.
+  --usb SPEC             pass a host USB device through to the guest; repeatable.
+                         SPEC is VID:PID (046d:c099), BUS.ADDR (5.3) or
+                         BUS-PORT (5-1.2). Needs a Linux host — see --list-usb.
+  --list-usb             print the host USB devices with all three spec forms
+                         and exit
   --list-rails           print the rails and exit
   --list-snapshots       print the selected rail's snapshots and exit
 
@@ -115,6 +150,13 @@ Env: GUEST_DIR RAILS_DIR RAIL RUN_DIR QEMU_BIN AVPBOOTER RAM CPUS SSH_PORT REIMS
      (vulkan default for reims-vgpu-mmio; metal default for apple-gfx-mmio)
      TESTING_TIMEOUT QMP_DUMP_TIMEOUT GUEST_MAC
      NET=user (SLIRP, default) | NET=none (no NIC — one-time offline Setup Assistant bootstrap)
+       This pathway has NO bridge mode. boot-x86.sh defaults to NET=bridge on
+       virbr0, but virbr0 is a libvirt-on-Linux object and qemu-bridge-helper
+       speaks SIOCBRADDIF over linux/if_bridge.h; neither exists on the Apple
+       host this pathway requires. The macOS equivalent is QEMU's vmnet
+       (-netdev vmnet-bridged), which needs its own entitlement and root, and
+       is not wired up here.
+     USB_PASSTHROUGH="SPEC SPEC ..." — same specs as --usb
      TRACE=1 — control-plane trace rail: the display device's QEMU trace events
      (MMIO order, ring records, map/unmap, IRQs, frames) → \$RUN_DIR/trace-<stamp>.log
      TRACE_PATTERN=glob — override the default display-device trace glob
@@ -165,6 +207,9 @@ while [ "$#" -gt 0 ]; do
       esac
       ;;
     --snapshot=*) SNAPSHOT_LABEL="${1#--snapshot=}"; shift ;;
+    --usb) shift; [ -n "${1:-}" ] || { echo "boot-arm64.sh: --usb needs a spec (VID:PID | BUS.ADDR | BUS-PORT)" >&2; exit 64; }; USB_SPECS+=("$1"); USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); shift ;;
+    --usb=*) USB_SPECS+=("${1#--usb=}"); USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); shift ;;
+    --list-usb) LIST_USB=1; shift ;;
     --list-rails) LIST_RAILS=1; shift ;;
     --list-snapshots) LIST_SNAPSHOTS=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -196,6 +241,43 @@ require_plain_label() {
 
 # --- Resolve the rail ------------------------------------------------------------
 # Answered before anything is built — these are questions about the disk tree.
+# --- Resolve USB passthrough ------------------------------------------------------
+# Answered before anything is built, for the same reason as --list-rails: it is a
+# question about the host, and a bad spec must cost a second rather than a QEMU
+# build and a boot.
+if [ "$LIST_USB" -eq 1 ]; then
+  if [ ! -d "$USB_SYSFS_ROOT" ]; then
+    die "--list-usb reads $USB_SYSFS_ROOT, which this host ($(uname -s)) does not have.
+This pathway requires an Apple host (-accel hvf), so USB passthrough is unavailable here;
+see the NET/USB_PASSTHROUGH notes in --help."
+  fi
+  usb_list_devices
+  echo
+  echo "pass one to a boot with --usb SPEC (repeatable), or USB_PASSTHROUGH=\"SPEC SPEC\"."
+  exit 0
+fi
+
+# Each spec becomes one `-device usb-host,...`. No `bus=`: the vmapple machine
+# builds exactly one qemu-xhci and gives it no id, so an unqualified usb-host
+# lands on that controller alongside the machine's own usb-kbd and usb-tablet.
+USB_QEMU_ARGS=()
+USB_QEMU_ARG_COUNT=0
+if [ "$USB_SPEC_COUNT" -gt 0 ]; then
+  [ -d "$USB_SYSFS_ROOT" ] || die \
+    "--usb/USB_PASSTHROUGH resolves specs through $USB_SYSFS_ROOT, which this host ($(uname -s)) does not have.
+This pathway runs under HVF and is therefore always macOS, so there is no sysfs to read.
+See the USB_PASSTHROUGH note in --help for why there is no Apple-host resolver."
+  _usb_index=0
+  for _usb_spec in "${USB_SPECS[@]}"; do
+    usb_resolve_spec "$_usb_spec" || die "usb: $USB_R_ERROR"
+    echo "boot-arm64.sh: usb passthrough $_usb_spec -> $USB_R_DESC"
+    USB_QEMU_ARGS+=(-device "usb-host,id=usbpt$_usb_index,$USB_R_PROPS")
+    USB_QEMU_ARG_COUNT=$((USB_QEMU_ARG_COUNT + 2))
+    _usb_index=$((_usb_index + 1))
+  done
+  echo "boot-arm64.sh: usb passthrough — the host loses these devices until this boot exits"
+fi
+
 if [ "$LIST_RAILS" -eq 1 ]; then
   echo "rails under $RAILS_DIR (current -> $(readlink "$RAILS_DIR/current" 2>/dev/null || echo '(unset)')):"
   list_rail_labels | while IFS= read -r label; do echo "  $label"; done
@@ -454,6 +536,10 @@ if [ -n "$NETDEV" ]; then
   QEMU_ARGS+=(-netdev "$NETDEV" -device "virtio-net-pci,netdev=net0,mac=$GUEST_MAC")
 else
   QEMU_ARGS+=(-nic none)   # suppress QEMU's implicit default user-mode NIC
+fi
+
+if [ "$USB_QEMU_ARG_COUNT" -gt 0 ]; then
+  QEMU_ARGS+=("${USB_QEMU_ARGS[@]}")
 fi
 
 # The Vulkan product build owns its AppKit window in Rust and therefore disables

--- a/vm/boot-x86.sh
+++ b/vm/boot-x86.sh
@@ -85,6 +85,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# USB passthrough spec parsing is shared with boot-arm64.sh; see that file's
+# header for why the rule has one owner rather than a copy per boot script.
+# shellcheck source=vm/lib/usb-passthrough.sh
+. "$REPO_ROOT/vm/lib/usb-passthrough.sh"
 
 # --- Configuration (override via env or flags) ----------------------------------
 DISKS_DIR="${DISKS_DIR:-$SCRIPT_DIR/disks}"
@@ -109,10 +113,13 @@ RUN_DIR="${RUN_DIR:-$DISKS_DIR/run}"
 #   copy in /tmp prints this script's normal header and then dies on
 #   `failed to find romfile "efi-virtio.rom"` — a boot that looks started.
 # - Keep `qemu-system-x86_64` in the filename. Every VM sweep in this repo and
-#   in the repro scripts matches that pattern. A pin named anything else
-#   survives the sweep, keeps hostfwd 2222, and the next boot fails to bind and
-#   exits — after which the scoring script talks to the *pinned* guest and
-#   reports a clean run of the wrong binary.
+#   in the repro scripts matches that pattern, so a pin named anything else
+#   survives the sweep and the next boot then contends with it. Under NET=user
+#   that showed up as the survivor holding hostfwd 2222 and the new boot failing
+#   to bind; under the NET=bridge default there is no port to contend for, so
+#   the two guests simply collide on GUEST_MAC and nothing fails at all. Either
+#   way the scoring script goes on to talk to the *pinned* guest and reports a
+#   clean run of the wrong binary — the bridge case just does it silently.
 QEMU_BIN_DEFAULT="$REPO_ROOT/vendor/qemu/build/qemu-system-x86_64"
 QEMU_BIN="${QEMU_BIN:-$QEMU_BIN_DEFAULT}"
 REIMS_VGPU_EFI_ROM_SCRIPT="$REPO_ROOT/crates/reims-vgpu-efi/scripts/reims-vgpu-efi-rom/reims-vgpu-efi-rom.sh"
@@ -157,11 +164,59 @@ AUDIO_BUFFER_US="${AUDIO_BUFFER_US:-46440}"
 # notices.
 AUDIO_USB_BUFFER="${AUDIO_USB_BUFFER:-65536}"
 
+# --- USB passthrough ----------------------------------------------------------
+# Host USB devices to hand to the guest, one spec per `--usb`, plus whatever
+# USB_PASSTHROUGH names (whitespace-separated) so a harness can set it without
+# rewriting an argv. Empty means the guest sees only the emulated usb-kbd /
+# usb-tablet / usb-audio it has always had.
+#
+# THREE SPEC FORMS, and which one to pick is a real choice rather than taste:
+#
+#   VID:PID    four hex digits each, as `lsusb` prints them (e.g. 046d:c099).
+#              Follows the device across ports and replugs, because QEMU matches
+#              on the descriptor. Ambiguous if two identical devices are plugged
+#              in — QEMU takes the first it enumerates.
+#   BUS.ADDR   decimal bus and device address (e.g. 5.3), the numbers in
+#              `lsusb`'s "Bus 005 Device 003". Names exactly one device even
+#              among identical twins, but ADDR is reassigned on every replug and
+#              on some hub resets, so it is a spec for one boot.
+#   BUS-PORT   decimal bus and the physical port path (e.g. 5-1.2), the sysfs
+#              name. Pinned to the socket rather than to the device or to an
+#              enumeration order, so it survives replugs and disambiguates
+#              twins. This is the form to prefer for a fixed rig.
+#
+# All three are resolved against /sys/bus/usb/devices below so that a typo, an
+# unplugged device, or a /dev/bus/usb node this user cannot write is a named
+# refusal before QEMU starts rather than a guest that silently never sees the
+# device.
+#
+# WHAT THE HOST LOSES. A passed-through device is detached from the host driver
+# for the life of the boot. Passing the keyboard or mouse you are typing on
+# hands it to the guest, and the emulated usb-kbd/usb-tablet that the QMP input
+# helpers drive is a different device — so the host input you give up is not
+# given back until the VM exits. Each resolved device is printed with its
+# manufacturer and product string so what is being surrendered is on screen
+# before the boot starts.
+#
+# USB_SPEC_COUNT shadows ${#USB_SPECS[@]} on purpose: on an EMPTY array both
+# ${#arr[@]} and "${arr[@]}" are an unbound-variable error under `set -u` in
+# bash 3.2, which is the bash a stock macOS host gives boot-arm64.sh. The two
+# boot scripts share vm/lib/usb-passthrough.sh, so they share the idiom too.
+USB_SPECS=()
+USB_SPEC_COUNT=0
+if [ -n "${USB_PASSTHROUGH:-}" ]; then
+  # Deliberately unquoted: this knob is a whitespace-separated list.
+  # shellcheck disable=SC2206
+  USB_SPECS=($USB_PASSTHROUGH)
+  for _ in $USB_PASSTHROUGH; do USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); done
+fi
+
 BOOT_CLASS="testing"          # testing | interactive | capture
 RAIL_LABEL="${RAIL:-}"        # empty = follow rails/current; else a rail name
 SNAPSHOT_LABEL=""             # empty = follow the rail's snapshots/current
 LIST_RAILS=0
 LIST_SNAPSHOTS=0
+LIST_USB=0
 # Default to the product device: it is the whole point of this tree, and its
 # host-owned Vulkan window (REIMS_VGPU_WINDOW=1, present + input) is what a human
 # expects to see. The legacy vmware-svga console is opt-in via --device — a bare
@@ -190,6 +245,11 @@ usage: vm/boot-x86.sh [--device reims-vgpu-pci|vmware-svga] [--testing|--interac
   --snapshot LABEL       snapshot WITHIN that rail. Default: the rail's own
                          \`snapshots/current\`. A bare --snapshot (no label) is
                          the old spelling of --capture.
+  --usb SPEC             pass a host USB device through to the guest; repeatable.
+                         SPEC is VID:PID (046d:c099), BUS.ADDR (5.3) or
+                         BUS-PORT (5-1.2). See --list-usb.
+  --list-usb             print the host USB devices with all three spec forms
+                         and exit
   --list-rails           print the rails and exit
   --list-snapshots       print the selected rail's snapshots and exit
 
@@ -202,7 +262,11 @@ Env: DISKS_DIR OVMF_DIR RAILS_DIR RAIL RUN_DIR QEMU_BIN OVMF_CODE OVMF_VARS_MAST
      OPENCORE_MASTER DISK_MASTER RAM CPU_SOCKETS CPU_CORES CPU_THREADS CPU_MODEL
      CPU_OPTIONS SSH_PORT TESTING_TIMEOUT QMP_DUMP_TIMEOUT GUEST_MAC REIMS_VGPU_BACKEND
      (metal|vulkan for qemu-build)
-     NET=user (SLIRP, default) | NET=none (no NIC)
+     NET=bridge (default; guest joins \$BRIDGE and takes a real DHCP lease)
+       | NET=user (SLIRP NAT + hostfwd \$SSH_PORT->22) | NET=none (no NIC)
+     BRIDGE=virbr0 (default) — host bridge for NET=bridge
+     BRIDGE_HELPER=path — override the qemu-bridge-helper this boot execs
+     USB_PASSTHROUGH="SPEC SPEC ..." — same specs as --usb
      REIMS_VGPU_PCI_ATTACH=pcibridge|bus0   (default pcibridge; product secondary bus)
      REIMS_VGPU_GOP_ROM=path | REIMS_VGPU_GOP_ROM= (option ROM on reims-vgpu-pci; auto if built)
      QEMU_REBOOT_ACTION=exit|pause|reset
@@ -252,6 +316,9 @@ while [ "$#" -gt 0 ]; do
       esac
       ;;
     --snapshot=*) SNAPSHOT_LABEL="${1#--snapshot=}"; shift ;;
+    --usb) shift; [ -n "${1:-}" ] || { echo "boot-x86.sh: --usb needs a spec (VID:PID | BUS.ADDR | BUS-PORT)" >&2; exit 64; }; USB_SPECS+=("$1"); USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); shift ;;
+    --usb=*) USB_SPECS+=("${1#--usb=}"); USB_SPEC_COUNT=$((USB_SPEC_COUNT + 1)); shift ;;
+    --list-usb) LIST_USB=1; shift ;;
     --list-rails) LIST_RAILS=1; shift ;;
     --list-snapshots) LIST_SNAPSHOTS=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -278,6 +345,41 @@ require_plain_label() {
     */*|.|..|"") die "$1 takes a plain label, not a path: '$2'" ;;
   esac
 }
+
+# --- Resolve USB passthrough ------------------------------------------------------
+# Answered before anything is built, for the same reason as --list-rails below:
+# it is a question about the host, and a bad spec must cost a second rather than
+# a QEMU build and a boot.
+if [ "$LIST_USB" -eq 1 ]; then
+  usb_list_devices
+  echo
+  echo "pass one to a boot with --usb SPEC (repeatable), or USB_PASSTHROUGH=\"SPEC SPEC\"."
+  echo "prefer BUS-PORT: it is pinned to the socket, so it survives a replug and"
+  echo "distinguishes two identical devices, which VID:PID cannot and BUS.ADDR loses."
+  exit 0
+fi
+
+# Each spec becomes one `-device usb-host,...`. The properties differ per spec
+# form, so they are resolved once here and the QEMU arguments are assembled from
+# what came back — nothing downstream re-parses a spec.
+USB_QEMU_ARGS=()
+USB_QEMU_ARG_COUNT=0
+if [ "$USB_SPEC_COUNT" -gt 0 ]; then
+  [ "$(uname -s)" = "Linux" ] || die \
+    "--usb/USB_PASSTHROUGH resolves specs through $USB_SYSFS_ROOT, which is Linux-only ($(uname -s) here)"
+  _usb_index=0
+  for _usb_spec in "${USB_SPECS[@]}"; do
+    usb_resolve_spec "$_usb_spec" || die "usb: $USB_R_ERROR"
+    echo "boot-x86.sh: usb passthrough $_usb_spec -> $USB_R_DESC"
+    # bus=xhci.0 is the qemu-xhci this script already adds for usb-kbd and
+    # usb-tablet; a passed-through device shares that controller rather than
+    # getting one of its own, so the guest sees one USB topology.
+    USB_QEMU_ARGS+=(-device "usb-host,id=usbpt$_usb_index,bus=xhci.0,$USB_R_PROPS")
+    USB_QEMU_ARG_COUNT=$((USB_QEMU_ARG_COUNT + 2))
+    _usb_index=$((_usb_index + 1))
+  done
+  echo "boot-x86.sh: usb passthrough — the host loses these devices until this boot exits"
+fi
 
 # --- Resolve the rail ------------------------------------------------------------
 # Answered before anything is built — these are questions about the disk tree.
@@ -468,12 +570,206 @@ else
 fi
 
 # --- Network -------------------------------------------------------------------
-# SLIRP user-mode NAT; ipv6=off avoids a phantom IPv6 default that macOS prefers.
-NET="${NET:-user}"
+# NET=bridge (default): the guest joins the host bridge named by BRIDGE (virbr0,
+#   libvirt's `default` network) and takes a real DHCP lease from that network's
+#   dnsmasq, so it is a peer on the bridge's subnet rather than a client behind
+#   SLIRP's NAT. host->guest, guest->host and guest->guest all work, which SLIRP
+#   structurally cannot do: it has no route back in except an explicit hostfwd
+#   rule per port.
+#
+#   THE SSH ENDPOINT MOVES, and this is the part that breaks a harness silently.
+#   A bridge has no hostfwd, so `localhost:2222` is dead in this mode while
+#   every probe under `scripts/` still types `ssh macos-vm`. If that alias
+#   points at 127.0.0.1:2222 it will connect to whatever else is listening
+#   there, or fail in the way BatchMode=yes turns into "guest not up yet".
+#   `vm/guest-ip.sh` resolves the lease from $GUEST_MAC and
+#   `vm/guest-authorize.sh` writes the alias against it; both are driven from
+#   the SSH line this script prints below.
+#
+#   QEMU never opens the tap itself — it execs `qemu-bridge-helper`, which needs
+#   CAP_NET_ADMIN to enslave a tap to a bridge and therefore ships setuid root.
+#   This tree configures QEMU with --disable-tools, so no helper is built in
+#   `vendor/qemu/build/` and the compiled-in default path (relative to the
+#   binary) does not exist. The helper is resolved from the host below and
+#   passed explicitly with `helper=`; without that, a bridge boot dies on
+#   "failed to launch bridge helper" naming a path nobody installed.
+#
+# NET=user: QEMU SLIRP user-mode NAT with hostfwd ${SSH_PORT} -> 22. Needs no
+#   privilege and no host configuration, and is the ONLY mode in which
+#   `localhost:$SSH_PORT` reaches the guest. ipv6=off per QEMU's own
+#   vmapple.rst reference invocation: SLIRP's fec0::/64 RA otherwise gives the
+#   guest a phantom IPv6 default that macOS prefers and that goes nowhere, so
+#   outbound traffic (DNS first) stalls before falling back to v4.
+# NET=none: no NIC at all. QEMU adds a DEFAULT user-mode NIC when no
+#   -netdev/-nic is given, so genuinely disabling the network needs an explicit
+#   -nic none; omitting the netdev is not enough.
+NET="${NET:-bridge}"
+BRIDGE="${BRIDGE:-virbr0}"
+BRIDGE_HELPER_BIN=""
+
+# Where the setuid-root helper lives is a distro decision, so try the places
+# that ship it. An in-tree build is listed first for the day this tree is
+# configured without --disable-tools, but it will not be setuid and so only
+# qualifies if somebody gave it file capabilities.
+bridge_helper_candidates() {
+  if [ -n "${BRIDGE_HELPER:-}" ]; then printf '%s\n' "$BRIDGE_HELPER"; return; fi
+  printf '%s\n' \
+    "$REPO_ROOT/vendor/qemu/build/qemu-bridge-helper" \
+    /usr/lib/qemu/qemu-bridge-helper \
+    /usr/libexec/qemu-bridge-helper \
+    /usr/local/libexec/qemu-bridge-helper \
+    /usr/lib/x86_64-linux-gnu/qemu/qemu-bridge-helper
+}
+
+# A helper that cannot get CAP_NET_ADMIN will fail inside QEMU with an exit
+# status and no explanation, so decide here and say which file was rejected and
+# why. setuid-root is the shipped arrangement; file capabilities are the other
+# way to grant it, and both are accepted.
+resolve_bridge_helper() {
+  BRIDGE_HELPER_BIN=""
+  BRIDGE_HELPER_UNPRIVILEGED=""
+  local candidate
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] && [ -x "$candidate" ] || continue
+    if [ -u "$candidate" ] && [ "$(stat -c %u "$candidate" 2>/dev/null)" = "0" ]; then
+      BRIDGE_HELPER_BIN="$candidate"; return 0
+    fi
+    if command -v getcap >/dev/null 2>&1 \
+       && getcap "$candidate" 2>/dev/null | grep -q 'cap_net_admin'; then
+      BRIDGE_HELPER_BIN="$candidate"; return 0
+    fi
+    [ -n "$BRIDGE_HELPER_UNPRIVILEGED" ] || BRIDGE_HELPER_UNPRIVILEGED="$candidate"
+  done <<EOF
+$(bridge_helper_candidates)
+EOF
+  return 1
+}
+
+# The helper's first act is to open /dev/net/tun, and it reports a failure there
+# as the same opaque "bridge helper failed" it reports everything else as. The
+# node existing is not the check — a missing tun driver leaves the node in place
+# and fails the OPEN with ENODEV, so the only honest test is to open it.
+#
+# The interesting diagnosis is the second one below. `tun` is a module on every
+# distro kernel that has it, so it loads on demand; it CANNOT load when the
+# running kernel's module tree is absent, which is what a kernel upgrade without
+# a reboot leaves behind. That state breaks bridge networking while `lsmod`,
+# `modinfo` and `modprobe` all report something that reads like a missing
+# package, and the fix is a reboot rather than an install.
+# A kernel replaced on disk usually leaves its own package behind in the package
+# cache, and that package carries the module tree for the kernel that is STILL
+# RUNNING. `tun` declares no dependencies, so the single .ko out of that archive
+# loads with insmod and needs neither depmod nor a restored tree — which makes
+# the reboot avoidable rather than mandatory. Only mention this when the matching
+# package is actually there; a hint that names a file nobody has is worse than
+# no hint. Arch spells the release `7.1.8-arch1-3` as `7.1.8.arch1-3` in the
+# package name, hence the substitution.
+cached_kernel_package_hint() {
+  command -v bsdtar >/dev/null 2>&1 || return 0
+  local release pkgver candidate
+  release="$(uname -r)"
+  pkgver="${release/-arch/.arch}"
+  for candidate in /var/cache/pacman/pkg/linux-"$pkgver"-*.pkg.tar.zst; do
+    [ -f "$candidate" ] || continue
+    printf '%s' "
+Or load the running kernel's OWN tun module out of the package cache — no reboot:
+  d=\$(mktemp -d) && bsdtar -C \"\$d\" -xf $candidate \\
+    usr/lib/modules/$release/kernel/drivers/net/tun.ko.zst &&
+  unzstd \"\$d/usr/lib/modules/$release/kernel/drivers/net/tun.ko.zst\" -o \"\$d/tun.ko\" &&
+  sudo insmod \"\$d/tun.ko\"
+(tun declares no dependencies, so insmod needs no depmod and no restored tree.
+ Undo with: sudo rmmod tun)"
+    return 0
+  done
+  return 0
+}
+
+require_tun_device() {
+  if (exec 3<>/dev/net/tun) 2>/dev/null; then
+    exec 3>&- 2>/dev/null || true
+    return 0
+  fi
+  local detail=""
+  if [ ! -d "/lib/modules/$(uname -r)" ]; then
+    detail="
+The running kernel is $(uname -r) and /lib/modules/$(uname -r) does not exist, so NO
+module can load — this kernel was replaced on disk and not rebooted into. Installed trees:
+$(ls /lib/modules 2>/dev/null | sed 's/^/  /')
+A reboot into an installed kernel fixes it.$(cached_kernel_package_hint)"
+  elif ! lsmod 2>/dev/null | grep -q '^tun[[:space:]]'; then
+    detail="
+The tun module is not loaded. Load it, and make it persist:
+  sudo modprobe tun
+  echo tun | sudo tee /etc/modules-load.d/tun.conf"
+  fi
+  die "NET=bridge needs a working /dev/net/tun and this host cannot open it.$detail
+Every bridged netdev is a tap, so there is no bridge networking without tun.
+Fall back for now with:  NET=user vm/boot-x86.sh ..."
+}
+
+# The helper is the authority on its own ACL — it parses
+# CONFIG_QEMU_CONFDIR/bridge.conf relative to its own location, honours
+# `allow`/`deny`/`all` and follows `include` lines. Re-implementing that here
+# would be a second copy of the rule that can disagree with the first, so this
+# only reads the obvious file and WARNS. If the boot then dies in the helper,
+# the reason is already on screen.
+warn_unless_bridge_acl_allows() {
+  local conf=/etc/qemu/bridge.conf
+  if [ ! -r "$conf" ]; then
+    echo "boot-x86.sh: WARNING $conf is not readable; qemu-bridge-helper may refuse '$1'." >&2
+    echo "boot-x86.sh:   fix: echo 'allow $1' | sudo tee -a $conf && sudo chmod 0640 $conf" >&2
+    return
+  fi
+  if ! grep -Eq "^[[:space:]]*allow[[:space:]]+($1|all)[[:space:]]*\$" "$conf"; then
+    echo "boot-x86.sh: WARNING $conf has no 'allow $1' line; the bridge helper will refuse the tap." >&2
+    echo "boot-x86.sh:   fix: echo 'allow $1' | sudo tee -a $conf" >&2
+  fi
+}
+
 case "$NET" in
-  user) NETDEV="user,id=net0,ipv6=off,hostfwd=tcp::${SSH_PORT}-:22" ;;
-  none) NETDEV="" ;;
-  *) die "unknown NET: $NET (user | none)" ;;
+  bridge)
+    # qemu-bridge-helper is Linux-only (it speaks SIOCBRADDIF over
+    # linux/if_bridge.h), and virbr0 is a libvirt-on-Linux object. On the arm64
+    # macOS host there is neither, which is why boot-arm64.sh keeps NET=user as
+    # its default. Refuse by name rather than emitting a netdev that cannot work.
+    [ "$(uname -s)" = "Linux" ] || die \
+      "NET=bridge is Linux-only: qemu-bridge-helper and '$BRIDGE' do not exist on $(uname -s). Use NET=user."
+    ip link show "$BRIDGE" >/dev/null 2>&1 || die \
+      "no bridge '$BRIDGE' on this host.
+virbr0 belongs to libvirt's 'default' network; bring it up with:
+  sudo virsh --connect qemu:///system net-start default
+  sudo virsh --connect qemu:///system net-autostart default
+A bridge with no guest attached reports DOWN/NO-CARRIER — that is normal and not
+the failure; only 'does not exist' is. Point elsewhere with BRIDGE=<name>."
+    resolve_bridge_helper || die \
+      "no usable qemu-bridge-helper for NET=bridge.$(
+        [ -n "$BRIDGE_HELPER_UNPRIVILEGED" ] \
+          && printf '\n%s is present but is neither setuid root nor holds cap_net_admin.' \
+               "$BRIDGE_HELPER_UNPRIVILEGED"
+      )
+This tree builds QEMU with --disable-tools, so the helper comes from the host:
+  Arch/Fedora   /usr/lib/qemu/qemu-bridge-helper   (package qemu-common / qemu-system-x86)
+  Debian/Ubuntu /usr/lib/qemu/qemu-bridge-helper   (package qemu-system-common)
+Grant it the capability it needs, either way:
+  sudo chmod u+s <path>
+  sudo setcap cap_net_admin+ep <path>
+Or name one explicitly with BRIDGE_HELPER=<path>, or fall back to NET=user."
+    require_tun_device
+    warn_unless_bridge_acl_allows "$BRIDGE"
+    NETDEV="bridge,id=net0,br=$BRIDGE,helper=$BRIDGE_HELPER_BIN"
+    # No hostfwd exists on a bridge. Resolve the lease rather than printing a
+    # port that nothing is listening on.
+    SSH_TARGET_NOTE="ssh -> \$(vm/guest-ip.sh) [DHCP lease on $BRIDGE for $GUEST_MAC]"
+    ;;
+  user)
+    NETDEV="user,id=net0,ipv6=off,hostfwd=tcp::${SSH_PORT}-:22"
+    SSH_TARGET_NOTE="ssh -> localhost:$SSH_PORT"
+    ;;
+  none)
+    NETDEV=""
+    SSH_TARGET_NOTE="ssh -> (none: NET=none has no NIC)"
+    ;;
+  *) die "unknown NET: $NET (bridge | user | none)" ;;
 esac
 
 # Product Reims VGPU: Tahoe x86 kext path is sensitive to high SMP (StorageNode::init).
@@ -601,9 +897,14 @@ else
   QEMU_ARGS+=(-nic none)
 fi
 
+if [ "$USB_QEMU_ARG_COUNT" -gt 0 ]; then
+  QEMU_ARGS+=("${USB_QEMU_ARGS[@]}")
+fi
+
 echo "boot-x86.sh: device=$GFX_DEVICE class=$BOOT_CLASS rail=$RAIL_NAME snapshot=$SNAPSHOT_NAME cpu=$CPU_MODEL smp=${CPU_THREADS},cores=${CPU_CORES} mem=$RAM reboot=${QEMU_REBOOT_ACTION}"
 echo "boot-x86.sh: audiodev=$AUDIODEV out.buffer-length=${AUDIO_BUFFER_US}us usb-audio buffer=${AUDIO_USB_BUFFER}"
-echo "boot-x86.sh: ssh → localhost:$SSH_PORT   serial → $SERIAL_LOG   qmp → $QMP_SOCK"
+echo "boot-x86.sh: net=$NET$([ "$NET" = bridge ] && printf ' bridge=%s helper=%s' "$BRIDGE" "$BRIDGE_HELPER_BIN") mac=$GUEST_MAC"
+echo "boot-x86.sh: $SSH_TARGET_NOTE   serial → $SERIAL_LOG   qmp → $QMP_SOCK"
 [ -n "$TRACE_LOG" ] && echo "boot-x86.sh: trace → $TRACE_LOG ($TRACE_SPEC)"
 
 discard_clone() {

--- a/vm/guest-authorize.sh
+++ b/vm/guest-authorize.sh
@@ -41,8 +41,32 @@
 #   vm/guest-authorize.sh --timeout 300   # bound the wait differently
 #   vm/guest-authorize.sh --no-automation # skip the Apple Events consent step
 #
+# THE ENDPOINT DEPENDS ON HOW THE BOOT WAS NETWORKED, and getting it wrong is
+# silent. boot-x86.sh defaults to NET=bridge, where the guest is a peer on
+# virbr0 with its own DHCP lease and there is NO hostfwd — so `127.0.0.1:2222`
+# reaches whatever else happens to be listening there, or nothing, and
+# BatchMode=yes renders both as "guest not up yet". Under NET=user the guest is
+# reachable only at `127.0.0.1:$SSH_PORT` and has no address of its own. This
+# script resolves whichever applies (`vm/guest-ip.sh` for the bridge) and prints
+# which one it used; set NET to match the boot if the default is wrong.
+#
+# IT ALSO WRITES THE `macos-vm` ALIAS, because that is the name every probe
+# types and its address moves with the endpoint. The alias is written to
+# `vm/disks/run/ssh-config` — inside the workspace, replaced per boot, nothing
+# outside it touched. For `ssh macos-vm` to see it, ~/.ssh/config needs one line
+# once:
+#
+#     Include /path/to/repo/vm/disks/run/ssh-config
+#
+# This script prints that line if the alias does not resolve, and `--write-ssh-
+# config` adds the Include for you (idempotent, in a delimited managed block).
+#
 # Environment:
-#   SSH_PORT              host port forwarded to the guest's 22 (default 2222)
+#   NET                   bridge (default, matches boot-x86.sh) | user | none
+#   BRIDGE                host bridge for NET=bridge (default virbr0)
+#   GUEST_MAC             the pinned guest MAC the lease is looked up by
+#   SSH_PORT              host port forwarded to the guest's 22 under NET=user
+#                         (default 2222); unused under NET=bridge
 #   REIMS_GUEST_USER      guest account (default aneesiqbal)
 #   REIMS_GUEST_PASSWORD  its password (default aneesiqbal) — a throwaway
 #                         credential for a local development VM, not a secret
@@ -60,6 +84,12 @@
 set -euo pipefail
 
 SSH_PORT="${SSH_PORT:-2222}"
+# Default must track boot-x86.sh's own NET default or this script authorizes the
+# wrong endpoint on a plain boot.
+NET="${NET:-bridge}"
+BRIDGE="${BRIDGE:-virbr0}"
+GUEST_MAC="${GUEST_MAC:-52:54:00:c9:18:27}"
+WRITE_SSH_CONFIG=0
 GUEST_USER="${REIMS_GUEST_USER:-aneesiqbal}"
 GUEST_PASSWORD="${REIMS_GUEST_PASSWORD:-aneesiqbal}"
 GUEST_KEY="${REIMS_GUEST_KEY:-$HOME/.ssh/macos_x86_guest}"
@@ -86,6 +116,7 @@ while [ $# -gt 0 ]; do
     --timeout) shift; WAIT_SECONDS="${1:-}"; [ -n "$WAIT_SECONDS" ] || die "--timeout needs seconds"; shift ;;
     --timeout=*) WAIT_SECONDS="${1#--timeout=}"; shift ;;
     --no-automation) WANT_AUTOMATION=0; shift ;;
+    --write-ssh-config) WRITE_SSH_CONFIG=1; shift ;;
     -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
     *) die "unknown arg: $1" ;;
   esac
@@ -98,25 +129,46 @@ PUBKEY="$(cat "$GUEST_KEY.pub")"
 # The guest's host key changes with every rail and every reprovision, and this
 # is a loopback port on a development box — pinning it would only produce a
 # mismatch to click through. Keep that decision out of the user's known_hosts.
+# --- Resolve the endpoint ---------------------------------------------------
+# A bridged guest takes its lease late in macOS boot, well after this script is
+# usually called, so the lease lookup gets the same deadline as the sshd wait
+# rather than a short one — a missing lease here is "not up yet", not "broken".
+case "$NET" in
+  bridge)
+    GUEST_ADDR="$(BRIDGE="$BRIDGE" GUEST_MAC="$GUEST_MAC" \
+      "$REPO_ROOT/vm/guest-ip.sh" --wait "$WAIT_SECONDS")" || die \
+      "no DHCP lease for $GUEST_MAC on $BRIDGE within ${WAIT_SECONDS}s.
+If the boot used NET=user, re-run this with NET=user (its guest has no address of its own)."
+    GUEST_SSH_PORT=22
+    ;;
+  user)
+    GUEST_ADDR=127.0.0.1
+    GUEST_SSH_PORT="$SSH_PORT"
+    ;;
+  none) die "NET=none: that boot has no NIC, so there is nothing to authorize" ;;
+  *) die "unknown NET: $NET (bridge | user | none)" ;;
+esac
+echo "guest-authorize: net=$NET endpoint=$GUEST_USER@$GUEST_ADDR:$GUEST_SSH_PORT"
+
 SSH_COMMON=(
   -o StrictHostKeyChecking=no
   -o UserKnownHostsFile=/dev/null
   -o LogLevel=ERROR
   -o ConnectTimeout=8
-  -p "$SSH_PORT"
+  -p "$GUEST_SSH_PORT"
 )
 
 ssh_key() {
   timeout "$STEP_TIMEOUT" ssh "${SSH_COMMON[@]}" \
     -o BatchMode=yes -o IdentitiesOnly=yes -i "$GUEST_KEY" \
-    "$GUEST_USER@127.0.0.1" "$@"
+    "$GUEST_USER@$GUEST_ADDR" "$@"
 }
 
 ssh_password() {
   command -v sshpass >/dev/null 2>&1 || die "sshpass not found (needed to authorize a rail that has no key yet)"
   timeout "$STEP_TIMEOUT" sshpass -p "$GUEST_PASSWORD" ssh "${SSH_COMMON[@]}" \
     -o PubkeyAuthentication=no -o NumberOfPasswordPrompts=1 \
-    "$GUEST_USER@127.0.0.1" "$@"
+    "$GUEST_USER@$GUEST_ADDR" "$@"
 }
 
 # --- Wait for sshd ---------------------------------------------------------
@@ -130,11 +182,11 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   if ssh_key true 2>/dev/null || ssh_password true 2>/dev/null; then up=1; break; fi
   sleep 5
 done
-[ "$up" -eq 1 ] || die "guest sshd did not answer on port $SSH_PORT within ${WAIT_SECONDS}s"
+[ "$up" -eq 1 ] || die "guest sshd did not answer at $GUEST_ADDR:$GUEST_SSH_PORT within ${WAIT_SECONDS}s"
 
 # --- Authorize -------------------------------------------------------------
 if ssh_key true 2>/dev/null; then
-  echo "guest-authorize: key auth already works (port $SSH_PORT, user $GUEST_USER)"
+  echo "guest-authorize: key auth already works ($GUEST_USER@$GUEST_ADDR:$GUEST_SSH_PORT)"
 else
   echo "guest-authorize: installing $GUEST_KEY.pub for $GUEST_USER ..."
   # Appending only when absent keeps a re-run from growing the file, and the
@@ -150,26 +202,89 @@ else
   echo "guest-authorize: key auth now works"
 fi
 
-# --- Report what a probe will see ------------------------------------------
-# `macos-vm` is what the probes actually type, and it authenticates against the
-# user's own ~/.ssh/known_hosts. That file cannot hold a useful entry for this
-# endpoint: `127.0.0.1:2222` is a different machine on every rail, so whichever
-# rail booted first wins and every other rail then fails the host-key check —
-# with `BatchMode=yes` turning the mismatch into a silent probe failure. Forget
-# the pin before verifying; `accept-new` re-learns it for the rail that is
-# actually running.
-for host in "[127.0.0.1]:$SSH_PORT" "[localhost]:$SSH_PORT"; do
-  timeout "$STEP_TIMEOUT" ssh-keygen -R "$host" >/dev/null 2>&1 || true
-done
+# --- Point the `macos-vm` alias at this boot -------------------------------
+# `macos-vm` is what the probes actually type, and where it points is now a
+# per-boot question rather than a constant: NET=user puts the guest on
+# 127.0.0.1:$SSH_PORT and NET=bridge gives it a lease of its own. Writing the
+# alias here is the same argument as installing the ssh key into the COW clone
+# rather than into the snapshot — it costs nothing, it is replaced by the next
+# boot, and every existing probe then works unchanged.
+#
+# The file lives in the workspace. StrictHostKeyChecking=no with a /dev/null
+# known-hosts is deliberate and is the same reasoning the ssh calls above use:
+# this endpoint is a DIFFERENT MACHINE on every rail, whether it is spelled
+# 127.0.0.1:2222 or a virbr0 lease that dnsmasq hands to whichever rail asked
+# first. A pin can only produce a mismatch, and BatchMode=yes turns a mismatch
+# into a silent probe failure that reads as a dead guest.
+SSH_CONFIG_FILE="$REPO_ROOT/vm/disks/run/ssh-config"
+mkdir -p "$(dirname "$SSH_CONFIG_FILE")"
+cat > "$SSH_CONFIG_FILE" <<EOF
+# Written by vm/guest-authorize.sh — regenerated on every run, do not edit.
+# net=$NET rail endpoint=$GUEST_USER@$GUEST_ADDR:$GUEST_SSH_PORT
+Host macos-vm
+  HostName $GUEST_ADDR
+  Port $GUEST_SSH_PORT
+  User $GUEST_USER
+  IdentityFile $GUEST_KEY
+  IdentitiesOnly yes
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  LogLevel ERROR
+  ConnectTimeout 8
+EOF
+echo "guest-authorize: wrote $SSH_CONFIG_FILE (Host macos-vm -> $GUEST_ADDR:$GUEST_SSH_PORT)"
 
-# If ~/.ssh/config points `macos-vm` somewhere else, say so here rather than
-# letting a probe fail obscurely.
-if timeout "$STEP_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=8 \
-     -o StrictHostKeyChecking=accept-new macos-vm true 2>/dev/null; then
+INCLUDE_LINE="Include $SSH_CONFIG_FILE"
+MANAGED_BEGIN="# BEGIN reims-vgpu (vm/guest-authorize.sh)"
+MANAGED_END="# END reims-vgpu"
+
+# ssh reads the FIRST value it finds for any keyword, so an Include that is not
+# at the top of the file loses to any earlier `Host macos-vm` or `Host *` block.
+# Prepending is the only placement that is always correct.
+add_include_to_user_config() {
+  local cfg="$HOME/.ssh/config"
+  mkdir -p "$HOME/.ssh"; chmod 700 "$HOME/.ssh"
+  if [ -f "$cfg" ] && grep -qxF "$INCLUDE_LINE" "$cfg"; then
+    echo "guest-authorize: $cfg already includes the alias"
+    return 0
+  fi
+  local tmp
+  tmp="$(mktemp "$cfg.reims.XXXXXX")"
+  {
+    printf '%s\n%s\n%s\n\n' "$MANAGED_BEGIN" "$INCLUDE_LINE" "$MANAGED_END"
+    [ -f "$cfg" ] && cat "$cfg"
+  } > "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$cfg"
+  echo "guest-authorize: prepended the alias Include to $cfg"
+}
+
+if [ "$WRITE_SSH_CONFIG" -eq 1 ]; then
+  add_include_to_user_config
+fi
+
+# --- Report what a probe will see ------------------------------------------
+if timeout "$STEP_TIMEOUT" ssh -F "$SSH_CONFIG_FILE" -o BatchMode=yes macos-vm true 2>/dev/null; then
+  echo "guest-authorize: ssh -F $SSH_CONFIG_FILE macos-vm ok"
+else
+  echo "guest-authorize: WARNING the generated alias does not connect even though direct key auth works." >&2
+  exit 1
+fi
+
+# The probes type a bare `ssh macos-vm`, which reads ~/.ssh/config and not the
+# file above. Verify the name the probes will actually use, and if it does not
+# resolve, print the one line that fixes it rather than leaving 20 probes to
+# fail at their first hop.
+if timeout "$STEP_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=8 macos-vm true 2>/dev/null; then
   echo "guest-authorize: ssh macos-vm ok — probes under scripts/ will reach this guest"
 else
-  echo "guest-authorize: WARNING ssh macos-vm failed even though direct key auth works." >&2
-  echo "guest-authorize: probes default to GUEST=macos-vm; check ~/.ssh/config names port $SSH_PORT and $GUEST_KEY." >&2
+  {
+    echo "guest-authorize: WARNING \`ssh macos-vm\` does not reach this guest, so every probe under scripts/ will fail at its first hop."
+    echo "guest-authorize: the alias itself is correct — it is just not on ssh's path. Add this line at the TOP of ~/.ssh/config:"
+    echo "guest-authorize:     $INCLUDE_LINE"
+    echo "guest-authorize: or re-run:  vm/guest-authorize.sh --write-ssh-config"
+    echo "guest-authorize: (if ~/.ssh/config already defines macos-vm, that definition wins; delete it or move the Include above it.)"
+  } >&2
   exit 1
 fi
 
@@ -178,8 +293,7 @@ fi
 # System Events and asks it something, which is the whole trigger. Its answer is
 # discarded — this is a consent probe, not a query.
 consent_probe() {
-  timeout "$CONSENT_PROBE_TIMEOUT" ssh -o BatchMode=yes -o ConnectTimeout=8 \
-    -o StrictHostKeyChecking=accept-new macos-vm \
+  timeout "$CONSENT_PROBE_TIMEOUT" ssh -F "$SSH_CONFIG_FILE" -o BatchMode=yes macos-vm \
     'osascript -e '\''tell application "System Events" to get name'\''' >/dev/null 2>&1
 }
 

--- a/vm/guest-ip.sh
+++ b/vm/guest-ip.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# vm/guest-ip.sh — print the bridged guest's IP address.
+#
+# WHY THIS EXISTS. With NET=bridge (boot-x86.sh's default) the guest is a peer on
+# the bridge's subnet and there is no hostfwd, so `localhost:2222` reaches
+# nothing. The guest's address is assigned by the bridge network's DHCP server
+# and is therefore not knowable from this repo — but the guest MAC IS pinned
+# (GUEST_MAC in boot-x86.sh, load-bearing for exactly this reason), so the
+# address is a lookup rather than a guess.
+#
+# THREE SOURCES, tried in order, because they fail in different places and the
+# first one that answers is the cheapest:
+#
+#   1. libvirt's dnsmasq lease file, /var/lib/libvirt/dnsmasq/<bridge>.status.
+#      World-readable JSON, needs no privilege and no libvirt connection, and
+#      holds the lease the moment dnsmasq grants it. This is the normal answer.
+#   2. `virsh net-dhcp-leases`. Same data through libvirt, which is worth having
+#      as a second opinion when the status file is unreadable (a distro that
+#      tightens its mode) or when the bridge belongs to a network whose lease
+#      file is named differently.
+#   3. The host's own neighbour table for the bridge. This is the only source
+#      that works for a guest with a STATIC address, and the only one that keeps
+#      working on a bridge with no DHCP server at all. It answers only after the
+#      guest has put a packet on the wire, which for macOS means after it has
+#      finished its own network setup.
+#
+# None of them is a side channel: each is a record of an address the guest itself
+# claimed, keyed by the MAC this repo pinned. Nothing here infers an address from
+# timing, ordering, or a scan.
+#
+#   vm/guest-ip.sh                  # print the IP, or fail after --wait seconds
+#   vm/guest-ip.sh --wait 180       # bound the wait differently (default 120)
+#   vm/guest-ip.sh --wait 0         # answer now or fail now, for a status check
+#   vm/guest-ip.sh --ssh-target     # print user@ip, ready to hand to ssh
+#
+# Environment: BRIDGE (default virbr0), GUEST_MAC, REIMS_GUEST_USER, LIBVIRT_NET,
+# and LEASE_STATUS to name a dnsmasq status file directly — which is what a
+# bridge served by a dnsmasq that libvirt does not own needs.
+#
+# Exits 0 having printed one address, or 3 with nothing on stdout. Exit 3 rather
+# than 1 so a harness can tell "no lease yet" from "this script is broken".
+set -euo pipefail
+
+BRIDGE="${BRIDGE:-virbr0}"
+GUEST_MAC="${GUEST_MAC:-52:54:00:c9:18:27}"
+GUEST_USER="${REIMS_GUEST_USER:-aneesiqbal}"
+LIBVIRT_NET="${LIBVIRT_NET:-default}"
+WAIT_SECONDS=120
+WANT_SSH_TARGET=0
+
+die() { echo "guest-ip: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --wait) shift; WAIT_SECONDS="${1:-}"; [ -n "$WAIT_SECONDS" ] || die "--wait needs seconds"; shift ;;
+    --wait=*) WAIT_SECONDS="${1#--wait=}"; shift ;;
+    --ssh-target) WANT_SSH_TARGET=1; shift ;;
+    --bridge) shift; BRIDGE="${1:-}"; [ -n "$BRIDGE" ] || die "--bridge needs a name"; shift ;;
+    --bridge=*) BRIDGE="${1#--bridge=}"; shift ;;
+    -h|--help) sed -n '2,36p' "$0"; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+case "$WAIT_SECONDS" in
+  ''|*[!0-9]*) die "--wait takes whole seconds, got '$WAIT_SECONDS'" ;;
+esac
+
+# dnsmasq writes the MAC lowercase; a MAC given in either case must match.
+MAC_LC="$(printf '%s' "$GUEST_MAC" | tr 'A-F' 'a-f')"
+
+# --- Source 1: the lease file ------------------------------------------------
+# The file is a JSON array of objects carrying "mac-address" and "ip-address".
+# Parsed with python3 rather than a regex because the two fields are not
+# adjacent and their order is not promised; a regex that assumes either would
+# return the wrong guest's address on a bridge with more than one VM, which is
+# the failure mode that reads as working.
+from_lease_file() {
+  local status="${LEASE_STATUS:-/var/lib/libvirt/dnsmasq/$BRIDGE.status}"
+  [ -r "$status" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$status" "$MAC_LC" <<'PY' 2>/dev/null
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        leases = json.load(f)
+except Exception:
+    sys.exit(1)
+want = sys.argv[2].lower()
+for lease in leases if isinstance(leases, list) else []:
+    if str(lease.get("mac-address", "")).lower() == want:
+        ip = lease.get("ip-address")
+        if ip:
+            print(ip)
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# --- Source 2: libvirt ---------------------------------------------------------
+from_virsh() {
+  command -v virsh >/dev/null 2>&1 || return 1
+  # Columns: Expiry | MAC | Protocol | IP/prefix | Hostname | ClientID.
+  # The address carries a prefix length that ssh must not see.
+  virsh --connect qemu:///system net-dhcp-leases "$LIBVIRT_NET" 2>/dev/null \
+    | awk -v mac="$MAC_LC" 'tolower($2) == mac { split($5, a, "/"); if (a[1] != "") { print a[1]; exit } }' \
+    | grep . || return 1
+}
+
+# --- Source 3: the neighbour table ---------------------------------------------
+# Works for a static guest and on a DHCP-less bridge, but only once the guest has
+# sent something. `ip neigh` prints "<ip> dev <br> lladdr <mac> <state>"; a
+# FAILED or INCOMPLETE entry is a MAC we asked about and got no answer for, so
+# those states are excluded rather than reported as an address.
+from_neighbours() {
+  ip neigh show dev "$BRIDGE" 2>/dev/null \
+    | awk -v mac="$MAC_LC" '
+        tolower($3) == "lladdr" && tolower($4) == mac {
+          state = $NF
+          if (state != "FAILED" && state != "INCOMPLETE") { print $1; exit }
+        }' \
+    | grep . || return 1
+}
+
+resolve_once() {
+  from_lease_file || from_virsh || from_neighbours
+}
+
+IP=""
+deadline=$(( $(date +%s) + WAIT_SECONDS ))
+while :; do
+  if IP="$(resolve_once)" && [ -n "$IP" ]; then break; fi
+  IP=""
+  [ "$(date +%s)" -lt "$deadline" ] || break
+  sleep 3
+done
+
+if [ -z "$IP" ]; then
+  {
+    echo "guest-ip: no address for $GUEST_MAC on $BRIDGE after ${WAIT_SECONDS}s."
+    if ! ip link show "$BRIDGE" >/dev/null 2>&1; then
+      echo "guest-ip: there is no bridge '$BRIDGE' — start libvirt's network:"
+      echo "guest-ip:   sudo virsh --connect qemu:///system net-start $LIBVIRT_NET"
+    else
+      echo "guest-ip: the bridge exists, so the guest has not taken a lease yet."
+      echo "guest-ip: a macOS guest DHCPs late in boot — wait for the desktop, then retry."
+      echo "guest-ip: if it never does, confirm the boot ran with NET=bridge (NET=user has no lease;"
+      echo "guest-ip:   its guest is reachable at localhost:\${SSH_PORT:-2222} instead)."
+    fi
+  } >&2
+  exit 3
+fi
+
+if [ "$WANT_SSH_TARGET" -eq 1 ]; then
+  printf '%s@%s\n' "$GUEST_USER" "$IP"
+else
+  printf '%s\n' "$IP"
+fi

--- a/vm/lib/usb-passthrough.sh
+++ b/vm/lib/usb-passthrough.sh
@@ -1,0 +1,180 @@
+# vm/lib/usb-passthrough.sh — resolve host USB passthrough specs into QEMU
+# `-device usb-host,...` properties. Sourced by vm/boot-x86.sh and
+# vm/boot-arm64.sh; not executable on its own.
+#
+# WHY THIS IS A LIBRARY AND NOT A BLOCK IN EACH BOOT SCRIPT. The two boot
+# scripts already carry hand-copied versions of several things, and a spec
+# parser is the worst candidate for a fourth: three accepted spellings, each
+# mapping to a different pair of QEMU properties, and a wrong mapping does not
+# fail — it hands the guest a device the caller did not name, or nothing at all.
+# One owner means the arm64 host cannot drift from the x86 one on a rule neither
+# of them can test for the other.
+#
+# WHAT `usb-host` ACTUALLY NEEDS, which is the whole reason this file resolves
+# anything instead of passing the spec straight through:
+#
+#   1. The device has to be there. QEMU's usb-host will realize against a
+#      vendorid/productid that matches nothing and simply present no device to
+#      the guest, which is indistinguishable from a driverless guest. A typo in
+#      four hex digits therefore costs a whole boot and reads as a device bug,
+#      so a spec matching nothing is refused here by name.
+#   2. This process has to be able to open /dev/bus/usb/BBB/DDD read-write.
+#      libusb needs write access to claim an interface; read access alone gets
+#      far enough to enumerate and then fails at claim time, deep inside the
+#      guest's own driver probe. The node is checked before QEMU starts.
+#   3. The host driver is detached for the life of the boot. That is the point
+#      of passthrough and it is also how somebody loses the keyboard they are
+#      typing on, so every resolved device is announced with its strings.
+#
+# The sysfs walk is the contract here: /sys/bus/usb/devices holds one directory
+# per device named BUS-PORT[.PORT...] (and `usbN` for a root hub), each carrying
+# idVendor, idProduct, busnum and devnum. Those four files are what `lsusb`
+# reads too, so the three spec forms below are all derived from one source
+# rather than from parsing another tool's output.
+
+USB_SYSFS_ROOT="${USB_SYSFS_ROOT:-/sys/bus/usb/devices}"
+
+# Read a sysfs attribute, empty if absent. Keeps the callers below free of
+# `2>/dev/null || true` on every field.
+_usb_attr() {
+  [ -r "$1/$2" ] && tr -d '\n' < "$1/$2" || true
+}
+
+# Every passthrough-eligible device directory, one per line. A root hub (`usbN`)
+# is excluded: it is the controller, has no host driver to detach, and passing
+# it is not a thing QEMU can do.
+_usb_device_dirs() {
+  local dir
+  for dir in "$USB_SYSFS_ROOT"/*; do
+    [ -d "$dir" ] || continue
+    case "${dir##*/}" in
+      usb*) continue ;;      # root hub
+      *:*)  continue ;;      # an interface, e.g. 1-1:1.0
+    esac
+    [ -r "$dir/idVendor" ] && [ -r "$dir/busnum" ] && [ -r "$dir/devnum" ] || continue
+    printf '%s\n' "$dir"
+  done
+}
+
+# Human description: "Manufacturer Product" with either half allowed to be
+# missing, falling back to the VID:PID that is always present.
+_usb_describe() {
+  local dir="$1" man prod
+  man="$(_usb_attr "$dir" manufacturer)"
+  prod="$(_usb_attr "$dir" product)"
+  if [ -n "$man$prod" ]; then
+    printf '%s' "$(printf '%s %s' "$man" "$prod" | sed 's/^ *//; s/ *$//')"
+  else
+    printf '%s:%s' "$(_usb_attr "$dir" idVendor)" "$(_usb_attr "$dir" idProduct)"
+  fi
+}
+
+# `--list-usb`: print all three spec forms for every device, so a caller can
+# copy one rather than translate `lsusb` output by hand.
+usb_list_devices() {
+  local dir name bus dev vid pid port
+  printf '%-12s %-10s %-10s %s\n' 'VID:PID' 'BUS.ADDR' 'BUS-PORT' 'DEVICE'
+  while IFS= read -r dir; do
+    name="${dir##*/}"
+    bus="$(_usb_attr "$dir" busnum)"
+    dev="$(_usb_attr "$dir" devnum)"
+    vid="$(_usb_attr "$dir" idVendor)"
+    pid="$(_usb_attr "$dir" idProduct)"
+    port="${name#*-}"
+    printf '%-12s %-10s %-10s %s\n' \
+      "$vid:$pid" "$((10#$bus)).$((10#$dev))" "$name" "$(_usb_describe "$dir")"
+  done <<EOF
+$(_usb_device_dirs)
+EOF
+}
+
+# usb_resolve_spec SPEC
+#
+# On success sets USB_R_PROPS (the QEMU property fragment), USB_R_DESC (what to
+# print), USB_R_BUSNUM and USB_R_DEVNUM (for the /dev node check), and returns 0.
+# On failure sets USB_R_ERROR and returns 1. Never exits — the caller owns how a
+# refusal is reported, because the two boot scripts spell `die` differently.
+usb_resolve_spec() {
+  local spec="$1"
+  USB_R_PROPS=""; USB_R_DESC=""; USB_R_BUSNUM=""; USB_R_DEVNUM=""; USB_R_ERROR=""
+
+  local kind vid pid want_bus want_addr want_port
+  if printf '%s' "$spec" | grep -Eq '^[0-9a-fA-F]{4}:[0-9a-fA-F]{4}$'; then
+    kind=id
+    # sysfs writes idVendor/idProduct in lowercase hex; normalise so `046D:C099`
+    # and `046d:c099` are the same spec.
+    vid="$(printf '%s' "${spec%%:*}" | tr 'A-F' 'a-f')"
+    pid="$(printf '%s' "${spec##*:}" | tr 'A-F' 'a-f')"
+  elif printf '%s' "$spec" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+    kind=addr
+    want_bus="$((10#${spec%%.*}))"
+    want_addr="$((10#${spec##*.}))"
+  elif printf '%s' "$spec" | grep -Eq '^[0-9]+-[0-9]+(\.[0-9]+)*$'; then
+    kind=port
+    want_port="$spec"
+  else
+    USB_R_ERROR="unrecognised USB spec '$spec' (want VID:PID like 046d:c099, BUS.ADDR like 5.3, or BUS-PORT like 5-1.2)"
+    return 1
+  fi
+
+  local dir name bus dev match=""
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    name="${dir##*/}"
+    bus="$((10#$(_usb_attr "$dir" busnum)))"
+    dev="$((10#$(_usb_attr "$dir" devnum)))"
+    case "$kind" in
+      id)
+        [ "$(_usb_attr "$dir" idVendor)" = "$vid" ] || continue
+        [ "$(_usb_attr "$dir" idProduct)" = "$pid" ] || continue
+        ;;
+      addr)
+        [ "$bus" = "$want_bus" ] && [ "$dev" = "$want_addr" ] || continue
+        ;;
+      port)
+        [ "$name" = "$want_port" ] || continue
+        ;;
+    esac
+    match="$dir"
+    break
+  done <<EOF
+$(_usb_device_dirs)
+EOF
+
+  if [ -z "$match" ]; then
+    USB_R_ERROR="no USB device matches '$spec' — plug it in before booting, or run --list-usb to see what is present"
+    return 1
+  fi
+
+  name="${match##*/}"
+  USB_R_BUSNUM="$((10#$(_usb_attr "$match" busnum)))"
+  USB_R_DEVNUM="$((10#$(_usb_attr "$match" devnum)))"
+  USB_R_DESC="$(_usb_describe "$match") [$(_usb_attr "$match" idVendor):$(_usb_attr "$match" idProduct) bus $USB_R_BUSNUM addr $USB_R_DEVNUM port $name]"
+
+  # Each spec form keeps the identity the caller asked for. Resolving BUS-PORT or
+  # VID:PID down to hostbus/hostaddr here would silently convert a stable spec
+  # into a one-boot one, so the property pair mirrors the form that was given.
+  case "$kind" in
+    id)   USB_R_PROPS="vendorid=0x$vid,productid=0x$pid" ;;
+    addr) USB_R_PROPS="hostbus=$USB_R_BUSNUM,hostaddr=$USB_R_DEVNUM" ;;
+    port) USB_R_PROPS="hostbus=$USB_R_BUSNUM,hostport=${name#*-}" ;;
+  esac
+
+  # libusb claims an interface, which needs write access and not just read.
+  local node
+  node="$(printf '/dev/bus/usb/%03d/%03d' "$USB_R_BUSNUM" "$USB_R_DEVNUM")"
+  if [ ! -e "$node" ]; then
+    USB_R_ERROR="$spec resolved to $USB_R_DESC but $node does not exist (is usbfs mounted?)"
+    return 1
+  fi
+  if [ ! -r "$node" ] || [ ! -w "$node" ]; then
+    USB_R_ERROR="$spec resolved to $USB_R_DESC but $node is not readable+writable by $(id -un).
+libusb must claim the interface, so read access alone is not enough — it fails later, inside the guest's driver probe.
+Grant it with a udev rule (survives replug), then replug the device:
+  echo 'SUBSYSTEM==\"usb\", ATTR{idVendor}==\"$(_usb_attr "$match" idVendor)\", ATTR{idProduct}==\"$(_usb_attr "$match" idProduct)\", MODE=\"0660\", TAG+=\"uaccess\"' | sudo tee /etc/udev/rules.d/70-reims-vgpu-usb.rules
+  sudo udevadm control --reload && sudo udevadm trigger
+Or, for this boot only:  sudo chmod 0666 $node"
+    return 1
+  fi
+  return 0
+}


### PR DESCRIPTION
## What this is

Six decode/contract gaps and two drain-thread performance costs on the x86 macOS / Linux Vulkan pathway, each diagnosed from the device's own typed refusals on a driven 3D workload (macos-13 rail, NVIDIA host) and fixed in the owning type, with tests that fail without the change. Together they take real-world Metal 3D content from refusing every draw to executing with **zero failed draws over whole boots**.

## Contract gaps (in the order the refusals surfaced them)

1. **`'l10r'` IOSurface FourCC** (`kCVPixelFormatType_ARGB2101010LEPacked`) was unmapped in `objects::iosurface_pixel_format_to_mtl`, so any surface declared with it hit `rt_type4_base_format`'s refusal and every draw into it failed. Now `MTLPixelFormatBGR10A2Unorm`, corroborated by the guest's own type-5 view (`fmt=0x5e`) and the surface's 4-byte/texel geometry. The format joins `render_target_bpp`, `store_texel_order` (the byte copy is the only lossless rail for a packed word), `sampled_class`, and the CPU conversion rails, with a bit-exact round-trip test.
2. **The texture descriptor's `mipmapLevelCount` is one byte, not a u16** — the byte above it carries an undecoded field, so a 7-level pyramid decoded as 32 775 levels and the shifted format trailer landed a megabyte past the body: the descriptor then carried no pixel format and the bind refused. The body-length identity `116+(n−1)·36` pins the width on four guest-sent descriptors; the undecoded neighbour is reported by name.
3. **Pipeline TLV tags `0x2e`/`0x37`** are `alphaTestFunction`/`logicOperation`, identified by driving `-[_MTLDevice serializeRenderPipelineDescriptor:]` in the guest with one setter perturbed per fork (the full ~30-tag map is recorded at `note_pipeline_tlv_fields`). The two values are benign — their enables (`0x2d`/`0x2f`) are absent on the measured traffic and stay refused — so pipelines carrying them decode instead of losing every draw.
4. **The BC1–BC7 block-compressed family** enters the contract as `BlockGeometry`: `bytes_per_pixel` stays `None` for every BC format on purpose, and `block_geometry`/`tight_row_bytes`/`tight_row_count` are the one sizing vocabulary both families share (an uncompressed block is 1×1). Gated on `VkPhysicalDeviceFeatures::textureCompressionBC` — asked, enabled, and published through `DeviceCapabilitySnapshot`; Apple/MoltenVK hosts read false and refuse by name. The per-layout capability masks narrowed to `TexelLayout::UNCOMPRESSED_COUNT` (the packed word's `const` assertion caught the overflow). The blit texture-to-texture copy converts to block space once at the top; the buffer↔texture blit rails refuse compressed by name; view compatibility compares whole storage grids, so equal bytes over a different grid is its own refusal.
5. **Cube maps on the sampled rail**: `sampled_image_shape` names `Cube` as a six-layer cube image (the engine had carried CUBE creation and layers-is-six validation all along), and `texture_view::load_cube_faces` reads the six faces one face-stride apart — the contiguous-image array packing `blit_exec` measured against live traffic, block-rows corrected. The bind replaces the ladder's one-image source for `Bytes` and `GuestRuns` sources; a resident `Target` cube stays refused by name.
6. **A serialized render pass's records share one depth attachment**: anonymous depth now keys a stable pass-geometry resident instead of a fresh transient per record (`vk_alloc_sites transient_depth` read ~45 000/session against a rail documented near zero — inter-record occlusion was silently lost), and continuation records force depth LOAD exactly as the record loop already forced colour LOAD.

## Drain-thread performance

Measured mid-workload: host GPU 6% busy, drain duty 0.91 — the device was CPU-bound on its own thread.

- **BC binds ride the zero-copy gather**: `strided_level_extent` and the engine's GuestRuns validation speak block units, retiring a per-bind CPU re-read + memcmp that cost 53% of every drain second (~11 800 binds/s on textures whose bytes never change). `sampled_us` 530 ms/s → 3–58 ms/s.
- **The eager CLEAR-seed Store defaults off** (`REIMS_VGPU_CLEAR_SEED=on` restores it for A/B): a successful record's Store overwrites the identical extent and `exec`'s `apply_clear` covers zero-draw packets, so its ~550 ms/s of guest-page writes bought nothing. The chaining recipe is captured outside the gate and the skipped-draw census was hoisted above the `any_store` split it had been quietly living under. `prep_seed_us` 550 ms/s → ~0.2 ms/s; drain duty 0.91 → 0.09–0.44.

Also included (first commit): vm tooling — `NET=bridge` default with `vm/guest-ip.sh` lease resolution and the `macos-vm` alias flow, a USB passthrough lib, and a stdlib-only fail-log dashboard implementing the AGENTS.md counter-reading rules.

## Verification

- `cargo test` (vulkan,host-window): 2208 lib + 97 other targets green, serial.
- Feature matrix compiles on all three arms; clippy `-D warnings` on all three arms adds **no findings** over the pre-existing set (19 vulkan / 17 metal, all `uninlined_format_args`/`dead_code` in untouched lines).
- Live driven boots on the macos-13 rail at each step: `mrt_request` failures 7 226 → 0, `draw_load_pipeline desc_decode` 1 348 → 0, `tex_bad_bpp` 448 → 0, whole-boot `draws_fail` → 0, `transient_depth` → 0.

**Not verified**: the arm64/Metal pathways beyond cross-compiled clippy + `cargo check` (no Apple host here); the wire-fixture oracle tests (fixtures absent on this checkout, reported ignored); sustained-animation-probe A/B for the two perf changes (measured through the censuses instead); `REIMS_VGPU_GUEST_IMPORT=off` copying-rail boots for the BC gather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJpmabbTTYq31VM7mZs75M
