### PR TITLE
x86/Vulkan: BC texture family, cube maps, packed ten-bit targets, pass-shared depth, and two drain-thread costs

### DIFF
--- a/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/caps/device_features.rs
@@ -328,6 +328,24 @@ pub struct DeviceFeatures {
     /// pipeline invalid. Same shape as [`Self::dual_src_blend`] — optional
     /// core, asked rather than assumed, declined by name where absent.
     pub fill_mode_non_solid: bool,
+    /// `VkPhysicalDeviceFeatures::textureCompressionBC` — whether this device
+    /// can sample the BC (DXT / S3TC) block-compressed families.
+    ///
+    /// One bit covers BC1 through BC7, which is why
+    /// `pixel_format::MTL_FORMAT_BC1_RGBA`'s doc admits the family whole: there
+    /// is no per-member capability to measure. Enabling it also brings the
+    /// guarantees the sampled rail relies on — Vulkan's mandatory-format table
+    /// requires `SAMPLED_IMAGE`, `SAMPLED_IMAGE_FILTER_LINEAR` and `BLIT_SRC`
+    /// of every BC format on a device that has this feature enabled, so no
+    /// per-format query is owed either.
+    ///
+    /// **Asked and enabled rather than assumed**, and this one genuinely
+    /// divides hosts: desktop GPUs have it and Apple GPUs do not — they carry
+    /// ASTC instead — so the arm64/Metal pathways and MoltenVK refuse a BC
+    /// bind by name. Creating a BC image without the feature enabled is invalid
+    /// use, not a slower path, which is why the gate is at
+    /// `draw::texture_view::NativeUploads` and not a `#[cfg]`.
+    pub texture_compression_bc: bool,
     /// `VkPhysicalDeviceFeatures::depthClamp` — whether a pipeline may set
     /// `depthClampEnable`.
     ///
@@ -422,6 +440,7 @@ impl DeviceFeatures {
             .shader_storage_image_read_without_format(self.storage_image_read_without_format)
             .dual_src_blend(self.dual_src_blend)
             .fill_mode_non_solid(self.fill_mode_non_solid)
+            .texture_compression_bc(self.texture_compression_bc)
             .depth_clamp(self.depth_clamp)
             .multi_viewport(self.multi_viewport)
             .occlusion_query_precise(self.occlusion_query_precise)
@@ -534,6 +553,7 @@ impl DeviceFeatures {
             storage_image_write_without_format,
             storage_image_read_without_format,
             bgra8_storage,
+            texture_compression_bc,
             sampled_linear_filter,
             color_attachment_blend,
             storage16,
@@ -579,6 +599,7 @@ impl DeviceFeatures {
              max_compute_shared_memory_bytes={max_compute_shared_memory_bytes} \
              max_sample_count={max_sample_count} d24_unorm_s8_attachment={d24_unorm_s8_attachment} \
              shader_int16={shader_int16} shader_int64={shader_int64} \
+             texture_compression_bc={texture_compression_bc} \
              sampled_image_array_dynamic_indexing={sampled_image_array_dynamic_indexing} \
              storage_image_array_dynamic_indexing={storage_image_array_dynamic_indexing} \
              sampled_image_descriptor_limit={sampled_image_descriptor_limit} \
@@ -762,6 +783,7 @@ pub unsafe fn query(
         sampler_anisotropy: supported.sampler_anisotropy == vk::TRUE,
         dual_src_blend: supported.dual_src_blend == vk::TRUE,
         fill_mode_non_solid: supported.fill_mode_non_solid == vk::TRUE,
+        texture_compression_bc: supported.texture_compression_bc == vk::TRUE,
         depth_clamp: supported.depth_clamp == vk::TRUE,
         multi_viewport: supported.multi_viewport == vk::TRUE,
         occlusion_query_precise: supported.occlusion_query_precise == vk::TRUE,
@@ -829,6 +851,7 @@ mod tests {
         DeviceFeatures {
             occlusion_query_precise: true,
             robust_buffer_access: true,
+            texture_compression_bc: true,
             sampler_anisotropy: true,
             max_sampler_anisotropy: 16.0,
             max_image_dimension_2d: 16384,

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -1870,11 +1870,18 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                 },
             ));
         }
-        // Footprint of one texel of the image's own format. `None` means a
-        // format whose bytes are not one number per texel (block-compressed,
-        // multi-planar) reached a rail that sizes a linear buffer — decline by
-        // name rather than compute a wrong length.
-        let Some(texel) = super::super::translate::pixel::bytes_per_texel(image.format) else {
+        // Storage grid of the image's own format. `None` means a format whose
+        // footprint this table cannot describe at all (multi-planar) reached a
+        // rail that sizes a linear buffer — decline by name rather than compute
+        // a wrong length.
+        //
+        // The **grid** and not a bytes-per-texel, because a block-compressed
+        // image is a legitimate sampled bind and its buffer is a quarter as wide
+        // and a quarter as tall in blocks as it is in texels. Sizing one per
+        // texel over-counts by sixteen and refuses the guest's own
+        // correctly-sized bytes as `SampledBytesLength` — which is a refusal
+        // wearing the name of a guest error.
+        let Some(block) = super::super::translate::pixel::vk_block_geometry(image.format) else {
             return Err(DrawError::DrawValidation(
                 DrawValidationDecline::SampledNoLinearTexelFootprint {
                     binding: image.binding,
@@ -1882,22 +1889,21 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                 },
             ));
         };
-        let texel = texel as usize;
         // Four factors, so the widening the operands already carry is not
         // enough — see the target-seed check above for why two of them exhaust
         // a u64 on their own. `contract::extent` owns the checked form.
-        let Some(expected) = crate::contract::extent::tight_layered_image_bytes(
+        let Some(expected) = crate::contract::extent::tight_layered_block_bytes(
             image.width,
             image.height,
             image.layers,
-            texel,
+            block,
         ) else {
             return Err(DrawError::DrawValidation(
                 DrawValidationDecline::UnrepresentableImageBytes {
                     width: image.width,
                     height: image.height,
                     layers: image.layers,
-                    bytes_per_texel: texel as u32,
+                    bytes_per_texel: block.bytes,
                 },
             ));
         };
@@ -1943,12 +1949,42 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                         },
                     ));
                 }
+                // Every count below is in units of the image's storage grid —
+                // rows of blocks and bytes per block — which for an
+                // uncompressed format is exactly the texel arithmetic this
+                // always was (a 1x1 block whose bytes are the bytes-per-texel).
+                // `bufferRowLength` stays Vulkan's unit, texels: the stride in
+                // bytes is `(row_length / block.width) * block.bytes`, and a
+                // row length that does not divide into whole blocks cannot
+                // describe a compressed row at all, so it refuses as a stride
+                // defect rather than rounding into a shifted image.
+                let texel = block.bytes as usize;
                 let planes = image.layers as usize;
+                let storage_rows = block.block_rows(image.height) as usize;
+                let tight_row = block.blocks_across(image.width) as usize * texel;
+                if storage_rows == 0 || tight_row == 0 {
+                    return Err(DrawError::DrawValidation(
+                        DrawValidationDecline::SampledZeroGeometry {
+                            binding: image.binding,
+                            width: image.width,
+                            height: image.height,
+                            layers: image.layers,
+                        },
+                    ));
+                }
                 let run_expected = if src.row_length_texels == 0 {
                     expected
                 } else {
-                    let stride = src.row_length_texels as usize * texel;
-                    let tight_row = image.width as usize * texel;
+                    if !src.row_length_texels.is_multiple_of(block.width) {
+                        return Err(DrawError::DrawValidation(
+                            DrawValidationDecline::GuestSampleRowStride {
+                                binding: image.binding,
+                                stride: src.row_length_texels as usize,
+                                tight_row,
+                            },
+                        ));
+                    }
+                    let stride = (src.row_length_texels / block.width) as usize * texel;
                     if stride < tight_row {
                         return Err(DrawError::DrawValidation(
                             DrawValidationDecline::GuestSampleRowStride {
@@ -1958,8 +1994,8 @@ pub(crate) fn validate_v1(req: &DrawRequest) -> Result<(), DrawError> {
                             },
                         ));
                     }
-                    (planes - 1) * image.height as usize * stride
-                        + (image.height as usize - 1) * stride
+                    (planes - 1) * storage_rows * stride
+                        + (storage_rows - 1) * stride
                         + tight_row
                 };
                 if src.total_len as usize != run_expected {

--- a/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
@@ -407,12 +407,30 @@ struct DeviceCapabilitySnapshot(u64);
 
 const CAP_MAX_DIMENSION_BITS: u32 = u32::BITS;
 const CAP_LAYOUT_SHIFT: u32 = CAP_MAX_DIMENSION_BITS;
-const CAP_GPU_ONLY_BIT: u32 =
-    CAP_LAYOUT_SHIFT + crate::contract::pixel_format::TexelLayout::ALL.len() as u32;
+/// Both per-layout masks span the **uncompressed** vocabulary only.
+///
+/// Two masks of the full `TexelLayout::ALL` no longer fit beside a `u32`
+/// dimension and two flags in one word, and the assertion below is what said so
+/// — it failed the build the moment the ten BC layouts were declared, which is
+/// exactly what a `const` relation is for. Narrowing rather than widening is
+/// also the right answer on the merits: a block-compressed layout is never a
+/// colour attachment, and Vulkan's mandatory-format table already guarantees it
+/// linear filtering wherever `textureCompressionBC` is enabled. See
+/// `TexelLayout::UNCOMPRESSED_COUNT`.
+const CAP_LAYOUT_COUNT: u32 =
+    crate::contract::pixel_format::TexelLayout::UNCOMPRESSED_COUNT as u32;
+const CAP_GPU_ONLY_BIT: u32 = CAP_LAYOUT_SHIFT + CAP_LAYOUT_COUNT;
 const CAP_SAMPLED_FILTER_SHIFT: u32 = CAP_GPU_ONLY_BIT + 1;
-const CAP_PUBLISHED_BIT: u32 =
-    CAP_SAMPLED_FILTER_SHIFT + crate::contract::pixel_format::TexelLayout::ALL.len() as u32;
-const _: () = assert!(CAP_PUBLISHED_BIT < u64::BITS);
+const CAP_PUBLISHED_BIT: u32 = CAP_SAMPLED_FILTER_SHIFT + CAP_LAYOUT_COUNT;
+/// Whether this device can sample the BC block-compressed families.
+///
+/// One bit for the whole family, because Vulkan gates BC1 through BC7 behind one
+/// feature — see `caps::device_features::DeviceFeatures::texture_compression_bc`.
+/// It rides this word rather than being asked under the engine lock for the
+/// reason the rest of it does: the sampled ladder consults it while a draw
+/// request is being assembled, before the engine transaction opens.
+const CAP_TEXTURE_COMPRESSION_BC_BIT: u32 = CAP_PUBLISHED_BIT + 1;
+const _: () = assert!(CAP_TEXTURE_COMPRESSION_BC_BIT < u64::BITS);
 
 impl DeviceCapabilitySnapshot {
     const CONSERVATIVE: Self =
@@ -427,18 +445,26 @@ impl DeviceCapabilitySnapshot {
         quirks: crate::backend::vulkan::caps::DriverQuirk,
     ) -> Self {
         let mut word = u64::from(features.max_image_dimension_2d);
-        for (index, supported) in features.color_attachment_blend.iter().enumerate() {
-            if *supported {
-                word |= 1_u64 << (CAP_LAYOUT_SHIFT + index as u32);
+        // Walked by layout rather than by array position: the feature arrays are
+        // indexed by `TexelLayout::index()` over the whole vocabulary and the
+        // masks by `uncompressed_index()` over part of it, so enumerating the
+        // array would put a layout's answer in another layout's bit.
+        for layout in crate::contract::pixel_format::TexelLayout::ALL {
+            let Some(bit) = layout.uncompressed_index() else {
+                continue;
+            };
+            if features.color_attachment_blend[layout.index()] {
+                word |= 1_u64 << (CAP_LAYOUT_SHIFT + bit as u32);
+            }
+            if features.sampled_linear_filter[layout.index()] {
+                word |= 1_u64 << (CAP_SAMPLED_FILTER_SHIFT + bit as u32);
             }
         }
         if !quirks.guest_pages_stay_authoritative {
             word |= 1_u64 << CAP_GPU_ONLY_BIT;
         }
-        for (index, supported) in features.sampled_linear_filter.iter().enumerate() {
-            if *supported {
-                word |= 1_u64 << (CAP_SAMPLED_FILTER_SHIFT + index as u32);
-            }
+        if features.texture_compression_bc {
+            word |= 1_u64 << CAP_TEXTURE_COMPRESSION_BC_BIT;
         }
         word |= 1_u64 << CAP_PUBLISHED_BIT;
         Self(word)
@@ -452,19 +478,50 @@ impl DeviceCapabilitySnapshot {
         self,
         layout: crate::contract::pixel_format::TexelLayout,
     ) -> bool {
-        self.0 & (1_u64 << (CAP_LAYOUT_SHIFT + layout.index() as u32)) != 0
+        let Some(bit) = layout.uncompressed_index() else {
+            // No host renders into a block-compressed format, and this device
+            // does not ask it to: `pixel_format::render_target_bpp` has no BC
+            // arm, so the resolve refuses one before reaching here. Answering
+            // `false` keeps that true instead of reading a bit the word does not
+            // carry.
+            return false;
+        };
+        self.0 & (1_u64 << (CAP_LAYOUT_SHIFT + bit as u32)) != 0
     }
 
     fn deferred_gpu_only_content_allowed(self) -> bool {
         self.0 & (1_u64 << CAP_GPU_ONLY_BIT) != 0
     }
 
+    /// Whether the published device sampled BC formats, or `None` before any
+    /// device has published.
+    ///
+    /// `None` rather than `false` for the unpublished case, so a caller creates
+    /// the device and asks it rather than refusing every compressed texture for
+    /// the life of a process that simply had not drawn yet — the same shape
+    /// [`Self::sampled_layout_linear_filter_if_published`] has.
+    fn texture_compression_bc_if_published(self) -> Option<bool> {
+        (self.0 & (1_u64 << CAP_PUBLISHED_BIT) != 0)
+            .then_some(self.0 & (1_u64 << CAP_TEXTURE_COMPRESSION_BC_BIT) != 0)
+    }
+
     fn sampled_layout_linear_filter_if_published(
         self,
         layout: crate::contract::pixel_format::TexelLayout,
     ) -> Option<bool> {
-        (self.0 & (1_u64 << CAP_PUBLISHED_BIT) != 0)
-            .then_some(self.0 & (1_u64 << (CAP_SAMPLED_FILTER_SHIFT + layout.index() as u32)) != 0)
+        if self.0 & (1_u64 << CAP_PUBLISHED_BIT) == 0 {
+            return None;
+        }
+        let Some(bit) = layout.uncompressed_index() else {
+            // Vulkan's mandatory-format table requires
+            // `SAMPLED_IMAGE_FILTER_LINEAR` of every BC format on a device that
+            // enables `textureCompressionBC`, and that feature is what admits
+            // the format at `translate::pixel::sampled_pixels` in the first
+            // place. So there is nothing to query — the same unconditional
+            // reading `R16_SFLOAT` gets from the spec, one family over.
+            return Some(true);
+        };
+        Some(self.0 & (1_u64 << (CAP_SAMPLED_FILTER_SHIFT + bit as u32)) != 0)
     }
 }
 
@@ -2336,7 +2393,47 @@ pub fn supports_sampled_layout_linear_filter(
         ..
     } = &mut *guard;
     match owner.ensure(counters) {
-        Ok(ctx) => ctx.sampled_linear_filter[layout.index()],
+        Ok(ctx) => {
+            if layout.is_block_compressed() {
+                // Mandated by the spec wherever the family is available at all,
+                // so there is nothing in this array to read and its BC entries
+                // are never written. Same answer the published snapshot gives.
+                ctx.features.texture_compression_bc
+            } else {
+                ctx.sampled_linear_filter[layout.index()]
+            }
+        }
+        Err(error) => {
+            engine_probe_decline(EngineProbe::SampledLayoutLinearFilter, &error)
+                .fail_once(EngineProbe::SampledLayoutLinearFilter.discriminant());
+            false
+        }
+    }
+}
+
+/// Whether this host samples the BC block-compressed families.
+///
+/// The gate `runtime::draw::texture_view::NativeUploads` carries into the linear
+/// sampled loaders. Structured exactly like
+/// [`supports_sampled_layout_linear_filter`]: the lock-free snapshot when a
+/// device has published, and otherwise the first query is allowed to create one.
+///
+/// A `false` here is not a slow path — there is no CPU decompressor and there
+/// will not be one — so it becomes a typed refusal and the guest loses that
+/// texture. That is the honest answer for a host without the format: Apple GPUs
+/// carry ASTC instead, so the arm64 pathways and MoltenVK read `false`.
+pub fn supports_block_compressed_sampled() -> bool {
+    if let Some(supported) = device_capabilities().texture_compression_bc_if_published() {
+        return supported;
+    }
+    let mut guard = lock_engine();
+    let EngineState {
+        ref mut owner,
+        ref counters,
+        ..
+    } = &mut *guard;
+    match owner.ensure(counters) {
+        Ok(ctx) => ctx.features.texture_compression_bc,
         Err(error) => {
             engine_probe_decline(EngineProbe::SampledLayoutLinearFilter, &error)
                 .fail_once(EngineProbe::SampledLayoutLinearFilter.discriminant());

--- a/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
@@ -147,6 +147,48 @@ pub fn translate(mtl: u16) -> Result<PixelFormat, TranslateReason> {
             srgb(vk::Format::B8G8R8A8_SRGB, vk::Format::B8G8R8A8_UNORM, 4)
         }
         p::MTL_FORMAT_RGB9E5_FLOAT => linear(vk::Format::E5B9G9R9_UFLOAT_PACK32, 4),
+        // The BC block-compressed families. `bytes_per_texel` here is bytes per
+        // **4x4 block** — 8 or 16 — which is what `pixel_format::block_geometry`
+        // says and what every sizing expression on the sampled rail asks for.
+        // The uncompressed arms above are the same field with a 1x1 block, so
+        // this is not a second meaning; it is the same number with the grid
+        // stated. See `pixel_format::MTL_FORMAT_BC1_RGBA` for why the family
+        // arrives whole and `caps::device_features::DeviceFeatures::
+        // texture_compression_bc` for the one feature that gates all of it.
+        p::MTL_FORMAT_BC1_RGBA => linear(vk::Format::BC1_RGBA_UNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC1_RGBA_SRGB => srgb(
+            vk::Format::BC1_RGBA_SRGB_BLOCK,
+            vk::Format::BC1_RGBA_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+        ),
+        p::MTL_FORMAT_BC2_RGBA => linear(vk::Format::BC2_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC2_RGBA_SRGB => srgb(
+            vk::Format::BC2_SRGB_BLOCK,
+            vk::Format::BC2_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
+        p::MTL_FORMAT_BC3_RGBA => linear(vk::Format::BC3_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC3_RGBA_SRGB => srgb(
+            vk::Format::BC3_SRGB_BLOCK,
+            vk::Format::BC3_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
+        p::MTL_FORMAT_BC4_R_UNORM => linear(vk::Format::BC4_UNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC4_R_SNORM => linear(vk::Format::BC4_SNORM_BLOCK, p::BC_BLOCK_BYTES_8),
+        p::MTL_FORMAT_BC5_RG_UNORM => linear(vk::Format::BC5_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC5_RG_SNORM => linear(vk::Format::BC5_SNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC6H_RGB_FLOAT => {
+            linear(vk::Format::BC6H_SFLOAT_BLOCK, p::BC_BLOCK_BYTES_16)
+        }
+        p::MTL_FORMAT_BC6H_RGB_UFLOAT => {
+            linear(vk::Format::BC6H_UFLOAT_BLOCK, p::BC_BLOCK_BYTES_16)
+        }
+        p::MTL_FORMAT_BC7_RGBA_UNORM => linear(vk::Format::BC7_UNORM_BLOCK, p::BC_BLOCK_BYTES_16),
+        p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB => srgb(
+            vk::Format::BC7_SRGB_BLOCK,
+            vk::Format::BC7_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+        ),
         // The packed 32-bit colour family. Each Vulkan spelling is the same
         // word cut the same way as its Metal one — `A2B10G10R10` puts red in
         // the low bits as `RGB10A2Unorm` does, `A2R10G10B10` puts blue there as
@@ -213,6 +255,14 @@ pub fn sampled_pixels(
     mtl: u16,
 ) -> Result<(TexelLayout, Option<TranslateReason>, SwizzlePlan), TranslateReason> {
     let f = translate(mtl)?;
+    // The compressed families answer from the contract rather than from a
+    // `linear_vk` arm here, because `runtime::draw::texture_view` needs the same
+    // answer and cannot reach this module. One mapping, asked twice — see
+    // `pixel_format::block_compressed_layout`. Whether this host can sample it
+    // is a capability the rail carries, not a fact of the translation.
+    if let Some(layout) = pixel_format::block_compressed_layout(mtl) {
+        return Ok((layout, None, pixel_format::swizzle_identity()));
+    }
     // A format whose Metal channels do not sit identically on its Vulkan
     // channels needs a component mapping on the view to sample correctly.
     let layout = match f.linear_vk {
@@ -289,6 +339,20 @@ pub fn vk_texel_layout(layout: TexelLayout) -> vk::Format {
         TexelLayout::Rgb10a2Unorm => vk::Format::A2B10G10R10_UNORM_PACK32,
         TexelLayout::Bgr10a2Unorm => vk::Format::A2R10G10B10_UNORM_PACK32,
         TexelLayout::Rg11b10Float => vk::Format::B10G11R11_UFLOAT_PACK32,
+        // The BC families. Each Metal spelling and its Vulkan counterpart are
+        // the same block layout with the same bytes in the same order, so the
+        // guest's payload is uploaded verbatim — which is why these need no
+        // conversion arm anywhere and are admitted as one family.
+        TexelLayout::Bc1Rgba => vk::Format::BC1_RGBA_UNORM_BLOCK,
+        TexelLayout::Bc2Rgba => vk::Format::BC2_UNORM_BLOCK,
+        TexelLayout::Bc3Rgba => vk::Format::BC3_UNORM_BLOCK,
+        TexelLayout::Bc4RUnorm => vk::Format::BC4_UNORM_BLOCK,
+        TexelLayout::Bc4RSnorm => vk::Format::BC4_SNORM_BLOCK,
+        TexelLayout::Bc5RgUnorm => vk::Format::BC5_UNORM_BLOCK,
+        TexelLayout::Bc5RgSnorm => vk::Format::BC5_SNORM_BLOCK,
+        TexelLayout::Bc6hRgbFloat => vk::Format::BC6H_SFLOAT_BLOCK,
+        TexelLayout::Bc6hRgbUfloat => vk::Format::BC6H_UFLOAT_BLOCK,
+        TexelLayout::Bc7Rgba => vk::Format::BC7_UNORM_BLOCK,
     }
 }
 
@@ -306,6 +370,13 @@ pub fn srgb_texel_layout(layout: TexelLayout) -> Option<vk::Format> {
     match layout {
         TexelLayout::Rgba8 => Some(vk::Format::R8G8B8A8_SRGB),
         TexelLayout::Bgra8 => Some(vk::Format::B8G8R8A8_SRGB),
+        // The four BC families Apple gives an sRGB spelling. BC4/BC5 are
+        // single- and two-channel data rather than colour and BC6H is HDR
+        // float, so none of the three has one on either side of the boundary.
+        TexelLayout::Bc1Rgba => Some(vk::Format::BC1_RGBA_SRGB_BLOCK),
+        TexelLayout::Bc2Rgba => Some(vk::Format::BC2_SRGB_BLOCK),
+        TexelLayout::Bc3Rgba => Some(vk::Format::BC3_SRGB_BLOCK),
+        TexelLayout::Bc7Rgba => Some(vk::Format::BC7_SRGB_BLOCK),
         _ => None,
     }
 }
@@ -384,6 +455,15 @@ pub fn storage_format(format: vk::Format) -> vk::Format {
     match format {
         vk::Format::R8G8B8A8_SRGB => vk::Format::R8G8B8A8_UNORM,
         vk::Format::B8G8R8A8_SRGB => vk::Format::B8G8R8A8_UNORM,
+        // The four BC families with an sRGB spelling. Same rule one storage
+        // shape over: a compressed image's blocks are identical bytes under
+        // either qualifier, so both spellings must resolve to one allocation
+        // and differ only in the view. `the_srgb_spelling_of_a_layout_stores_
+        // that_layout` is what holds this to `srgb_texel_layout`.
+        vk::Format::BC1_RGBA_SRGB_BLOCK => vk::Format::BC1_RGBA_UNORM_BLOCK,
+        vk::Format::BC2_SRGB_BLOCK => vk::Format::BC2_UNORM_BLOCK,
+        vk::Format::BC3_SRGB_BLOCK => vk::Format::BC3_UNORM_BLOCK,
+        vk::Format::BC7_SRGB_BLOCK => vk::Format::BC7_UNORM_BLOCK,
         other => other,
     }
 }
@@ -749,6 +829,30 @@ pub fn resident_color(bgra: bool) -> vk::Format {
 /// know is indistinguishable from a block-compressed one and declines by the
 /// same name. Same argument as [`texel_layout_of`] being a search rather than a
 /// second `match`.
+/// The storage **block** grid of a Vulkan format, for the formats this table can
+/// produce.
+///
+/// [`bytes_per_texel`] with the grid stated, and derived from the same
+/// [`texel_layout_of`] search so the two cannot disagree. A caller sizing a
+/// linear buffer for an image must ask this rather than `bytes_per_texel`:
+/// multiplying a block byte count by width and height over-counts a compressed
+/// image by sixteen, which is a refusal against the guest's own correctly-sized
+/// buffer rather than a wrong image.
+///
+/// sRGB spellings fold through [`storage_format`] onto the allocation they share
+/// with their linear sibling. That fold is what covers the four `BC*_SRGB_BLOCK`
+/// formats, which a sampled bind of an sRGB compressed texture is created as.
+pub fn vk_block_geometry(format: vk::Format) -> Option<pixel_format::BlockGeometry> {
+    if let Some(layout) = texel_layout_of(storage_format(format)) {
+        return Some(layout.block());
+    }
+    Some(pixel_format::BlockGeometry {
+        width: 1,
+        height: 1,
+        bytes: bytes_per_texel(format)?,
+    })
+}
+
 pub fn bytes_per_texel(format: vk::Format) -> Option<u32> {
     if let Some(layout) = texel_layout_of(format) {
         return Some(layout.bytes_per_texel());
@@ -1026,6 +1130,21 @@ mod tests {
     ///   pinning that. Admitting it silently here would break the symmetry the
     ///   crate relies on, so it waits for the rail to gain a warning channel.
     ///
+    /// - The **BC block-compressed families** cannot cross this rail at all,
+    ///   and that is structural rather than pending a channel. A
+    ///   [`StorageImageFormat`] is what a compute *storage* binding is created
+    ///   as, and Vulkan has no block-compressed storage-image format — a shader
+    ///   cannot write a block. The compute rail routes its sampled textures
+    ///   through that same selector, so a compressed texture sampled inside a
+    ///   dispatch is refused by name. Giving it a rail of its own means a
+    ///   compute sampled path that does not go through the storage selector,
+    ///   which is a change to that rail and not to this table.
+    ///
+    ///   Measured on the workload that brought the family in: Asphalt 8 samples
+    ///   its BC3 textures from **fragment** shaders only, so this refusal cost
+    ///   nothing there. A guest that samples one in a dispatch loses that
+    ///   dispatch's texture and says so.
+    ///
     /// The converse is deliberately not asserted: this rail carries the integer
     /// and packed formats a compute shader reads and [`sampled_pixels`] has no
     /// [`TexelLayout`] for, because that one answers a CPU-upload byte order and
@@ -1036,6 +1155,23 @@ mod tests {
             (p::MTL_FORMAT_A8_UNORM, "needs a component mapping"),
             (p::MTL_FORMAT_RGBA8_UNORM_SRGB, "would downgrade unrecorded"),
             (p::MTL_FORMAT_BGRA8_UNORM_SRGB, "would downgrade unrecorded"),
+            (p::MTL_FORMAT_BC1_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC1_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC2_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC2_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC3_RGBA, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC3_RGBA_SRGB, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC4_R_UNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC4_R_SNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC5_RG_UNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC5_RG_SNORM, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC6H_RGB_FLOAT, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC6H_RGB_UFLOAT, "no block-compressed storage image exists"),
+            (p::MTL_FORMAT_BC7_RGBA_UNORM, "no block-compressed storage image exists"),
+            (
+                p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+                "no block-compressed storage image exists",
+            ),
         ];
 
         let mut refused = Vec::new();
@@ -1233,6 +1369,94 @@ mod tests {
             4,
             TransferFunction::Linear,
         ),
+        // The BC families. The width column is bytes per 4x4 **block** for
+        // these, which is what `pixel_format::block_geometry` says and what the
+        // sampled rail sizes rows and images from; the uncompressed rows above
+        // are the same field with a 1x1 block.
+        (
+            p::MTL_FORMAT_BC1_RGBA,
+            vk::Format::BC1_RGBA_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC1_RGBA_SRGB,
+            vk::Format::BC1_RGBA_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC2_RGBA,
+            vk::Format::BC2_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC2_RGBA_SRGB,
+            vk::Format::BC2_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC3_RGBA,
+            vk::Format::BC3_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC3_RGBA_SRGB,
+            vk::Format::BC3_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
+        (
+            p::MTL_FORMAT_BC4_R_UNORM,
+            vk::Format::BC4_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC4_R_SNORM,
+            vk::Format::BC4_SNORM_BLOCK,
+            p::BC_BLOCK_BYTES_8,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC5_RG_UNORM,
+            vk::Format::BC5_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC5_RG_SNORM,
+            vk::Format::BC5_SNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC6H_RGB_FLOAT,
+            vk::Format::BC6H_SFLOAT_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC6H_RGB_UFLOAT,
+            vk::Format::BC6H_UFLOAT_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC7_RGBA_UNORM,
+            vk::Format::BC7_UNORM_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Linear,
+        ),
+        (
+            p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+            vk::Format::BC7_SRGB_BLOCK,
+            p::BC_BLOCK_BYTES_16,
+            TransferFunction::Srgb,
+        ),
         (
             p::MTL_FORMAT_R16_UNORM,
             vk::Format::R16_UNORM,
@@ -1334,12 +1558,19 @@ mod tests {
     /// The texel size this module reports is the decode contract's, not a
     /// second opinion — the drift `byte_size`-beside-`vk_format` was written to
     /// prevent.
+    ///
+    /// Compared against the contract's **block** size rather than its
+    /// bytes-per-texel. For every uncompressed format those are the same number
+    /// — the block is 1x1 — and for the BC families only the block form exists,
+    /// because a BC1 texel is half a byte and `bytes_per_pixel` says `None` on
+    /// purpose. So this is the stronger reading of the same invariant, not a
+    /// weakened one.
     #[test]
     fn texel_size_agrees_with_the_decode_contract() {
         for (mtl, _, _, _) in EXPECTED {
             assert_eq!(
                 Some(translate(*mtl).unwrap().bytes_per_texel),
-                pixel_format::bytes_per_pixel(*mtl),
+                pixel_format::block_geometry(*mtl).map(|block| block.bytes),
                 "MTL {mtl:#x}"
             );
         }
@@ -1917,6 +2148,27 @@ mod tests {
                 p::MTL_FORMAT_RGB10A2_UNORM,
                 p::MTL_FORMAT_RG11B10_FLOAT,
                 p::MTL_FORMAT_BGR10A2_UNORM,
+                // The BC block-compressed families, in `EXPECTED`'s order.
+                // Named unconditionally here because `sampled_pixels` is a
+                // decode fact: whether this host can sample one is
+                // `engine::supports_block_compressed_sampled`, which the rail
+                // carries in `NativeUploads::block_compressed`. A host without
+                // the feature refuses the bind by name — it does not make the
+                // format untranslatable.
+                p::MTL_FORMAT_BC1_RGBA,
+                p::MTL_FORMAT_BC1_RGBA_SRGB,
+                p::MTL_FORMAT_BC2_RGBA,
+                p::MTL_FORMAT_BC2_RGBA_SRGB,
+                p::MTL_FORMAT_BC3_RGBA,
+                p::MTL_FORMAT_BC3_RGBA_SRGB,
+                p::MTL_FORMAT_BC4_R_UNORM,
+                p::MTL_FORMAT_BC4_R_SNORM,
+                p::MTL_FORMAT_BC5_RG_UNORM,
+                p::MTL_FORMAT_BC5_RG_SNORM,
+                p::MTL_FORMAT_BC6H_RGB_FLOAT,
+                p::MTL_FORMAT_BC6H_RGB_UFLOAT,
+                p::MTL_FORMAT_BC7_RGBA_UNORM,
+                p::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
                 // The ten-bit biplanar video planes and the four-channel
                 // sixteen-bit unorm. These three were carried by `translate`
                 // and by the layout table but were absent from `EXPECTED`, so
@@ -1956,6 +2208,19 @@ mod tests {
                 p::MTL_FORMAT_RGBA8_UNORM_SRGB,
                 p::MTL_FORMAT_BGRA8_UNORM,
                 p::MTL_FORMAT_BGRA8_UNORM_SRGB,
+                // The first packed 32-bit colour attachment, and the first one
+                // admitted for a *game* rather than for the window server. An
+                // `'l10r'` IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`
+                // — is what Asphalt 8 renders into on a macos-13 x86/Vulkan
+                // boot, and every draw of it failed at
+                // `draw::render_target`'s `rt_type4_base_format` until the
+                // FourCC and `render_target_bpp` both named it.
+                //
+                // Unlike every other member here this one is not a format
+                // Vulkan mandates for `COLOR_ATTACHMENT_BIT`, so a host may
+                // decline it and this rail is where that decline appears. The
+                // NVIDIA host it was measured on advertises it.
+                p::MTL_FORMAT_BGR10A2_UNORM,
                 // Admitted since the two arms became one answer. The contract
                 // has said a half-float render target is renderable since one
                 // could be created at that format; only this side still refused

--- a/crates/reims-vgpu/src/contract/extent.rs
+++ b/crates/reims-vgpu/src/contract/extent.rs
@@ -126,6 +126,35 @@ pub fn tight_layered_image_bytes(
         .ok()
 }
 
+/// [`tight_layered_image_bytes`] over a storage **block** grid.
+///
+/// The same product with the grid stated, so it covers a block-compressed image
+/// as well as an uncompressed one: an uncompressed block is 1x1 and its `bytes`
+/// is the bytes-per-texel, so this reduces to the sibling above for every format
+/// that has one. Blocks round *up* on both axes, which is the contract — a 2x2
+/// BC3 level still occupies one whole sixteen-byte block.
+///
+/// Zero on either axis is `None` for [`tight_image_bytes`]'s reason: a zero
+/// length passes every "does the guest's buffer hold this" check there is.
+pub fn tight_layered_block_bytes(
+    width: u32,
+    height: u32,
+    layers: u32,
+    block: crate::contract::pixel_format::BlockGeometry,
+) -> Option<usize> {
+    if layers == 0 || width == 0 || height == 0 || block.bytes == 0 {
+        return None;
+    }
+    let across = u64::from(block.blocks_across(width));
+    let down = u64::from(block.block_rows(height));
+    across
+        .checked_mul(down)?
+        .checked_mul(u64::from(block.bytes))?
+        .checked_mul(u64::from(layers))?
+        .try_into()
+        .ok()
+}
+
 /// [`tight_image_bytes`] together with the row stride it implies, as one pair.
 ///
 /// For the callers that hand a buffer to a texel-copy API. Such a call is given

--- a/crates/reims-vgpu/src/contract/pixel_format.rs
+++ b/crates/reims-vgpu/src/contract/pixel_format.rs
@@ -131,6 +131,232 @@ pub const MTL_FORMAT_BGR10A2_UNORM: u16 = 0x5e;
 /// answered `None`, so every path that asks about a texel width refused it, not
 /// just the sampled one.
 pub const MTL_FORMAT_RGBA16_UNORM: u16 = 0x6e;
+/// The BC (a.k.a. DXT / S3TC) block-compressed families, as Apple numbers them.
+///
+/// Every one of these stores a **4x4 block of texels** in a fixed 8 or 16 bytes,
+/// which is what separates them from everything else in this file: there is no
+/// bytes-per-texel for a BC1 texel — it is half a byte — so
+/// [`bytes_per_pixel`] deliberately answers `None` for all of them and
+/// [`block_geometry`] is the accessor that can describe them. That `None` is
+/// load-bearing: it is what keeps a BC format out of every rail that sizes work
+/// per texel, which is every rail except the sampled bind.
+///
+/// # Why the whole family arrives at once
+///
+/// Elsewhere this file adds members on measurement — `RG8_UNORM` is still absent
+/// from [`render_target_bpp`] for exactly that reason. This family is added
+/// whole, and the difference is real rather than convenience:
+///
+/// * **One capability covers all of them.** Vulkan gates BC1 through BC7 behind
+///   the single `textureCompressionBC` feature bit, and Metal behind the single
+///   `supportsBCTextureCompression`. There is no per-member capability to
+///   measure, so a member left out is refused by *this table* rather than by the
+///   host.
+/// * **There is no per-member conversion to write.** The guest's bytes are the
+///   `VK_FORMAT_BC*_BLOCK` payload already, so a member costs one row in each
+///   mapping and nothing else. The three conversion arms `render_target_bpp`'s
+///   doc obliges a *renderable* format to satisfy do not arise: a BC format is
+///   sampled-only, and every other rail refuses it by name.
+/// * **A partial family is the shape that bites later.** A game ships BC1 for
+///   opaque albedo, BC3 for alpha, BC4/BC5 for single- and two-channel maps and
+///   BC7 for anything modern, in one asset pipeline. Admitting the one that was
+///   measured and refusing its four siblings buys a second black-texture report.
+///
+/// # What was measured
+///
+/// `BC3_RGBA` (`0x86`), on a driven macos-13 x86/Vulkan boot running Asphalt 8:
+/// six distinct textures, and the 12 419 draws that sampled them were the only
+/// draws still failing once the `'l10r'` attachment and the pipeline-tag
+/// refusals were fixed. Its geometry is the confirmation and it is exact — the
+/// guest's own descriptors read `L0=1024x1024 bpr=4096`, which is
+/// `(1024/4) * 16`, with `alloc=1400832` for the eleven-level pyramid of a
+/// 1 MiB base; and `L0=64x64 bpr=256`, which is `(64/4) * 16`. The guest's SDK
+/// names `MTLPixelFormatBC3_RGBA = 134` and its paravirt device answers
+/// `supportsBCTextureCompression = 1`.
+pub const MTL_FORMAT_BC1_RGBA: u16 = 130;
+/// sRGB spelling of [`MTL_FORMAT_BC1_RGBA`]. Identical stored bytes; the
+/// qualifier is the conversion the sampler applies, which is why it folds onto
+/// the same [`TexelLayout`] and is carried as a transfer function instead.
+pub const MTL_FORMAT_BC1_RGBA_SRGB: u16 = 131;
+/// `MTLPixelFormatBC2_RGBA` — 16 bytes a block, four-bit explicit alpha.
+pub const MTL_FORMAT_BC2_RGBA: u16 = 132;
+/// sRGB spelling of [`MTL_FORMAT_BC2_RGBA`].
+pub const MTL_FORMAT_BC2_RGBA_SRGB: u16 = 133;
+/// `MTLPixelFormatBC3_RGBA` — 16 bytes a block, interpolated alpha. DXT5, and
+/// the member this family was measured through.
+pub const MTL_FORMAT_BC3_RGBA: u16 = 134;
+/// sRGB spelling of [`MTL_FORMAT_BC3_RGBA`].
+pub const MTL_FORMAT_BC3_RGBA_SRGB: u16 = 135;
+/// `MTLPixelFormatBC4_RUnorm` — one channel, 8 bytes a block.
+pub const MTL_FORMAT_BC4_R_UNORM: u16 = 140;
+/// `MTLPixelFormatBC4_RSnorm` — the signed twin of [`MTL_FORMAT_BC4_R_UNORM`].
+pub const MTL_FORMAT_BC4_R_SNORM: u16 = 141;
+/// `MTLPixelFormatBC5_RGUnorm` — two channels, 16 bytes a block. The usual
+/// tangent-space normal-map encoding.
+pub const MTL_FORMAT_BC5_RG_UNORM: u16 = 142;
+/// `MTLPixelFormatBC5_RGSnorm` — the signed twin of [`MTL_FORMAT_BC5_RG_UNORM`].
+pub const MTL_FORMAT_BC5_RG_SNORM: u16 = 143;
+/// `MTLPixelFormatBC6H_RGBFloat` — three signed half-float channels, 16 bytes a
+/// block. An HDR source format.
+pub const MTL_FORMAT_BC6H_RGB_FLOAT: u16 = 150;
+/// `MTLPixelFormatBC6H_RGBUfloat` — the unsigned twin of
+/// [`MTL_FORMAT_BC6H_RGB_FLOAT`].
+pub const MTL_FORMAT_BC6H_RGB_UFLOAT: u16 = 151;
+/// `MTLPixelFormatBC7_RGBAUnorm` — 16 bytes a block, the modern four-channel
+/// mode-switching encoding.
+pub const MTL_FORMAT_BC7_RGBA_UNORM: u16 = 152;
+/// sRGB spelling of [`MTL_FORMAT_BC7_RGBA_UNORM`].
+pub const MTL_FORMAT_BC7_RGBA_UNORM_SRGB: u16 = 153;
+
+/// Side of a BC block, in texels. Every BC family uses the same 4x4 grid.
+pub const BC_BLOCK_SIDE: u32 = 4;
+/// Bytes one block occupies in the two BC weight classes.
+pub const BC_BLOCK_BYTES_8: u32 = 8;
+/// The 16-byte class — everything that carries explicit alpha or two channels.
+pub const BC_BLOCK_BYTES_16: u32 = 16;
+/// A 4x4 block of BC1 is 64 texels' worth of colour in 8 bytes, and of BC3 in
+/// 16. Stated as a relation so a wrong constant cannot look right.
+const _: () = assert!(
+    BC_BLOCK_BYTES_16 == BC_BLOCK_BYTES_8 * 2
+        && BC_BLOCK_SIDE * BC_BLOCK_SIDE == 16
+        && BC_BLOCK_BYTES_8 * 2 == BC_BLOCK_SIDE * BC_BLOCK_SIDE
+);
+
+/// The texel grid one addressable unit of storage covers, and its size.
+///
+/// Uncompressed formats have a 1x1 block whose `bytes` is [`bytes_per_pixel`],
+/// so this is not a second vocabulary for them — it is the same number with the
+/// grid stated. That is what lets [`tight_row_bytes`] be one expression for
+/// both families instead of a branch, and what
+/// `a_block_geometry_agrees_with_the_texel_table` holds honest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockGeometry {
+    /// Texels a block spans horizontally.
+    pub width: u32,
+    /// Texels a block spans vertically.
+    pub height: u32,
+    /// Bytes one block occupies.
+    pub bytes: u32,
+}
+
+impl BlockGeometry {
+    /// Blocks needed to cover `texels` along one axis, rounding up.
+    ///
+    /// The rounding is the contract and not a convenience: a 2x2 BC3 mip level
+    /// still occupies one whole 16-byte block, so a caller that divided down
+    /// would read four bytes of a level and none of the tail of a pyramid.
+    pub const fn blocks_for(divisor: u32, texels: u32) -> u32 {
+        if divisor == 0 {
+            return 0;
+        }
+        texels.div_ceil(divisor)
+    }
+
+    /// Blocks in one row of a `texels`-wide image.
+    pub const fn blocks_across(self, texels: u32) -> u32 {
+        Self::blocks_for(self.width, texels)
+    }
+
+    /// Rows of blocks in a `texels`-tall image — what a row loop over this
+    /// format must count, rather than the texel height.
+    pub const fn block_rows(self, texels: u32) -> u32 {
+        Self::blocks_for(self.height, texels)
+    }
+
+    /// Whether this describes a compressed format, i.e. a block wider or taller
+    /// than one texel.
+    pub const fn is_compressed(self) -> bool {
+        self.width > 1 || self.height > 1
+    }
+}
+
+/// Bytes one BC block of `format` occupies, or `None` if it is not a BC format.
+///
+/// The one place the family membership is spelled. Everything else asks
+/// [`block_geometry`] or [`is_block_compressed`].
+const fn bc_block_bytes(format: u16) -> Option<u32> {
+    Some(match format {
+        MTL_FORMAT_BC1_RGBA
+        | MTL_FORMAT_BC1_RGBA_SRGB
+        | MTL_FORMAT_BC4_R_UNORM
+        | MTL_FORMAT_BC4_R_SNORM => BC_BLOCK_BYTES_8,
+        MTL_FORMAT_BC2_RGBA
+        | MTL_FORMAT_BC2_RGBA_SRGB
+        | MTL_FORMAT_BC3_RGBA
+        | MTL_FORMAT_BC3_RGBA_SRGB
+        | MTL_FORMAT_BC5_RG_UNORM
+        | MTL_FORMAT_BC5_RG_SNORM
+        | MTL_FORMAT_BC6H_RGB_FLOAT
+        | MTL_FORMAT_BC6H_RGB_UFLOAT
+        | MTL_FORMAT_BC7_RGBA_UNORM
+        | MTL_FORMAT_BC7_RGBA_UNORM_SRGB => BC_BLOCK_BYTES_16,
+        _ => return None,
+    })
+}
+
+/// Whether `format` stores texels in compressed blocks rather than one at a time.
+pub const fn is_block_compressed(format: u16) -> bool {
+    bc_block_bytes(format).is_some()
+}
+
+/// The [`TexelLayout`] a block-compressed guest format's bytes are already in,
+/// or `None` for an uncompressed one.
+///
+/// **The single mapping**, consulted by both the backend-independent sampled
+/// loaders in `runtime::draw::texture_view` and by
+/// `backend::vulkan::translate::pixel::sampled_pixels`. The uncompressed
+/// families reach their layout through [`sampled_class`], whose vocabulary is
+/// deliberately narrow and has no room for a block; rather than widen it or keep
+/// a second table in the backend, the compressed families are answered here and
+/// both sides ask.
+///
+/// The four sRGB spellings fold onto their linear sibling's layout, as
+/// `RGBA8Unorm_sRGB` folds onto `Rgba8`: identical stored bytes, and the
+/// qualifier travels as [`SampledByteFormat`]'s source format so the bind picks
+/// the `_SRGB_BLOCK` view.
+///
+/// Saying `Some` is **not** a claim that this host can sample it. That is a
+/// capability — `engine::supports_block_compressed_sampled` — and the rail
+/// carries it in `NativeUploads::block_compressed`. Naming the layout
+/// unconditionally is what makes the refusal a typed one rather than an
+/// unrecognised format.
+pub fn block_compressed_layout(format: u16) -> Option<TexelLayout> {
+    Some(match format {
+        MTL_FORMAT_BC1_RGBA | MTL_FORMAT_BC1_RGBA_SRGB => TexelLayout::Bc1Rgba,
+        MTL_FORMAT_BC2_RGBA | MTL_FORMAT_BC2_RGBA_SRGB => TexelLayout::Bc2Rgba,
+        MTL_FORMAT_BC3_RGBA | MTL_FORMAT_BC3_RGBA_SRGB => TexelLayout::Bc3Rgba,
+        MTL_FORMAT_BC4_R_UNORM => TexelLayout::Bc4RUnorm,
+        MTL_FORMAT_BC4_R_SNORM => TexelLayout::Bc4RSnorm,
+        MTL_FORMAT_BC5_RG_UNORM => TexelLayout::Bc5RgUnorm,
+        MTL_FORMAT_BC5_RG_SNORM => TexelLayout::Bc5RgSnorm,
+        MTL_FORMAT_BC6H_RGB_FLOAT => TexelLayout::Bc6hRgbFloat,
+        MTL_FORMAT_BC6H_RGB_UFLOAT => TexelLayout::Bc6hRgbUfloat,
+        MTL_FORMAT_BC7_RGBA_UNORM | MTL_FORMAT_BC7_RGBA_UNORM_SRGB => TexelLayout::Bc7Rgba,
+        _ => return None,
+    })
+}
+
+/// The storage grid `format` addresses, or `None` for a format this crate has
+/// no width for at all.
+///
+/// Derived from [`bytes_per_pixel`] for the uncompressed families rather than
+/// re-listed, so the two cannot disagree — the second spelling is the bug this
+/// avoids having.
+pub fn block_geometry(format: u16) -> Option<BlockGeometry> {
+    if let Some(bytes) = bc_block_bytes(format) {
+        return Some(BlockGeometry {
+            width: BC_BLOCK_SIDE,
+            height: BC_BLOCK_SIDE,
+            bytes,
+        });
+    }
+    Some(BlockGeometry {
+        width: 1,
+        height: 1,
+        bytes: bytes_per_pixel(format)?,
+    })
+}
+
 pub const MTL_FORMAT_RGBA16_UINT: u16 = 0x71;
 pub const MTL_FORMAT_RGBA16_FLOAT: u16 = 0x73;
 pub const MTL_FORMAT_RGBA32_UINT: u16 = 0x7b;
@@ -192,6 +418,18 @@ pub enum SampledClass {
     Bgra8Unorm,
     Rgba16Float,
     Rg16Float,
+    /// The packed 32-bit word `MTLPixelFormatBGR10A2Unorm` stores a texel in.
+    ///
+    /// Declared for the cross-check and not for a CPU upload rail. This class is
+    /// how [`store_texel_order`]'s admission of that format is held against an
+    /// independent statement of the same byte layout, which is what
+    /// `a_byte_copy_destination_is_the_texel_every_other_table_agrees_it_is`
+    /// asks. `runtime::draw::texture_view`'s `linear_native_upload_format`
+    /// answers `None` for it, so a **sampled** bind still takes the native
+    /// packed rail `translate::pixel::sampled_pixels` has carried all along;
+    /// nothing here moves such a bind to the CPU, which could not serve it
+    /// anyway — its channels do not sit on byte boundaries.
+    Bgr10a2Unorm,
 }
 
 /// The byte layout of one guest texel on the sampled rails, independent of any
@@ -305,6 +543,43 @@ pub enum TexelLayout {
     /// sampled natively as `B10G11R11_UFLOAT_PACK32`. An HDR-intermediate
     /// colour format, native for the same reason as its two neighbours.
     Rg11b10Float,
+    // The BC block-compressed layouts. Every one is 4x4 texels in 8 or 16 bytes,
+    // so `bytes_per_texel` answers about a **block** for these and
+    // `block_geometry` is what a caller sizing an image must ask — read that
+    // method's doc before using either on one of these.
+    //
+    // They are the only layouts here that no CPU rail can serve: decoding a
+    // block needs a decompressor this crate does not have and does not want, so
+    // `has_cpu_loader_arm` is false, the two `rgba8` conversions refuse, and the
+    // bind is native or nothing. Nothing is a typed refusal, which is why the
+    // capability gate lives at `translate::pixel::sampled_pixels`.
+    //
+    // The sRGB spellings of BC1/BC2/BC3/BC7 fold onto these same layouts, as
+    // `Rgba8`'s sRGB spelling folds onto `Rgba8`: the stored bytes are
+    // identical and the qualifier is a sampler conversion carried by
+    // `SampledByteFormat`'s source format.
+    /// 8 bytes per 4x4 block — BC1/DXT1, three colour channels plus one bit of
+    /// alpha, sampled as `VK_FORMAT_BC1_RGBA_UNORM_BLOCK`.
+    Bc1Rgba,
+    /// 16 bytes per 4x4 block — BC2/DXT3, four-bit explicit alpha.
+    Bc2Rgba,
+    /// 16 bytes per 4x4 block — BC3/DXT5, interpolated alpha. The member a guest
+    /// was measured binding; see [`MTL_FORMAT_BC3_RGBA`].
+    Bc3Rgba,
+    /// 8 bytes per 4x4 block — BC4, one unsigned channel.
+    Bc4RUnorm,
+    /// 8 bytes per 4x4 block — BC4, one signed channel.
+    Bc4RSnorm,
+    /// 16 bytes per 4x4 block — BC5, two unsigned channels.
+    Bc5RgUnorm,
+    /// 16 bytes per 4x4 block — BC5, two signed channels.
+    Bc5RgSnorm,
+    /// 16 bytes per 4x4 block — BC6H, three signed half-float channels (HDR).
+    Bc6hRgbFloat,
+    /// 16 bytes per 4x4 block — BC6H, three unsigned half-float channels.
+    Bc6hRgbUfloat,
+    /// 16 bytes per 4x4 block — BC7, four channels, mode-switching.
+    Bc7Rgba,
 }
 
 impl TexelLayout {
@@ -331,6 +606,16 @@ impl TexelLayout {
         Self::Rgb10a2Unorm,
         Self::Bgr10a2Unorm,
         Self::Rg11b10Float,
+        Self::Bc1Rgba,
+        Self::Bc2Rgba,
+        Self::Bc3Rgba,
+        Self::Bc4RUnorm,
+        Self::Bc4RSnorm,
+        Self::Bc5RgUnorm,
+        Self::Bc5RgSnorm,
+        Self::Bc6hRgbFloat,
+        Self::Bc6hRgbUfloat,
+        Self::Bc7Rgba,
     ];
 
     /// This layout's position in [`Self::ALL`], so a host-side table can be an
@@ -357,10 +642,164 @@ impl TexelLayout {
             Self::Rgb10a2Unorm => 11,
             Self::Bgr10a2Unorm => 12,
             Self::Rg11b10Float => 13,
+            Self::Bc1Rgba => 14,
+            Self::Bc2Rgba => 15,
+            Self::Bc3Rgba => 16,
+            Self::Bc4RUnorm => 17,
+            Self::Bc4RSnorm => 18,
+            Self::Bc5RgUnorm => 19,
+            Self::Bc5RgSnorm => 20,
+            Self::Bc6hRgbFloat => 21,
+            Self::Bc6hRgbUfloat => 22,
+            Self::Bc7Rgba => 23,
         }
     }
 
-    /// Bytes occupied by one texel in guest linear storage.
+    /// The texel grid one unit of this layout's storage covers.
+    ///
+    /// 1x1 for every uncompressed layout, 4x4 for the BC families. A caller
+    /// sizing an image or striding a row must ask this rather than
+    /// [`Self::bytes_per_texel`], which for a BC layout answers about a block
+    /// and would under-count a row by four and an image by sixteen.
+    pub fn block(self) -> BlockGeometry {
+        let side = if self.is_block_compressed() {
+            BC_BLOCK_SIDE
+        } else {
+            1
+        };
+        BlockGeometry {
+            width: side,
+            height: side,
+            bytes: self.bytes_per_texel(),
+        }
+    }
+
+    /// Whether this layout stores a 4x4 block per addressable unit.
+    ///
+    /// Exhaustive rather than a range test on [`Self::index`]: the positions are
+    /// an implementation detail of the table above and a new uncompressed layout
+    /// appended after the BC block would silently join the compressed set.
+    pub const fn is_block_compressed(self) -> bool {
+        match self {
+            Self::Rgba8
+            | Self::Bgra8
+            | Self::R8
+            | Self::Rg8
+            | Self::R16Float
+            | Self::R32Float
+            | Self::R16Unorm
+            | Self::Rg16Unorm
+            | Self::Rgba16Float
+            | Self::Rg16Float
+            | Self::Rgba16Unorm
+            | Self::Rgb10a2Unorm
+            | Self::Bgr10a2Unorm
+            | Self::Rg11b10Float => false,
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => true,
+        }
+    }
+
+    /// How many of [`Self::ALL`] address one texel at a time.
+    ///
+    /// Counted from `ALL` rather than written down, so it cannot fall behind the
+    /// vocabulary. It exists because `backend::vulkan::engine`'s
+    /// `DeviceCapabilitySnapshot` packs **two** per-layout bitmasks into one
+    /// atomically-published `u64`, and two masks of the full vocabulary no
+    /// longer fit — the `const` assertion there is what said so when the BC
+    /// families were added, which is the whole reason that assertion exists.
+    ///
+    /// Narrowing the masks rather than widening the word is right on the merits
+    /// and not only on the bit budget: both masks answer questions a
+    /// block-compressed layout is never asked. One is colour-attachment blend,
+    /// and no BC format is a colour attachment on any host. The other is
+    /// sampled linear filtering, which Vulkan's mandatory-format table
+    /// *requires* for every BC format on a device that enables
+    /// `textureCompressionBC` — so there is nothing to query.
+    pub const UNCOMPRESSED_COUNT: usize = {
+        let mut count = 0;
+        let mut i = 0;
+        while i < Self::ALL.len() {
+            if !Self::ALL[i].is_block_compressed() {
+                count += 1;
+            }
+            i += 1;
+        }
+        count
+    };
+
+    /// This layout's position among the uncompressed layouts, or `None` for a
+    /// block-compressed one.
+    ///
+    /// Walks [`Self::ALL`] rather than keeping a second ordering, for
+    /// [`Self::UNCOMPRESSED_COUNT`]'s reason: one list, one order, nothing to
+    /// drift.
+    pub fn uncompressed_index(self) -> Option<usize> {
+        if self.is_block_compressed() {
+            return None;
+        }
+        let mut index = 0;
+        for layout in Self::ALL {
+            if *layout == self {
+                return Some(index);
+            }
+            if !layout.is_block_compressed() {
+                index += 1;
+            }
+        }
+        None
+    }
+
+    /// Bytes one tightly-packed row of `width` texels of this layout occupies.
+    ///
+    /// One row of **blocks** for a compressed layout, so a caller comparing a
+    /// guest row stride against "one tight row of the upload layout" gets the
+    /// right answer for both families from one expression. `None` on overflow.
+    pub fn tight_row_bytes(self, width: u32) -> Option<u32> {
+        let block = self.block();
+        block.blocks_across(width).checked_mul(block.bytes)
+    }
+
+    /// Rows a copy of a `height`-tall image of this layout must walk — a quarter
+    /// of the texel height, rounded up, for a compressed layout.
+    pub fn tight_row_count(self, height: u32) -> u32 {
+        self.block().block_rows(height)
+    }
+
+    /// Bytes a whole `width` x `height` image of this layout occupies, tightly
+    /// packed.
+    ///
+    /// The one sizing expression for both families. `None` on overflow, so a
+    /// caller declines rather than allocating a wrapped length.
+    pub fn image_bytes(self, width: u32, height: u32) -> Option<u64> {
+        let block = self.block();
+        let across = u64::from(block.blocks_across(width));
+        let down = u64::from(block.block_rows(height));
+        across.checked_mul(down)?.checked_mul(u64::from(block.bytes))
+    }
+
+    /// Bytes occupied by one texel in guest linear storage — or by one **4x4
+    /// block**, for the BC layouts.
+    ///
+    /// The name is kept because ninety-odd call sites use it and every one of
+    /// them is on a rail a BC layout cannot reach: a BC format has no
+    /// [`render_target_bpp`], no [`storage_selector`], no [`sampled_class`] and
+    /// no [`bytes_per_pixel`], so it is refused before any of them.
+    /// `a_bc_format_is_refused_by_every_rail_but_the_sampled_bind` is that
+    /// argument as a test rather than as this paragraph.
+    ///
+    /// For anything that sizes storage, ask [`Self::image_bytes`] or
+    /// [`Self::block`]. Multiplying this by width and height is correct for the
+    /// uncompressed layouts and wrong by sixteen for the BC ones.
     pub fn bytes_per_texel(self) -> u32 {
         match self {
             Self::Rgba8 | Self::Bgra8 => RGBA8_BPP,
@@ -372,6 +811,17 @@ impl TexelLayout {
             Self::Rg16Unorm => RG16_BPP,
             Self::Rgba16Float => RGBA16F_BPP,
             Self::Rg16Float => RG16F_BPP,
+            Self::Bc1Rgba => BC_BLOCK_BYTES_8,
+            Self::Bc2Rgba => BC_BLOCK_BYTES_16,
+            Self::Bc3Rgba => BC_BLOCK_BYTES_16,
+            Self::Bc4RUnorm => BC_BLOCK_BYTES_8,
+            Self::Bc4RSnorm => BC_BLOCK_BYTES_8,
+            Self::Bc5RgUnorm => BC_BLOCK_BYTES_16,
+            Self::Bc5RgSnorm => BC_BLOCK_BYTES_16,
+            Self::Bc6hRgbFloat => BC_BLOCK_BYTES_16,
+            Self::Bc6hRgbUfloat => BC_BLOCK_BYTES_16,
+            Self::Bc7Rgba => BC_BLOCK_BYTES_16,
+
             Self::Rgba16Unorm => RGBA16_BPP,
             Self::Rgb10a2Unorm | Self::Bgr10a2Unorm | Self::Rg11b10Float => RGBA8_BPP,
         }
@@ -430,6 +880,22 @@ impl TexelLayout {
             | Self::Rgb10a2Unorm
             | Self::Bgr10a2Unorm
             | Self::Rg11b10Float => false,
+            // No CPU rail can serve a BC layout, and none should be written:
+            // decoding a block needs a decompressor, and a decompressed block
+            // is not the guest's bytes. `false` here is what keeps a cost
+            // threshold from routing one to a loader that does not exist — the
+            // native bind or a typed refusal are the only two answers.
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => false,
         }
     }
 
@@ -462,6 +928,20 @@ impl TexelLayout {
             | Self::Rgb10a2Unorm
             | Self::Bgr10a2Unorm
             | Self::Rg11b10Float => false,
+            // Vacuously false: there is no arm, so no arm loses anything.
+            // `has_cpu_loader_arm` is the question a caller should be asking
+            // about these, and it answers `false`.
+            Self::Bc1Rgba
+            | Self::Bc2Rgba
+            | Self::Bc3Rgba
+            | Self::Bc4RUnorm
+            | Self::Bc4RSnorm
+            | Self::Bc5RgUnorm
+            | Self::Bc5RgSnorm
+            | Self::Bc6hRgbFloat
+            | Self::Bc6hRgbUfloat
+            | Self::Bc7Rgba
+            => false,
         }
     }
 
@@ -501,7 +981,11 @@ impl TexelLayout {
     /// four-byte ones, and they answer different questions. A three-byte
     /// `RGB8_SRGB` layout would separate them.
     pub fn has_srgb_encoding(self) -> bool {
-        matches!(self, Self::Rgba8 | Self::Bgra8)
+        matches!(
+            self,
+            Self::Rgba8 | Self::Bgra8 | Self::Bc1Rgba | Self::Bc2Rgba | Self::Bc3Rgba
+                | Self::Bc7Rgba
+        )
     }
 }
 
@@ -889,7 +1373,17 @@ pub fn blit_aspect_bytes_per_pixel(format: u16, aspect: BlitAspect) -> Option<u3
             }
             Some(1)
         }
-        BlitAspect::Full => bytes_per_pixel(format),
+        // The whole texel — or the whole **block**, for a compressed format,
+        // whose addressable unit is what a copy strides by. Derived from
+        // `block_geometry` rather than `bytes_per_pixel` so the two families are
+        // one expression: an uncompressed block is 1x1 and its `bytes` *is* the
+        // bytes-per-texel, so this is the same number it always was for them.
+        //
+        // A caller taking this for a compressed format is being told the size of
+        // one block and must stride in blocks. `runtime::blit_exec`'s
+        // texture-to-texture copy is the one rail that does; every other blit
+        // rail refuses a compressed format by name.
+        BlitAspect::Full => block_geometry(format).map(|block| block.bytes),
     }
 }
 
@@ -1076,7 +1570,16 @@ pub fn insert_plane_row(
 pub fn is_srgb(format: u16) -> bool {
     matches!(
         format,
-        MTL_FORMAT_RGBA8_UNORM_SRGB | MTL_FORMAT_BGRA8_UNORM_SRGB
+        MTL_FORMAT_RGBA8_UNORM_SRGB
+            | MTL_FORMAT_BGRA8_UNORM_SRGB
+            // The four BC families Apple gives an sRGB spelling. The fold this
+            // predicate exists beside is the same one: `block_compressed_layout`
+            // maps both spellings of each onto one layout, so the qualifier is
+            // recoverable only from here.
+            | MTL_FORMAT_BC1_RGBA_SRGB
+            | MTL_FORMAT_BC2_RGBA_SRGB
+            | MTL_FORMAT_BC3_RGBA_SRGB
+            | MTL_FORMAT_BC7_RGBA_UNORM_SRGB
     )
 }
 
@@ -1120,6 +1623,7 @@ pub fn sampled_class(format: u16) -> Option<SampledClass> {
         MTL_FORMAT_BGRA8_UNORM | MTL_FORMAT_BGRA8_UNORM_SRGB => SampledClass::Bgra8Unorm,
         MTL_FORMAT_RGBA16_FLOAT => SampledClass::Rgba16Float,
         MTL_FORMAT_RG16_FLOAT => SampledClass::Rg16Float,
+        MTL_FORMAT_BGR10A2_UNORM => SampledClass::Bgr10a2Unorm,
         _ => return None,
     })
 }
@@ -1196,6 +1700,26 @@ pub fn storage_selector(format: u16) -> Option<StorageImageSelector> {
 /// one, because a one-byte texel had never been a render target: the readback
 /// narrow, the CPU `Load` seed expansion and the CPU Store converter.
 ///
+/// `BGR10A2_UNORM` is here because a **game** asks for it, and it is the first
+/// packed 32-bit colour format admitted. A driven macos-13 x86/Vulkan boot
+/// running Asphalt 8 creates its 1280x720 render surface as an `'l10r'`
+/// IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`, which
+/// `runtime::objects::iosurface_pixel_format_to_mtl` now names — and before
+/// either half of that change every draw of the frame was refused at
+/// `draw::render_target`'s `rt_type4_base_format` and the window was black:
+/// 20 822 `draw_fail_clear_fallback` records and zero successful draws in one
+/// 100 s capture. Vulkan does not *mandate* `A2R10G10B10_UNORM_PACK32` as a
+/// colour attachment the way it does `R16_SFLOAT`, so unlike the two members
+/// above this one is a format a host could in principle decline —
+/// `translate::pixel::color_attachment` is where such a decline would surface,
+/// and the NVIDIA host this was measured on advertises it.
+///
+/// It needed all three conversion rails plus a fourth thing the two members
+/// above did not: an arm in [`store_texel_order`], because its channels do not
+/// sit on byte boundaries and so the CPU converter's eight-bit round trip is the
+/// only lossy rail in the set. The byte copy is what normally runs and it is
+/// exact.
+///
 /// `RG8_UNORM` is deliberately *not* here. No guest has been observed declaring
 /// a two-channel eight-bit render target, and admitting a format costs three
 /// conversions plus a census line, so members are added on measurement rather
@@ -1215,6 +1739,7 @@ pub fn render_target_bpp(format: u16) -> Option<u32> {
         MTL_FORMAT_RG16_FLOAT => RG16F_BPP,
         MTL_FORMAT_R16_FLOAT => R16F_BPP,
         MTL_FORMAT_R8_UNORM => R8_BPP,
+        MTL_FORMAT_BGR10A2_UNORM => RGBA8_BPP,
         _ => return None,
     })
 }
@@ -1275,16 +1800,39 @@ pub fn store_texel_order(format: u16) -> Option<TexelLayout> {
         MTL_FORMAT_RGBA8_UNORM | MTL_FORMAT_RGBA8_UNORM_SRGB => TexelLayout::Rgba8,
         MTL_FORMAT_BGRA8_UNORM | MTL_FORMAT_BGRA8_UNORM_SRGB => TexelLayout::Bgra8,
         MTL_FORMAT_RGBA16_FLOAT => TexelLayout::Rgba16Float,
+        // The packed ten-bit colour word. Admitted because the byte copy is the
+        // only rail that can land it without loss: the CPU converter reaches
+        // [`rgba8_to_texel`], whose arm for this format requantizes each channel
+        // from eight bits back up to ten, and ten bits is what the guest picked
+        // the format for. A resident created in the declared format holds the
+        // identical `VK_FORMAT_A2R10G10B10_UNORM_PACK32` word the guest's
+        // destination does, so the copy converts nothing.
+        MTL_FORMAT_BGR10A2_UNORM => TexelLayout::Bgr10a2Unorm,
         _ => return None,
     })
 }
 
+/// Bytes one row of `width` texels occupies with no padding.
+///
+/// For a compressed format this is one row of **blocks**, which is the row a
+/// copy strides by and the row `VkBufferImageCopy::bufferRowLength` describes
+/// when it is left at zero. One expression covers both families because an
+/// uncompressed format's block is 1x1 — see [`block_geometry`].
 pub fn tight_row_bytes(width: u32, format: u16) -> Option<u32> {
     if width == 0 {
         return None;
     }
-    let bpp = bytes_per_pixel(format)?;
-    width.checked_mul(bpp)
+    let block = block_geometry(format)?;
+    block.blocks_across(width).checked_mul(block.bytes)
+}
+
+/// Rows a copy of a `height`-tall image of `format` must walk.
+///
+/// The texel height for an uncompressed format and a quarter of it, rounded up,
+/// for BC. Named rather than open-coded because the row loops that need it are
+/// in three files and a `height` left un-divided reads as correct.
+pub fn tight_row_count(height: u32, format: u16) -> Option<u32> {
+    Some(block_geometry(format)?.block_rows(height))
 }
 
 pub fn swizzle_identity() -> SwizzlePlan {
@@ -1561,6 +2109,75 @@ fn unorm8_to_f16_lut() -> &'static [u16; 256] {
 /// arrives with eight bits per channel whatever this writes it as. What it buys
 /// is that the seed lands as the attachment's texels instead of as a quarter of
 /// them, and the *rendering* on top of it keeps the full range.
+/// Bit position of each channel in `MTLPixelFormatBGR10A2Unorm`'s texel word.
+///
+/// One little-endian 32-bit word: blue in bits 0..9, green in 10..19, red in
+/// 20..29 and alpha in 30..31. Those are the same bits in the same order as
+/// `VK_FORMAT_A2R10G10B10_UNORM_PACK32`, which is why the byte copy is exact and
+/// [`store_texel_order`] admits the format — the two functions below serve only
+/// the rails that cannot copy.
+///
+/// Stated as shifts rather than as a struct because the channels do not sit on
+/// byte boundaries, which is also why no byte-shaped loader can serve this
+/// format and why [`TexelLayout::has_cpu_loader_arm`] answers `false` for it.
+const BGR10A2_BLUE_SHIFT: u32 = 0;
+const BGR10A2_GREEN_SHIFT: u32 = 10;
+const BGR10A2_RED_SHIFT: u32 = 20;
+const BGR10A2_ALPHA_SHIFT: u32 = 30;
+/// Width of one colour channel in [`BGR10A2_RED_SHIFT`]'s word.
+const BGR10A2_COLOR_MASK: u32 = 0x3ff;
+/// Width of the alpha channel in the same word.
+const BGR10A2_ALPHA_MASK: u32 = 0x3;
+/// The three colour channels tile the word below alpha, and alpha closes it.
+const _: () = assert!(
+    BGR10A2_ALPHA_SHIFT == BGR10A2_RED_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_RED_SHIFT == BGR10A2_GREEN_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_GREEN_SHIFT == BGR10A2_BLUE_SHIFT + BGR10A2_COLOR_MASK.count_ones()
+        && BGR10A2_ALPHA_SHIFT + BGR10A2_ALPHA_MASK.count_ones() == u32::BITS
+);
+
+/// One `BGR10A2Unorm` word read as the four channels a semantic RGBA8 frame
+/// holds — the narrowing half of the pair, for the host readback rails.
+///
+/// A truncation and nothing else: ten bits of unorm become the eight most
+/// significant of them, and two bits of alpha become the four-fold replication
+/// of themselves, so the two-bit values `0..3` read back as `0, 85, 170, 255`.
+/// That replication is what makes the pair below an identity on every value a
+/// widened channel can hold, which is the property
+/// `a_packed_ten_bit_texel_survives_the_seed_and_readback_round_trip` checks.
+fn bgr10a2_word_to_rgba8(word: u32) -> [u8; 4] {
+    let channel = |shift: u32| (((word >> shift) & BGR10A2_COLOR_MASK) >> 2) as u8;
+    let alpha = ((word >> BGR10A2_ALPHA_SHIFT) & BGR10A2_ALPHA_MASK) as u8;
+    let mut out = [0u8; COMPONENT_COUNT];
+    out[COMPONENT_R] = channel(BGR10A2_RED_SHIFT);
+    out[COMPONENT_G] = channel(BGR10A2_GREEN_SHIFT);
+    out[COMPONENT_B] = channel(BGR10A2_BLUE_SHIFT);
+    out[COMPONENT_A] = alpha * BGR10A2_ALPHA_REPLICATE;
+    out
+}
+
+/// `0b01` in two bits is this value in eight, so multiplying replicates the pair
+/// across the byte and maps `0b11` to full scale rather than to `0xc0`.
+const BGR10A2_ALPHA_REPLICATE: u8 = 0x55;
+
+/// Four semantic-RGBA8 channels written into one `BGR10A2Unorm` word — the
+/// widening half, for a CPU `Load` seed and for the CPU Store converter.
+///
+/// Each colour channel gains two bits and they are filled with the value's own
+/// top two, which is the unorm widening that keeps both endpoints: `0` stays `0`
+/// and `255` becomes `1023`. Alpha loses six bits and keeps its top two, which
+/// is [`bgr10a2_word_to_rgba8`]'s replication inverted.
+fn rgba8_to_bgr10a2_word(rgba: [u8; COMPONENT_COUNT]) -> u32 {
+    let channel = |v: u8| {
+        let v = u32::from(v);
+        (v << 2) | (v >> 6)
+    };
+    (u32::from(rgba[COMPONENT_A]) >> 6) << BGR10A2_ALPHA_SHIFT
+        | channel(rgba[COMPONENT_R]) << BGR10A2_RED_SHIFT
+        | channel(rgba[COMPONENT_G]) << BGR10A2_GREEN_SHIFT
+        | channel(rgba[COMPONENT_B]) << BGR10A2_BLUE_SHIFT
+}
+
 pub fn expand_rgba8_to_texel(
     layout: TexelLayout,
     src_rgba: &[u8],
@@ -1622,6 +2239,19 @@ pub fn expand_rgba8_to_texel(
                 *d = src_rgba[i * RGBA8_BPP as usize + COMPONENT_R];
             }
         }
+        // The packed ten-bit colour word, which a guest was measured rendering
+        // into: an `'l10r'` IOSurface, named `BGR10A2Unorm` by
+        // `runtime::objects::iosurface_pixel_format_to_mtl`. A seed is semantic
+        // RGBA8, so each channel is widened into the bits it gains rather than
+        // shifted into place — see [`rgba8_to_bgr10a2_word`].
+        TexelLayout::Bgr10a2Unorm => {
+            for i in 0..px {
+                let (s, d) = (i * RGBA8_BPP as usize, i * RGBA8_BPP as usize);
+                let mut rgba = [0u8; COMPONENT_COUNT];
+                rgba.copy_from_slice(&src_rgba[s..s + COMPONENT_COUNT]);
+                dst[d..d + 4].copy_from_slice(&rgba8_to_bgr10a2_word(rgba).to_le_bytes());
+            }
+        }
         // Not colour-attachment layouts this device creates a render target at,
         // so a seed for one is a wiring error rather than a conversion. What
         // decides that is `render_target_bpp`, whose doc states the obligation
@@ -1633,20 +2263,34 @@ pub fn expand_rgba8_to_texel(
         // the arm is trivial to add when one is. Admitting a layout costs three
         // conversions and a census line, so they are added on measurement.
         //
-        // The three packed 32-bit colour layouts are here because
+        // The two remaining packed 32-bit colour layouts are here because
         // `render_target_bpp` does not admit their formats: no guest has been
         // observed declaring a render target in one, so there is no seed to
         // convert and an arm would be a conversion written against nothing. Add
         // both halves together if one is ever measured — the obligation
-        // `render_target_bpp` states runs in that direction.
+        // `render_target_bpp` states runs in that direction, and `Bgr10a2Unorm`
+        // is the member that has now been measured and moved out.
         TexelLayout::Rg8
         | TexelLayout::R32Float
         | TexelLayout::R16Unorm
         | TexelLayout::Rg16Unorm
         | TexelLayout::Rgba16Unorm
         | TexelLayout::Rgb10a2Unorm
-        | TexelLayout::Bgr10a2Unorm
         | TexelLayout::Rg11b10Float => return false,
+        // A BC layout is never a render target, so it never has a `Load` seed to
+        // widen. `render_target_bpp` has no arm for any BC format, which is what
+        // makes that a fact rather than an expectation.
+        TexelLayout::Bc1Rgba
+        | TexelLayout::Bc2Rgba
+        | TexelLayout::Bc3Rgba
+        | TexelLayout::Bc4RUnorm
+        | TexelLayout::Bc4RSnorm
+        | TexelLayout::Bc5RgUnorm
+        | TexelLayout::Bc5RgSnorm
+        | TexelLayout::Bc6hRgbFloat
+        | TexelLayout::Bc6hRgbUfloat
+        | TexelLayout::Bc7Rgba
+        => return false,
     }
     true
 }
@@ -1734,14 +2378,38 @@ pub fn narrow_texel_to_rgba8(
                 dst_rgba[d + COMPONENT_A] = UNORM8_MAX;
             }
         }
+        // The packed ten-bit colour word, read back the way a shader sampling
+        // it reads it: each channel truncated to its top eight bits and the
+        // two-bit alpha replicated out. `expand_rgba8_to_texel` is the inverse.
+        // This is the *fallback* rail — a host with no guest-RAM import, where
+        // refusing would lose the frame outright rather than quantize it.
+        TexelLayout::Bgr10a2Unorm => {
+            for i in 0..px {
+                let (s, d) = (i * RGBA8_BPP as usize, i * RGBA8_BPP as usize);
+                let word = u32::from_le_bytes([src[s], src[s + 1], src[s + 2], src[s + 3]]);
+                dst_rgba[d..d + COMPONENT_COUNT].copy_from_slice(&bgr10a2_word_to_rgba8(word));
+            }
+        }
         TexelLayout::Rg8
         | TexelLayout::R32Float
         | TexelLayout::R16Unorm
         | TexelLayout::Rg16Unorm
         | TexelLayout::Rgba16Unorm
         | TexelLayout::Rgb10a2Unorm
-        | TexelLayout::Bgr10a2Unorm
         | TexelLayout::Rg11b10Float => return false,
+        // Nothing reads a BC resident back: there is no BC render target to read
+        // back from, and a sampled BC image is never the source of a readback.
+        TexelLayout::Bc1Rgba
+        | TexelLayout::Bc2Rgba
+        | TexelLayout::Bc3Rgba
+        | TexelLayout::Bc4RUnorm
+        | TexelLayout::Bc4RSnorm
+        | TexelLayout::Bc5RgUnorm
+        | TexelLayout::Bc5RgSnorm
+        | TexelLayout::Bc6hRgbFloat
+        | TexelLayout::Bc6hRgbUfloat
+        | TexelLayout::Bc7Rgba
+        => return false,
     }
     true
 }
@@ -1844,6 +2512,14 @@ pub fn rgba8_to_texel(format: u16, rgba: [u8; 4], dst: &mut [u8]) -> bool {
             // directions are governed separately and nothing here couples them.
             let lut = unorm8_to_f16_lut();
             st16(&mut dst[0..2], lut[rgba[COMPONENT_R] as usize]);
+        }
+        MTL_FORMAT_BGR10A2_UNORM => {
+            // The third of the three rails `render_target_bpp`'s doc obliges a
+            // renderable format to satisfy. Lossy in the direction that matters
+            // — a seed only ever carries eight bits — which is why
+            // `store_texel_order` admits this format so the byte copy is what
+            // normally runs.
+            dst[..4].copy_from_slice(&rgba8_to_bgr10a2_word(rgba).to_le_bytes());
         }
         _ => return false,
     }
@@ -2701,11 +3377,34 @@ mod tests {
                 TexelLayout::Rgb10a2Unorm => MTL_FORMAT_RGB10A2_UNORM,
                 TexelLayout::Bgr10a2Unorm => MTL_FORMAT_BGR10A2_UNORM,
                 TexelLayout::Rg11b10Float => MTL_FORMAT_RG11B10_FLOAT,
+                TexelLayout::Bc1Rgba => MTL_FORMAT_BC1_RGBA,
+                TexelLayout::Bc2Rgba => MTL_FORMAT_BC2_RGBA,
+                TexelLayout::Bc3Rgba => MTL_FORMAT_BC3_RGBA,
+                TexelLayout::Bc4RUnorm => MTL_FORMAT_BC4_R_UNORM,
+                TexelLayout::Bc4RSnorm => MTL_FORMAT_BC4_R_SNORM,
+                TexelLayout::Bc5RgUnorm => MTL_FORMAT_BC5_RG_UNORM,
+                TexelLayout::Bc5RgSnorm => MTL_FORMAT_BC5_RG_SNORM,
+                TexelLayout::Bc6hRgbFloat => MTL_FORMAT_BC6H_RGB_FLOAT,
+                TexelLayout::Bc6hRgbUfloat => MTL_FORMAT_BC6H_RGB_UFLOAT,
+                TexelLayout::Bc7Rgba => MTL_FORMAT_BC7_RGBA_UNORM,
             };
+            // Compared as whole **block geometries** rather than as texel
+            // widths. That subsumes the reading this used to take — an
+            // uncompressed block is 1x1 and its `bytes` *is* `bytes_per_pixel`
+            // — and it is the only form that can say anything about a
+            // compressed layout, whose `bytes_per_pixel` is deliberately
+            // `None`. A layout and its guest format disagreeing on the grid is
+            // rows read at the wrong stride, which shears an image rather than
+            // refusing it.
             assert_eq!(
-                Some(layout.bytes_per_texel()),
-                bytes_per_pixel(mtl),
-                "{layout:?} and its guest format {mtl:#x} disagree on texel width"
+                Some(layout.block()),
+                block_geometry(mtl),
+                "{layout:?} and its guest format {mtl:#x} disagree on the storage grid"
+            );
+            assert_eq!(
+                layout.is_block_compressed(),
+                is_block_compressed(mtl),
+                "{layout:?} and its guest format {mtl:#x} disagree on being compressed"
             );
             // [`TexelLayout::has_cpu_loader_arm`] is a claim about
             // [`texel_to_rgba8`], so it is checked against `texel_to_rgba8`.
@@ -3129,8 +3828,21 @@ mod tests {
                 sampled_class(fmt),
                 Some(match order {
                     TexelLayout::Rgba8 => SampledClass::Rgba8Unorm,
+                    TexelLayout::Bgra8 => SampledClass::Bgra8Unorm,
                     TexelLayout::Rgba16Float => SampledClass::Rgba16Float,
-                    _ => SampledClass::Bgra8Unorm,
+                    TexelLayout::Bgr10a2Unorm => SampledClass::Bgr10a2Unorm,
+                    // Named rather than defaulted. This arm used to be
+                    // `_ => SampledClass::Bgra8Unorm`, which was true only while
+                    // the admitted set was {Rgba8, Bgra8, Rgba16Float}: the next
+                    // member widened into it would have been asserted against a
+                    // class describing a different word, and the assertion would
+                    // have *passed* if that class happened to be what
+                    // `sampled_class` answered. A panic here is the honest
+                    // failure — name the new layout's class above.
+                    other => panic!(
+                        "{fmt:#x} is admitted to the byte copy as {other:?}, which this \
+                         cross-check has no sampled class for"
+                    ),
                 }),
                 "{fmt:#x} is read as one layout by the sampler and copied as another"
             );
@@ -3150,6 +3862,253 @@ mod tests {
             "a half-float render target must reach the byte-copy rail, or its \
              frame is quantized to eight bits on the way to the guest"
         );
+        assert_eq!(
+            store_texel_order(MTL_FORMAT_BGR10A2_UNORM),
+            Some(TexelLayout::Bgr10a2Unorm),
+            "a packed ten-bit render target must reach the byte-copy rail: the CPU \
+             converter requantizes its channels through eight bits, which is the \
+             resolution the guest picked the format for"
+        );
+    }
+
+    /// A packed ten-bit texel survives the seed and readback pair unchanged.
+    ///
+    /// The pair is the *fallback* rail — a host with no guest-RAM import seeds a
+    /// `Load` from semantic RGBA8 and narrows the readback back to it — so the
+    /// property that matters is not that ten bits survive (they cannot; a seed
+    /// carries eight) but that the widening and the narrowing invert each other
+    /// exactly. If they did not, a frame that took the CPU rail twice would
+    /// drift, and a drift of one level per pass is invisible until it is not.
+    ///
+    /// Both endpoints are checked explicitly because the bit-replication
+    /// widening exists for them: a truncating `v << 2` would map 255 to 1020 and
+    /// read back as 254, so full white would darken on every round trip.
+    #[test]
+    fn a_packed_ten_bit_texel_survives_the_seed_and_readback_round_trip() {
+        for r in 0u16..=255 {
+            let rgba = [r as u8, (255 - r) as u8, r.wrapping_mul(7) as u8, 0];
+            for a in [0u8, 0x55, 0xaa, 0xff] {
+                let mut src = rgba;
+                src[COMPONENT_A] = a;
+                let word = rgba8_to_bgr10a2_word(src);
+                assert_eq!(
+                    bgr10a2_word_to_rgba8(word),
+                    src,
+                    "{src:?} did not survive the pair (word {word:#010x})"
+                );
+            }
+        }
+        // The endpoints of the widening, stated as words so a channel landing in
+        // the wrong bits fails here rather than in a frame.
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0, 0, 0xff]), 0xc000_0000);
+        assert_eq!(rgba8_to_bgr10a2_word([0xff, 0, 0, 0]), 0x3ff << 20);
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0xff, 0, 0]), 0x3ff << 10);
+        assert_eq!(rgba8_to_bgr10a2_word([0, 0, 0xff, 0]), 0x3ff);
+        // And the whole-frame wrappers agree with the per-texel pair, so a
+        // caller cannot be served a different conversion by going through the
+        // row functions the rails actually call.
+        let rgba: Vec<u8> = (0u8..=63).flat_map(|v| [v, 255 - v, v << 2, 0xff]).collect();
+        let pixels = (rgba.len() / 4) as u32;
+        let mut packed = vec![0u8; rgba.len()];
+        assert!(expand_rgba8_to_texel(
+            TexelLayout::Bgr10a2Unorm,
+            &rgba,
+            pixels,
+            &mut packed
+        ));
+        let mut back = vec![0u8; rgba.len()];
+        assert!(narrow_texel_to_rgba8(
+            TexelLayout::Bgr10a2Unorm,
+            &packed,
+            pixels,
+            &mut back
+        ));
+        assert_eq!(back, rgba, "the row rails and the texel pair disagree");
+        // The CPU Store converter is the same widening, one texel at a time.
+        let mut one = [0u8; 4];
+        assert!(rgba8_to_texel(
+            MTL_FORMAT_BGR10A2_UNORM,
+            [12, 34, 56, 0xff],
+            &mut one
+        ));
+        assert_eq!(
+            u32::from_le_bytes(one),
+            rgba8_to_bgr10a2_word([12, 34, 56, 0xff])
+        );
+    }
+
+    /// Every BC format the contract names, so a sweep is derived rather than
+    /// hand-listed the way `TexelLayout::ALL` is for the layouts.
+    const BC_FORMATS: &[u16] = &[
+        MTL_FORMAT_BC1_RGBA,
+        MTL_FORMAT_BC1_RGBA_SRGB,
+        MTL_FORMAT_BC2_RGBA,
+        MTL_FORMAT_BC2_RGBA_SRGB,
+        MTL_FORMAT_BC3_RGBA,
+        MTL_FORMAT_BC3_RGBA_SRGB,
+        MTL_FORMAT_BC4_R_UNORM,
+        MTL_FORMAT_BC4_R_SNORM,
+        MTL_FORMAT_BC5_RG_UNORM,
+        MTL_FORMAT_BC5_RG_SNORM,
+        MTL_FORMAT_BC6H_RGB_FLOAT,
+        MTL_FORMAT_BC6H_RGB_UFLOAT,
+        MTL_FORMAT_BC7_RGBA_UNORM,
+        MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+    ];
+
+    /// The list above is exactly the formats `is_block_compressed` claims.
+    ///
+    /// Swept over the whole `u16` space, so a family added to `bc_block_bytes`
+    /// and not to the list — or the reverse — fails here instead of being missed
+    /// by every test that iterates the list.
+    #[test]
+    fn the_bc_sweep_list_is_every_block_compressed_format() {
+        let claimed: Vec<u16> = (0..=u16::MAX).filter(|&f| is_block_compressed(f)).collect();
+        assert_eq!(claimed, BC_FORMATS.to_vec());
+    }
+
+    /// A block geometry is the texel table with its grid stated, for every
+    /// uncompressed format — not a second opinion about the same number.
+    ///
+    /// This is the invariant that lets [`tight_row_bytes`] be one expression
+    /// over both families. Swept over the whole space rather than a sample: the
+    /// two functions would agree on any list chosen after the fact.
+    #[test]
+    fn a_block_geometry_agrees_with_the_texel_table() {
+        for format in 0..=u16::MAX {
+            match (bytes_per_pixel(format), block_geometry(format)) {
+                (Some(bpp), Some(block)) => {
+                    assert!(
+                        !is_block_compressed(format),
+                        "{format:#x} has a bytes-per-texel and claims to be compressed"
+                    );
+                    assert_eq!(
+                        (block.width, block.height, block.bytes),
+                        (1, 1, bpp),
+                        "{format:#x}: an uncompressed block must be 1x1 of its own texel"
+                    );
+                }
+                (None, Some(block)) => {
+                    assert!(
+                        is_block_compressed(format),
+                        "{format:#x} has a block but no texel width and is not compressed"
+                    );
+                    assert_eq!((block.width, block.height), (BC_BLOCK_SIDE, BC_BLOCK_SIDE));
+                    assert!(block.bytes == BC_BLOCK_BYTES_8 || block.bytes == BC_BLOCK_BYTES_16);
+                }
+                (None, None) => {}
+                (Some(_), None) => panic!("{format:#x} has a texel width and no block"),
+            }
+        }
+    }
+
+    /// A BC format is refused by every rail except the sampled bind.
+    ///
+    /// **This is the whole safety argument for `TexelLayout::bytes_per_texel`
+    /// answering about a block**, and it is a test rather than a paragraph
+    /// because ninety-odd call sites call that method and none of them was
+    /// audited by hand. Each rail below is a total gate: a format the gate says
+    /// `None` for cannot reach the sizing code behind it, so the only rail a BC
+    /// layout travels is the sampled bind — where the staging buffer is sized
+    /// from the loader's own byte count and `VkBufferImageCopy` does the block
+    /// arithmetic itself.
+    ///
+    /// If a rail is ever widened to admit one, this test is what says the
+    /// argument has to be re-made.
+    #[test]
+    fn a_bc_format_is_refused_by_every_rail_but_the_sampled_bind() {
+        for &format in BC_FORMATS {
+            assert!(
+                bytes_per_pixel(format).is_none(),
+                "{format:#x}: a BC1 texel is half a byte, so there is no honest answer here"
+            );
+            assert!(
+                render_target_bpp(format).is_none(),
+                "{format:#x} must not be a colour attachment"
+            );
+            assert!(
+                storage_selector(format).is_none(),
+                "{format:#x} must not be a storage image — a shader cannot write a block"
+            );
+            assert!(
+                sampled_class(format).is_none(),
+                "{format:#x} must not claim a CPU-upload fast path"
+            );
+            assert!(
+                store_texel_order(format).is_none(),
+                "{format:#x} must not be a byte-copy Store destination"
+            );
+            assert!(
+                texel_to_rgba8(format, &[0u8; 16]).is_none(),
+                "{format:#x} must have no CPU loader arm"
+            );
+            assert!(
+                !rgba8_to_texel(format, [1, 2, 3, 4], &mut [0u8; 16]),
+                "{format:#x} must have no CPU Store converter"
+            );
+            // And the one rail it does travel names it.
+            let layout = block_compressed_layout(format)
+                .unwrap_or_else(|| panic!("{format:#x} must name a sampled layout"));
+            assert!(layout.is_block_compressed());
+            assert!(!layout.has_cpu_loader_arm());
+            assert_eq!(Some(layout.block()), block_geometry(format));
+        }
+    }
+
+    /// A BC3 level is sized and strided in blocks, on the geometry a guest was
+    /// measured sending.
+    ///
+    /// The bug class: every one of these numbers was computed per **texel**
+    /// before, so a 64x64 BC3 level read a 64-byte row instead of a 256-byte one
+    /// and claimed sixty-four rows instead of sixteen. Nothing about that is a
+    /// refusal — it is a texture bound from the wrong bytes — which is why the
+    /// figures here are the descriptors' own rather than round numbers.
+    ///
+    /// The mip tail is the half nobody writes down: a 2x2 and even a 1x1 level
+    /// still occupy one whole block, so the rounding is the contract and a
+    /// division would read four bytes of a sixteen-byte level.
+    #[test]
+    fn a_bc3_level_is_sized_and_strided_in_blocks() {
+        const BC3: u16 = MTL_FORMAT_BC3_RGBA;
+        // Measured on the boot that found the family: `L0=1024x1024 bpr=4096`
+        // and `L0=64x64 bpr=256`, both from the guest's own descriptors.
+        assert_eq!(tight_row_bytes(1024, BC3), Some(4096));
+        assert_eq!(tight_row_bytes(64, BC3), Some(256));
+        assert_eq!(tight_row_count(1024, BC3), Some(256));
+        assert_eq!(tight_row_count(64, BC3), Some(16));
+        // A 1 MiB base, which is what `alloc=1400832` is the eleven-level
+        // pyramid of.
+        assert_eq!(
+            TexelLayout::Bc3Rgba.image_bytes(1024, 1024),
+            Some(1024 * 1024)
+        );
+        // The tail. Every one of these is one block.
+        for side in [1u32, 2, 3, 4] {
+            assert_eq!(
+                tight_row_bytes(side, BC3),
+                Some(BC_BLOCK_BYTES_16),
+                "a {side}-wide BC3 row is one block"
+            );
+            assert_eq!(tight_row_count(side, BC3), Some(1));
+            assert_eq!(
+                TexelLayout::Bc3Rgba.image_bytes(side, side),
+                Some(u64::from(BC_BLOCK_BYTES_16))
+            );
+        }
+        // Five texels need two blocks, which is the rounding stated as a case
+        // rather than as a formula.
+        assert_eq!(tight_row_bytes(5, BC3), Some(2 * BC_BLOCK_BYTES_16));
+        assert_eq!(tight_row_count(5, BC3), Some(2));
+        // BC1 is the same grid at half the weight, so a wrong block-bytes
+        // constant cannot hide behind BC3's.
+        assert_eq!(tight_row_bytes(64, MTL_FORMAT_BC1_RGBA), Some(128));
+        assert_eq!(
+            TexelLayout::Bc1Rgba.image_bytes(1024, 1024),
+            Some(512 * 1024)
+        );
+        // And an uncompressed format is unchanged by all of it.
+        assert_eq!(tight_row_bytes(64, MTL_FORMAT_BGRA8_UNORM), Some(256));
+        assert_eq!(tight_row_count(64, MTL_FORMAT_BGRA8_UNORM), Some(64));
     }
 
     #[test]

--- a/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
@@ -354,6 +354,17 @@ struct LinearTextureLevel {
     height: u32,
     depth: u32,
     bpp: u32,
+    /// The storage grid one `bpp` unit covers.
+    ///
+    /// 1x1 for every uncompressed format, so `bpp` and this agree for all of
+    /// them and nothing downstream changes. 4x4 for the BC families, where `bpp`
+    /// is bytes per **block** — which is why the one rail that admits a
+    /// compressed texture, `exec_copy_texture_to_texture`, converts its
+    /// coordinates into block space before using any of the per-unit helpers
+    /// below. A compressed copy is an uncompressed copy of the block image, and
+    /// converting once at the top is what lets that be true rather than
+    /// threading a grid through every helper.
+    block: pixel_format::BlockGeometry,
     pixel_format: u16,
 }
 
@@ -418,6 +429,20 @@ impl TextureBacking {
             TextureBacking::Type11(t) => t.bpp,
         }
     }
+    /// The storage grid one [`Self::bpp`] unit covers.
+    fn block(&self) -> pixel_format::BlockGeometry {
+        match self {
+            TextureBacking::Linear(t) => t.block,
+            // A type-11 IOSurface is never block-compressed: its resolve takes
+            // `bytes_per_pixel`, which has no answer for a compressed format, so
+            // such a surface is refused as `t11_fmt_bpp` long before here.
+            TextureBacking::Type11(t) => pixel_format::BlockGeometry {
+                width: 1,
+                height: 1,
+                bytes: t.bpp,
+            },
+        }
+    }
     fn pixel_format(&self) -> u16 {
         match self {
             TextureBacking::Linear(t) => t.pixel_format,
@@ -430,8 +455,16 @@ impl TextureBacking {
 }
 
 impl LinearTextureLevel {
+    /// Bytes one depth plane / array slice of this level occupies.
+    ///
+    /// Counted in rows of **storage**: a block-compressed level is a quarter as
+    /// tall in rows as it is in texels, so the texel form overstated one by four
+    /// and would have strided a `z` plane or an array slice past its own image.
+    /// `block_rows` answers `height` for every uncompressed format, so this is
+    /// the same product it always was for them.
     fn bytes_per_image(&self) -> Option<u64> {
-        self.row_stride.checked_mul(self.height as u64)
+        self.row_stride
+            .checked_mul(u64::from(self.block.block_rows(self.height)))
     }
 
     /// Byte offset of texel origin (x,y,z) within the allocation (includes slice).
@@ -891,13 +924,22 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         ));
         return Err(br(BlitStatus::Unsupported, "tex_no_pixel_format"));
     }
-    let Some(bpp) = pixel_format::bytes_per_pixel(tex.pixel_format) else {
+    // The storage grid rather than a bytes-per-texel, so a block-compressed
+    // level resolves instead of being refused here. `tex_bad_bpp` fired 448
+    // times on one driven Asphalt 8 leg, every one of them a `kind=Copy` between
+    // two BC3 textures — a copy that moves whole blocks and converts nothing.
+    //
+    // Resolving is not admitting: only the texture-to-texture copy handles a
+    // compressed grid, and every other rail that takes this backing refuses one
+    // by name.
+    let Some(block) = pixel_format::block_geometry(tex.pixel_format) else {
         crate::observe::fail(format!(
             "blit tex bad_bpp ref={texture_ref} fmt={}",
             tex.pixel_format
         ));
         return Err(br(BlitStatus::Unsupported, "tex_bad_bpp"));
     };
+    let bpp = block.bytes;
     let Some((layout_gva, layout)) = tex.level_gva(level as u32, state.page_shift) else {
         crate::observe::fail(format!(
             "blit tex level_gva_shift fail ref={texture_ref} lvl={level} handle={} alloc={} mips={} page_shift={} w={} h={} fmt={:#x}",
@@ -979,6 +1021,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         alloc_size: tex.allocation_size,
         level_offset,
         row_stride: layout.row_stride,
+        block,
         slice_stride: one_slice,
         slice_index: slice as u32,
         width: layout.width,
@@ -2483,6 +2526,15 @@ fn exec_copy_buffer_to_texture<M: HostMemory + HostOps>(
         Ok(t) => t,
         Err(st) => return st,
     };
+    // A compressed texture reaches this rail only because
+    // `resolve_texture_backing` now admits one for the texture-to-texture copy.
+    // Everything below this line strides in texels, and a block is four of them
+    // in each axis — so the honest answer is a named refusal rather than a
+    // buffer sized a sixteenth of what it needs. See
+    // `exec_copy_texture_to_texture`, which converts to block space instead.
+    if dst.block().is_compressed() {
+        return br(BlitStatus::Unsupported, "b2t_compressed");
+    }
     let (aspect, copy_bpp) = match copy_aspect_for_options(dst.pixel_format(), cmd) {
         Ok(v) => v,
         Err(st) => return st,
@@ -2729,6 +2781,15 @@ fn exec_copy_texture_to_buffer<M: HostMemory + HostOps>(
         Ok(t) => t,
         Err(st) => return st,
     };
+    // A compressed texture reaches this rail only because
+    // `resolve_texture_backing` now admits one for the texture-to-texture copy.
+    // Everything below this line strides in texels, and a block is four of them
+    // in each axis — so the honest answer is a named refusal rather than a
+    // buffer sized a sixteenth of what it needs. See
+    // `exec_copy_texture_to_texture`, which converts to block space instead.
+    if src.block().is_compressed() {
+        return br(BlitStatus::Unsupported, "t2b_compressed");
+    }
     let (aspect, copy_bpp) = match copy_aspect_for_options(src.pixel_format(), cmd) {
         Ok(v) => v,
         Err(st) => return st,
@@ -3062,6 +3123,72 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
         "blit_t2t_resolve_us",
         phase_started.elapsed().as_micros() as u64,
     );
+    // From here down the coordinates are in units of `copy_bpp`, and for a
+    // block-compressed format that unit is a 4x4 **block**.
+    //
+    // A compressed copy is an uncompressed copy of the block image — same row
+    // stride, same staging, same page window — so the conversion happens once,
+    // here, and every per-unit helper below runs unchanged: `texel_offset`
+    // multiplies x by `bpp` and y by `row_stride`, which in block space is
+    // exactly a block column and a block row. Threading a grid through each
+    // helper instead would put the same division in six places.
+    //
+    // Above this line everything is texels, which is what the bounds checks and
+    // `note_t2t_shape` want; below it nothing is. That is the whole reason the
+    // conversion is a single shadowing binding rather than a flag.
+    let block = src.block();
+    let (sox, soy, dox, doy, copy_w, copy_h) = if !block.is_compressed() {
+        (sox, soy, dox, doy, copy_w, copy_h)
+    } else {
+        // Each refusal below is a copy this rail could describe wrongly rather
+        // than one Metal forbids, so each is named and none is a clamp.
+        if aspect != blit::BlitAspect::Full || repack_src || repack_dst {
+            // There is no depth or stencil plane inside a colour block, and a
+            // repack pass rewrites texels.
+            return br(BlitStatus::Unsupported, "t2t_compressed_aspect");
+        }
+        if any_t11 {
+            return br(BlitStatus::Unsupported, "t2t_compressed_t11");
+        }
+        if dst.block() != block {
+            // One allocation reinterpreted at two grids is not a copy; the
+            // format-mismatch check above lets a format-0 side through, and this
+            // is where that pairing stops.
+            return br(BlitStatus::Unsupported, "t2t_compressed_grid_mismatch");
+        }
+        if copy_d > 1 || soz != 0 || doz != 0 {
+            // `bytes_per_image` strides a depth plane by the *texel* height, and
+            // this conversion does not reach it. A 2D copy never asks.
+            return br(BlitStatus::Unsupported, "t2t_compressed_volume");
+        }
+        let (bw, bh) = (u64::from(block.width), u64::from(block.height));
+        if !sox.is_multiple_of(bw)
+            || !dox.is_multiple_of(bw)
+            || !soy.is_multiple_of(bh)
+            || !doy.is_multiple_of(bh)
+        {
+            // A block is the smallest unit this copy can move, so an origin
+            // inside one names bytes it cannot address.
+            return br(BlitStatus::Unsupported, "t2t_compressed_origin_unaligned");
+        }
+        // An extent may end mid-block only where it reaches the level edge on
+        // *both* ends — the one case a partial trailing block is the whole
+        // remainder of the image rather than a slice of a block.
+        let w_edge = sox + copy_w == src.width() as u64 && dox + copy_w == dst.width() as u64;
+        let h_edge = soy + copy_h == src.height() as u64 && doy + copy_h == dst.height() as u64;
+        if (!copy_w.is_multiple_of(bw) && !w_edge) || (!copy_h.is_multiple_of(bh) && !h_edge) {
+            return br(BlitStatus::Unsupported, "t2t_compressed_extent_unaligned");
+        }
+        crate::runtime::drain::note_store_route("blit_t2t_compressed");
+        (
+            sox / bw,
+            soy / bh,
+            dox / bw,
+            doy / bh,
+            copy_w.div_ceil(bw),
+            copy_h.div_ceil(bh),
+        )
+    };
     let row_bytes = match copy_w.checked_mul(copy_bpp as u64) {
         Some(v) => v,
         None => return br(BlitStatus::Capacity, "t2t_row_bytes_overflow"),
@@ -3890,7 +4017,15 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             }
         }
         let bpp = src0.bpp();
-        let row_bytes = match (w as u64).checked_mul(bpp as u64) {
+        // Whole levels, so a compressed one needs no origin or partial-block
+        // reasoning — only its row width and row *count* in blocks. The grids
+        // must agree for the same reason the `bpp`s must.
+        let block = src0.block();
+        if dst0.block() != block {
+            return br(BlitStatus::Unsupported, "sl_compressed_grid_mismatch");
+        }
+        let rows = u64::from(block.block_rows(h));
+        let row_bytes = match u64::from(block.blocks_across(w)).checked_mul(bpp as u64) {
             Some(v) => v,
             None => return br(BlitStatus::Capacity, "sl_row_bytes_overflow"),
         };
@@ -3948,7 +4083,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             // Same allocation overlap check (conservative).
             if sl.base_gva == dl.base_gva {
                 let span = row_bytes
-                    .saturating_mul(h as u64)
+                    .saturating_mul(rows)
                     .saturating_mul(image_count);
                 if ranges_overlap(src_off, span, dst_off, span) {
                     return br(BlitStatus::Overlap, "sl_overlap");
@@ -3965,7 +4100,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 dl.row_stride,
                 dst_img_stride,
                 row_bytes,
-                h as u64,
+                rows,
                 image_count,
             ) {
                 return st;
@@ -3984,7 +4119,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
         // were never the cost — re-entering the mapping rail per row was. It
         // stages the slice whole now; see [`read_texture_rect`].
         let sl_mixed_started = std::time::Instant::now();
-        let mut staged = vec![0u8; (row_bytes.saturating_mul(h as u64)) as usize];
+        let mut staged = vec![0u8; (row_bytes.saturating_mul(rows)) as usize];
         for si in 0..cmd.slice_count {
             let ss = match cmd.source_slice.checked_add(si) {
                 Some(v) => v,
@@ -4015,7 +4150,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 &dst,
                 Point { x: 0, y: 0, z: 0 },
                 w,
-                h as u64,
+                rows,
                 1,
                 bpp,
             ) {
@@ -4029,7 +4164,7 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
                 &src,
                 Point { x: 0, y: 0, z: 0 },
                 row_bytes,
-                h as u64,
+                rows,
                 &mut staged,
             ) {
                 return st;

--- a/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
@@ -1358,6 +1358,73 @@ fn type8_level_base_on_type11_rejected() {
     );
 }
 
+/// A compressed level's byte arithmetic is in blocks, in both axes.
+///
+/// The regression this pins is 448 refused copies on one driven Asphalt 8 leg:
+/// `blit_fail reason=tex_bad_bpp kind=Copy` between two BC3 textures, because
+/// the whole blit path asked `bytes_per_pixel` and a BC format has none. Now the
+/// backing carries its storage grid, and `exec_copy_texture_to_texture` converts
+/// the command's coordinates into block space once so every per-unit helper
+/// below it is correct unchanged.
+///
+/// Both halves are asserted because each fails differently. A wrong
+/// `bytes_per_image` strides an array slice or a `z` plane past its own image; a
+/// wrong `texel_offset` reads the right number of bytes from the wrong place.
+#[test]
+fn a_compressed_level_addresses_blocks_in_both_axes() {
+    use crate::contract::pixel_format::{self as pf, BlockGeometry};
+    // A 64x64 BC3 level as a guest sends it: 16 block columns of 16 bytes, and
+    // 16 block rows, so one image is 4096 bytes and not 16384.
+    let bc3 = LinearTextureLevel {
+        base_gva: 0,
+        alloc_size: 4096,
+        level_offset: 0,
+        row_stride: 256,
+        slice_stride: 4096,
+        slice_index: 0,
+        width: 64,
+        height: 64,
+        depth: 1,
+        bpp: pf::BC_BLOCK_BYTES_16,
+        block: pf::block_geometry(pf::MTL_FORMAT_BC3_RGBA).expect("bc3 has a grid"),
+        pixel_format: pf::MTL_FORMAT_BC3_RGBA,
+    };
+    assert_eq!(bc3.block, BlockGeometry { width: 4, height: 4, bytes: 16 });
+    assert_eq!(
+        bc3.bytes_per_image(),
+        Some(4096),
+        "16 block rows of 256 bytes — the texel form would say 16384 and stride \
+         a slice four times past its own image"
+    );
+    // Block coordinates, which is what the copy hands it: block (3, 2) starts at
+    // row 2 of blocks and column 3, i.e. 2*256 + 3*16.
+    assert_eq!(bc3.texel_offset(3, 2, 0), Some(2 * 256 + 3 * 16));
+    // The last block of the level is the last 16 bytes of the allocation, so the
+    // grid and the allocation agree exactly — a level that did not would be
+    // refused against `alloc_size` downstream.
+    assert_eq!(bc3.texel_offset(15, 15, 0), Some(4096 - 16));
+
+    // An uncompressed level is untouched by any of it: a 1x1 block whose bytes
+    // are the bytes-per-texel gives back the products this always computed.
+    let rgba = LinearTextureLevel {
+        base_gva: 0,
+        alloc_size: 0x1000,
+        level_offset: 0,
+        row_stride: 256,
+        slice_stride: 0,
+        slice_index: 0,
+        width: 64,
+        height: 4,
+        depth: 1,
+        bpp: 4,
+        block: pf::block_geometry(MTL_FORMAT_RGBA8_UNORM).expect("rgba8 has a grid"),
+        pixel_format: MTL_FORMAT_RGBA8_UNORM,
+    };
+    assert_eq!(rgba.block, BlockGeometry { width: 1, height: 1, bytes: 4 });
+    assert_eq!(rgba.bytes_per_image(), Some(256 * 4));
+    assert_eq!(rgba.texel_offset(3, 2, 0), Some(2 * 256 + 3 * 4));
+}
+
 #[test]
 fn texel_offset_math() {
     let t = LinearTextureLevel {
@@ -1371,6 +1438,11 @@ fn texel_offset_math() {
         height: 4,
         depth: 1,
         bpp: 4,
+        block: crate::contract::pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
         pixel_format: MTL_FORMAT_RGBA8_UNORM,
     };
     // (x=1,y=2) → 0x100 + 2*16 + 1*4 = 0x124
@@ -1413,6 +1485,11 @@ fn an_unmeasurable_copy_region_refuses_rather_than_writing_unbounded() {
         height: 1,
         depth: 1,
         bpp: 4,
+        block: crate::contract::pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
         pixel_format: MTL_FORMAT_RGBA8_UNORM,
     };
 

--- a/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
@@ -342,8 +342,23 @@ impl TextureLevelLayout {
     /// `None` for zero height (no rows) or on overflow. A bound this feeds must
     /// treat `None` as a refusal, never as "no limit".
     pub fn read_span(&self, tight_row: u32) -> Option<u64> {
-        self.height
-            .checked_sub(1)
+        self.read_span_rows(self.height, tight_row)
+    }
+
+    /// [`Self::read_span`] over a caller-supplied row count.
+    ///
+    /// The row count is a parameter because a **block-compressed** level has
+    /// fewer rows of storage than it has rows of texels: a 64x64 BC3 level is
+    /// sixteen 256-byte rows, not sixty-four. `contract::pixel_format::
+    /// tight_row_count` is what a caller passes, and it answers `height` for
+    /// every uncompressed format — so `read_span` above is this with the count
+    /// it always used.
+    ///
+    /// Deriving the count here instead would need this type to know the pixel
+    /// format, which it deliberately does not: a `TextureLevelLayout` is
+    /// geometry, and the format lives on the descriptor that owns it.
+    pub fn read_span_rows(&self, rows: u32, tight_row: u32) -> Option<u64> {
+        rows.checked_sub(1)
             .map(u64::from)?
             .checked_mul(self.row_stride)?
             .checked_add(u64::from(tight_row))
@@ -392,10 +407,20 @@ impl TextureLevelLayout {
     /// receiver holds, travelling as a loose argument that a second caller could
     /// get wrong with nothing to notice.
     pub fn slice_read_span(&self, tight_row: u32) -> Option<u64> {
+        self.slice_read_span_rows(self.height, tight_row)
+    }
+
+    /// [`Self::slice_read_span`] over a caller-supplied row count, for
+    /// [`Self::read_span_rows`]'s reason.
+    ///
+    /// BC compresses in two dimensions only, so each depth plane of a
+    /// compressed level is its own `rows`-tall block grid and the planes stack
+    /// exactly as they do uncompressed.
+    pub fn slice_read_span_rows(&self, rows: u32, tight_row: u32) -> Option<u64> {
         u64::from(self.planes() - 1)
             .checked_mul(self.row_stride)?
-            .checked_mul(u64::from(self.height))?
-            .checked_add(self.read_span(tight_row)?)
+            .checked_mul(u64::from(rows))?
+            .checked_add(self.read_span_rows(rows, tight_row)?)
     }
 }
 
@@ -504,7 +529,35 @@ impl TextureDescriptor {
 
 /// Texture descriptor field offsets (geometry prefix + format trailer).
 pub const TEXTURE_DESC_GEOMETRY_LEN: usize = 68;
+/// Offset of the mip-level count, which is **one byte wide**.
+///
+/// This was read as a `u16` and the byte above it is a field of its own. The
+/// descriptor's own length is what settles it, and it settles it exactly. A
+/// multi-mip body is `TEXTURE_DESC_BASE_LEN + (levels - 1) *
+/// TEXTURE_DESC_MIP_LEVEL_RECORD_LEN` bytes long, and on a driven macos-13
+/// x86/Vulkan boot running Asphalt 8 four distinct descriptors read the `u16`
+/// as `0x8001`, `0x8007`, `0x800a` and `0x800b` with body lengths 116, 332, 440
+/// and 476. Taking the low byte as the count reproduces all four lengths to the
+/// byte — 116, 116+6*36, 116+9*36, 116+10*36 — and no other reading of the field
+/// does.
+///
+/// What the byte above it means is **not** decided here and is not guessed: it
+/// read `0x80` on every one of those four and zero on every descriptor the
+/// desktop workload produces, which is why reading the pair as one count
+/// survived until a game set it. `decode_texture_descriptor` reports a non-zero
+/// one by name so the next session has the value rather than an absence.
+///
+/// Reading the pair cost the game every mipmapped texture it bound: a declared
+/// count of 32 779 put the format trailer 1 180 094 bytes into a 476-byte body,
+/// so `texture_desc_format_unreachable` fired, the descriptor carried no pixel
+/// format, and the fragment bind refused with
+/// `draw_prepare_texture_resolve_missing`.
 pub const TEXTURE_DESC_MIPMAP_LEVEL_COUNT: usize = 12;
+/// The byte above the mip-level count: a field this device does not decode.
+///
+/// Named so the read site is not an unexplained `+ 1`. See
+/// [`TEXTURE_DESC_MIPMAP_LEVEL_COUNT`] for why the two are separate fields.
+pub const TEXTURE_DESC_MIP_FIELD_UNDECODED: usize = TEXTURE_DESC_MIPMAP_LEVEL_COUNT + 1;
 pub const TEXTURE_DESC_DATA_OFFSET: usize = 16;
 pub const TEXTURE_DESC_BYTES_PER_ELEMENT: usize = 35;
 pub const TEXTURE_DESC_USED_SIZE: usize = 44;
@@ -1261,6 +1314,35 @@ pub const PIPELINE_TAG_TESSELLATION_OUTPUT_WINDING_ORDER: u8 = 0x12;
 /// policy choice: a pipeline built at any other count would not be compatible
 /// with the pass it is used in.
 pub const DEFAULT_RASTER_SAMPLE_COUNT: u32 = 1;
+/// `alphaTestEnabled` on Metal's internal render-pipeline descriptor.
+///
+/// One of the fixed-function fields Metal still carries from the OpenGL era.
+/// They live in `MTLRenderPipelineDescriptorPrivate`'s `miscHash` bitfield
+/// — `alphaTestFunc b3` next to `alphaTestEnabled b1`, and `logicOp b4` next to
+/// `logicOpEnabled b1` — reachable only through private setters on
+/// `MTLRenderPipelineDescriptorInternal`, which is why no workload built out of
+/// the public API had ever produced them here.
+///
+/// **This tag is deliberately neither consumed nor benign, so a pipeline
+/// carrying it is refused.** Its companion
+/// [`PIPELINE_TAG_ALPHA_TEST_FUNCTION`] *is* benign, and the pairing is the
+/// whole argument: a compare function with the test off changes nothing, while
+/// the test being *on* is a per-fragment discard this device does not implement.
+/// Dropping the enable would render every alpha-tested fragment that the guest
+/// asked to be discarded.
+pub const PIPELINE_TAG_ALPHA_TEST_ENABLED: u8 = 0x2d;
+/// `alphaTestFunction`, an `MTLCompareFunction`. Inert unless
+/// [`PIPELINE_TAG_ALPHA_TEST_ENABLED`] is present; see
+/// [`RENDER_PIPELINE_TAGS_BENIGN`].
+pub const PIPELINE_TAG_ALPHA_TEST_FUNCTION: u8 = 0x2e;
+/// `logicOperationEnabled`. Refused for [`PIPELINE_TAG_ALPHA_TEST_ENABLED`]'s
+/// reason one field over: a logic op is a fixed-function blend replacement this
+/// device does not implement, and dropping the enable would composite with the
+/// ordinary blend the guest asked to be replaced.
+pub const PIPELINE_TAG_LOGIC_OP_ENABLED: u8 = 0x2f;
+/// `logicOperation`, the op a
+/// [`PIPELINE_TAG_LOGIC_OP_ENABLED`] pipeline would apply. Inert without it.
+pub const PIPELINE_TAG_LOGIC_OP: u8 = 0x37;
 /// Mesh SPI section offset (analog of classic [`PIPELINE_TAG_COLOR_ATTACH_OFFSET`]).
 ///
 /// Live host Metal `-[_MTLDevice serializeMeshRenderPipelineDescriptor:]`
@@ -1762,8 +1844,27 @@ pub fn decode_texture_descriptor(bytes: &[u8]) -> Result<TextureDescriptor, Deco
         handle: ld32(&bytes[LINEAR_DESC_HANDLE..]),
         ..Default::default()
     };
-    if bytes.len() >= TEXTURE_DESC_MIPMAP_LEVEL_COUNT + 2 {
-        out.mipmap_level_count = ld16(&bytes[TEXTURE_DESC_MIPMAP_LEVEL_COUNT..]) as u32;
+    if bytes.len() > TEXTURE_DESC_MIPMAP_LEVEL_COUNT {
+        out.mipmap_level_count = u32::from(bytes[TEXTURE_DESC_MIPMAP_LEVEL_COUNT]);
+    }
+    // The field above the count is not part of it. Reported once per distinct
+    // value rather than interpreted, because nothing here knows what it means
+    // and a guess at it would be a rule the guest never agreed to.
+    let undecoded = bytes
+        .get(TEXTURE_DESC_MIP_FIELD_UNDECODED)
+        .copied()
+        .unwrap_or(0);
+    if undecoded != 0
+        && crate::observe::first_sight(
+            "texture_desc_mip_field_undecoded",
+            u64::from(undecoded),
+        )
+    {
+        crate::observe::fail(format!(
+            "texture_desc_mip_field_undecoded value={undecoded:#04x}              levels={} len={} (the byte above the mip-level count carries              something this device does not decode; the count is the low byte              and the body length confirms it)",
+            out.mipmap_level_count,
+            bytes.len()
+        ));
     }
     if bytes.len() >= TEXTURE_DESC_DATA_OFFSET + 4 {
         out.data_offset = ld32(&bytes[TEXTURE_DESC_DATA_OFFSET..]);
@@ -2378,10 +2479,27 @@ pub const PIPELINE_TAG_COMPUTE_STAGE_INPUT_OFFSET: u8 = 0x03;
 /// must refuse rather than be waved through. The third,
 /// [`PIPELINE_TAG_RASTER_SAMPLE_COUNT`], is now read — it is consumed on both
 /// shapes and carried to the backend render-pass and pipeline keys.
-const RENDER_PIPELINE_TAGS_BENIGN: [u8; 3] = [
+const RENDER_PIPELINE_TAGS_BENIGN: [u8; 5] = [
     RENDER_PIPELINE_TAG_LABEL,
     PIPELINE_TAG_DEPTH_ATTACH_FORMAT,
     PIPELINE_TAG_STENCIL_ATTACH_FORMAT,
+    // The two legacy fixed-function *values* whose enables stay refused. See
+    // the reading under `note_pipeline_tlv_fields` for what measured them and
+    // `PIPELINE_TAG_ALPHA_TEST_ENABLED` for why the pairing is what licenses
+    // this.
+    PIPELINE_TAG_ALPHA_TEST_FUNCTION,
+    PIPELINE_TAG_LOGIC_OP,
+];
+/// The enables that make the two benign members above load-bearing.
+///
+/// Not a list this decoder reads — it is here so the pairing is expressible, and
+/// so `an_alpha_test_or_logic_op_enable_is_still_refused` can assert it rather
+/// than restate two hex numbers. A tag in here must never join
+/// [`RENDER_PIPELINE_TAGS_BENIGN`].
+#[cfg(test)]
+const RENDER_PIPELINE_TAGS_STILL_REFUSED: [u8; 2] = [
+    PIPELINE_TAG_ALPHA_TEST_ENABLED,
+    PIPELINE_TAG_LOGIC_OP_ENABLED,
 ];
 /// The compute half of [`RENDER_PIPELINE_TAGS_BENIGN`]; same rule, and listed
 /// apart for the same reason `COMPUTE_PIPELINE_TAGS_CONSUMED` is.
@@ -2498,6 +2616,76 @@ const COMPUTE_PIPELINE_TAGS_BENIGN: [u8; 2] = [
 /// identified: see [`PIPELINE_TAG_RASTER_SAMPLE_COUNT`],
 /// [`PIPELINE_TAG_DEPTH_ATTACH_FORMAT`] and
 /// [`PIPELINE_TAG_STENCIL_ATTACH_FORMAT`].
+///
+/// # A game fired it twice, and the tags were named by driving the serializer
+///
+/// A macos-13 x86/Vulkan boot running Asphalt 8 produced one shape this list had
+/// never seen, and three pipeline refs carrying it were refused on every draw
+/// that used them — 1 348 `draw_load_pipeline reason=desc_decode` and 8 604
+/// `draw_fail_clear_fallback` in one capture, which is the game's canvas black
+/// while its window chrome composited:
+///
+/// ```text
+/// kind=render nfields=7 tags=[03:4,08:4,09:4*,2e:4*!,37:4*!,01:4,02:4]
+///                                          unconsumed=3 unknown=2
+/// ```
+///
+/// The two were identified the way this file's other layouts were — by
+/// perturbation against Apple's own serializer, not by reading ordinals. In the
+/// guest, `-[_MTLDevice serializeRenderPipelineDescriptor:]` returns this exact
+/// compact-TLV block (its `NSData` **starts** at the `fieldCount` byte; the
+/// 16-byte type-7 header this decoder reads is added by the transport). Build a
+/// baseline descriptor, set exactly one property through the runtime, serialize,
+/// and the tag that appears is that property's. Fifty-odd scalar setters on
+/// `MTLRenderPipelineDescriptor` and `MTLRenderPipelineDescriptorInternal`, one
+/// `fork` per probe so an assertion inside Metal costs one line:
+///
+/// ```text
+/// 0x00 label            0x0b inputPrimitiveTopology  0x2d alphaTestEnabled
+/// 0x01 vertexFunction   0x0c tessellationPartitionMode
+/// 0x02 fragmentFunction 0x0d maxTessellationFactor   0x2e alphaTestFunction
+/// 0x03 vertexDescriptor 0x0e tessellationFactorScaleEnabled
+/// 0x04 rasterSampleCount (also sampleCount)          0x2f logicOperationEnabled
+/// 0x05 alphaToCoverageEnabled  0x11 tessellationFactorStepFunction
+/// 0x06 alphaToOneEnabled       0x19 supportIndirectCommandBuffers
+/// 0x07 rasterizationEnabled    0x1a maxVertexAmplificationCount
+/// 0x08 colorAttachments offset 0x1b sampleCoverage   0x30 clipDistanceEnableMask
+/// 0x09 depthAttachmentPixelFormat  0x1c sampleMask   0x31 pointSmoothEnabled
+/// 0x0a stencilAttachmentPixelFormat 0x1e textureWriteRoundingMode
+/// 0x32 pointCoordLowerLeft  0x33 pointSizeOutputVS   0x34 twoSideEnabled
+/// 0x35 vertexDepthCompareClampMask  0x36 fragmentDepthCompareClampMask
+/// 0x37 logicOperation       0x38 depthStencilWriteDisabled
+/// 0x39 needsCustomBorderColorSamplers  0x3a explicitVisibilityGroupID
+/// ```
+///
+/// Only the four this commit acts on are declared as constants; the rest are
+/// recorded here because the sweep is cheap to re-run and expensive to
+/// rediscover. Everything from `0x2d` up is a private setter on the internal
+/// class, which is why a workload built on the public API never emits one — and
+/// the block is Metal's fixed-function inheritance: alpha test, logic op, point
+/// size and smoothing, two-sided lighting, clip-distance masks.
+///
+/// # Why the two values are benign and their two enables are not
+///
+/// The bitfield pairs each of these with an enable — `alphaTestFunc b3` beside
+/// `alphaTestEnabled b1`, `logicOp b4` beside `logicOpEnabled b1` — and a
+/// property left at its Metal default is omitted from this block rather than
+/// sent as a zero. That is measured, not assumed: the baseline descriptor emits
+/// **one** tag, and each of the fifty perturbations added exactly one. A fresh
+/// descriptor reads `isAlphaTestEnabled = 0` and `isLogicOperationEnabled = 0`.
+///
+/// The game's shape carries `0x2e` and `0x37` and **neither** `0x2d` nor
+/// `0x2f`. So both features are off, and a compare function and a logic op that
+/// nothing applies cannot change a pixel. Its `alphaTestFunction` was `7`,
+/// which is `MTLCompareFunctionAlways` — the value that discards nothing even
+/// were the test on.
+///
+/// The enables stay unnamed in both lists, which is the load-bearing half of
+/// this change: an alpha test that is *on* is a per-fragment discard this device
+/// does not implement, and a logic op that is on replaces blending. A pipeline
+/// asking for either is still refused by name, which is the right answer to a
+/// request that cannot be represented. `RENDER_PIPELINE_TAGS_STILL_REFUSED`
+/// holds them so that pairing is a test rather than a paragraph.
 ///
 /// Deduped per distinct `(tag, len)` rather than per value: what a reader needs
 /// first is which properties arrive, and a per-value latch on a field like a

--- a/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
@@ -1514,6 +1514,130 @@ fn multi_mip_level_layouts() {
     assert!(d.level_gva(2, PAGE_SHIFT_ARM64E).is_none());
 }
 
+/// A level's read span counts rows of storage, which for a compressed level is a
+/// quarter of its texel height.
+///
+/// The bound this feeds is the descriptor's own `allocation_size`, so a span
+/// computed from the texel height overstates a BC level by roughly four and gets
+/// the texture refused against an allocation the guest sized correctly — the
+/// same shape as the 27x27 mask `read_span` was written for, one axis over.
+///
+/// The numbers are a 1024x1024 BC3 level as a guest sends it: 256 block rows of
+/// 4096 bytes, which is 1 MiB exactly and no trailing padding to discount.
+#[test]
+fn a_compressed_level_spans_its_block_rows_not_its_texel_rows() {
+    use crate::contract::pixel_format as pf;
+    let level = TextureLevelLayout {
+        offset: 0,
+        size: 1024 * 1024,
+        row_stride: 4096,
+        width: 1024,
+        height: 1024,
+        depth: 1,
+    };
+    let tight = pf::tight_row_bytes(1024, pf::MTL_FORMAT_BC3_RGBA).expect("tight row");
+    let rows = pf::tight_row_count(1024, pf::MTL_FORMAT_BC3_RGBA).expect("rows");
+    assert_eq!((tight, rows), (4096, 256));
+    assert_eq!(
+        level.slice_read_span_rows(rows, tight),
+        Some(1024 * 1024),
+        "256 rows of 4096 bytes is the whole level and nothing past it"
+    );
+    // What the texel-height reading would have claimed, named so the difference
+    // is on the record rather than implied.
+    assert_eq!(level.slice_read_span(tight), Some(1023 * 4096 + 4096));
+    assert!(
+        level.slice_read_span(tight) > level.slice_read_span_rows(rows, tight),
+        "the texel-row form overstates a compressed level, which is the refusal \
+         this distinction exists to avoid"
+    );
+    // An uncompressed level is unchanged: `tight_row_count` answers its height,
+    // so the two forms agree by construction.
+    let plain = TextureLevelLayout {
+        offset: 0,
+        size: 64 * 4 * 32,
+        row_stride: 384,
+        width: 64,
+        height: 32,
+        depth: 1,
+    };
+    let ptight = pf::tight_row_bytes(64, pf::MTL_FORMAT_BGRA8_UNORM).expect("tight");
+    let prows = pf::tight_row_count(32, pf::MTL_FORMAT_BGRA8_UNORM).expect("rows");
+    assert_eq!(prows, 32);
+    assert_eq!(
+        plain.slice_read_span_rows(prows, ptight),
+        plain.slice_read_span(ptight)
+    );
+}
+
+/// The mip-level count is the low byte, and the byte above it does not join it.
+///
+/// The bug class this fixes: a game's mipmapped textures carry `0x80` in the
+/// byte above the count, the two were read as one `u16`, and a seven-level
+/// pyramid was decoded as 32 775 levels. Nothing about that reads as a wrong
+/// number downstream — it puts the format trailer a megabyte past the body, so
+/// the descriptor carries **no pixel format**, and seven downstream gates fail
+/// closed on that. The guest loses the texture and the draw refuses with
+/// `draw_prepare_texture_resolve_missing`.
+///
+/// The body length is the derivation and it is asserted here rather than
+/// described: a descriptor is `TEXTURE_DESC_BASE_LEN + (levels - 1) * 36` bytes,
+/// so a 332-byte body *is* seven levels and cannot be 32 775 of them. The four
+/// lengths measured on the boot that found this are on
+/// [`TEXTURE_DESC_MIPMAP_LEVEL_COUNT`].
+#[test]
+fn the_mip_level_count_is_one_byte_and_its_neighbour_is_another_field() {
+    use crate::contract::endian::{st16, st32};
+    use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
+    const LEVELS: usize = 7;
+    let body = TEXTURE_DESC_BASE_LEN + (LEVELS - 1) * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+    assert_eq!(body, 332, "the length identity this test turns on");
+    let mut b = vec![0u8; body];
+    b[TEXTURE_DESC_MIPMAP_LEVEL_COUNT] = LEVELS as u8;
+    // What the game sets and the desktop never does. Reading the pair as one
+    // count is what this asserts against.
+    b[TEXTURE_DESC_MIP_FIELD_UNDECODED] = 0x80;
+    st32(&mut b[TEXTURE_DESC_USED_SIZE..], 64 * 64 * 4);
+    st32(&mut b[TEXTURE_DESC_ROW_STRIDE..], 256);
+    st32(&mut b[TEXTURE_DESC_WIDTH..], 64);
+    st32(&mut b[TEXTURE_DESC_HEIGHT..], 64);
+    for extra in 0..LEVELS - 1 {
+        let rec = TEXTURE_DESC_LEVEL_RECORDS + extra * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+        let side = 32u32 >> extra;
+        st32(&mut b[rec + TEXTURE_LEVEL_WIDTH..], side.max(1));
+        st32(&mut b[rec + TEXTURE_LEVEL_HEIGHT..], side.max(1));
+        st32(&mut b[rec + TEXTURE_LEVEL_ROW_STRIDE..], side.max(1) * 4);
+    }
+    let pf_off = TEXTURE_DESC_PIXEL_FORMAT + (LEVELS - 1) * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
+    st16(&mut b[pf_off..], MTL_FORMAT_BGRA8_UNORM);
+
+    let cap = crate::observe::FailCapture::start();
+    let d = decode_texture_descriptor(&b).expect("the descriptor decodes");
+    assert_eq!(d.mipmap_level_count, LEVELS as u32);
+    assert_eq!(d.levels.len(), LEVELS, "every level the body carries is read");
+    assert_eq!(
+        d.declared_pixel_format(),
+        Some(MTL_FORMAT_BGRA8_UNORM),
+        "the shifted format trailer must be inside the body, which is the whole \
+         thing the level count decides"
+    );
+    let lines = cap.lines();
+    assert!(
+        !lines
+            .iter()
+            .any(|l| l.starts_with("texture_desc_levels_over_cap")
+                || l.starts_with("texture_desc_format_unreachable")),
+        "neither corruption guard may fire on a well-formed seven-level \
+         descriptor: {lines:?}"
+    );
+    // The undecoded neighbour is on the record rather than merely absent.
+    let note = lines
+        .iter()
+        .find(|l| l.starts_with("texture_desc_mip_field_undecoded"))
+        .expect("a non-zero undecoded field must be reported once");
+    assert!(note.contains("value=0x80") && note.contains("levels=7"), "{note}");
+}
+
 /// A mip level the descriptor named but the body does not reach is a drop,
 /// and it says so.
 ///
@@ -1693,6 +1817,106 @@ fn a_depth_stencil_pipeline_with_a_sample_count_decodes() {
         d.raster_sample_count, 4,
         "the guest's requested sample count is read rather than defaulted"
     );
+}
+
+/// Build a type-7 render-pipeline descriptor out of a compact-TLV field list.
+///
+/// Three tests below differ only in the fields, and each hand-rolled the same
+/// header/offset arithmetic. One builder means a layout change fails once.
+#[cfg(test)]
+fn render_pipeline_desc(object_id: u32, fields: &[(u8, u32)]) -> Vec<u8> {
+    let mut b = vec![0u8; TYPE7_FIRST_TLVS + 1 + fields.len() * 6];
+    let len = b.len() as u32;
+    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[4..], len);
+    st32(&mut b[8..], object_id);
+    st32(&mut b[12..], len - TYPE7_FIRST_TLVS as u32);
+    b[TYPE7_FIRST_TLVS] = fields.len() as u8;
+    let mut p = TYPE7_FIRST_TLVS + 1;
+    for &(tag, value) in fields {
+        b[p] = tag;
+        b[p + 1] = 4;
+        st32(&mut b[p + 2..], value);
+        p += 6;
+    }
+    b
+}
+
+/// A pipeline carrying Metal's legacy alpha-test and logic-op **values** decodes.
+///
+/// The regression this pins is a game's whole canvas. Asphalt 8 on a macos-13
+/// x86/Vulkan boot builds pipelines carrying `0x2e` and `0x37` — private
+/// setters on `MTLRenderPipelineDescriptorInternal`, so no workload built out of
+/// Metal's public API had ever produced them — and while they were unidentified
+/// every draw through those three pipeline refs was refused: 1 348
+/// `draw_load_pipeline reason=desc_decode` and 8 604 clear-only fallbacks in one
+/// capture. Same shape as the map-view regression `0x04`/`0x09`/`0x0a` caused.
+///
+/// The field values are the ones the game actually sent, so this is that
+/// descriptor and not a synthetic stand-in for it.
+#[test]
+fn a_pipeline_with_legacy_alpha_test_and_logic_op_values_decodes() {
+    let b = render_pipeline_desc(
+        47,
+        &[
+            (PIPELINE_TAG_DEPTH_ATTACH_FORMAT, 252),
+            (PIPELINE_TAG_ALPHA_TEST_FUNCTION, 7),
+            (PIPELINE_TAG_LOGIC_OP, 2),
+            (PIPELINE_TAG_VERTEX_FUNC, 11),
+            (PIPELINE_TAG_FRAGMENT_FUNC, 12),
+        ],
+    );
+    let cap = crate::observe::FailCapture::start();
+    let d = decode_render_pipeline_descriptor(&b)
+        .expect("an alpha-test/logic-op pipeline is decoded, not refused");
+    assert_eq!((d.vertex_func_ref, d.fragment_func_ref), (11, 12));
+    assert!(
+        !cap.lines()
+            .iter()
+            .any(|l| l.contains("pipeline_descriptor_field_dropped")),
+        "a benign field is dropped with an argument, not on the fail channel: {:?}",
+        cap.lines()
+    );
+}
+
+/// The **enables** beside those two values are still refused, one at a time.
+///
+/// This is the load-bearing half of naming them. An alpha test that is on is a
+/// per-fragment discard this device does not implement and a logic op that is on
+/// replaces blending, so a pipeline asking for either must lose rather than
+/// render without it. Asserted against
+/// `RENDER_PIPELINE_TAGS_STILL_REFUSED` so adding one to the benign list fails
+/// here instead of silently rendering a frame the guest did not ask for.
+#[test]
+fn an_alpha_test_or_logic_op_enable_is_still_refused() {
+    for enable in RENDER_PIPELINE_TAGS_STILL_REFUSED {
+        assert!(
+            !RENDER_PIPELINE_TAGS_BENIGN.contains(&enable),
+            "{enable:#04x} enables a fixed-function stage this device does not \
+             implement and must never be treated as benign"
+        );
+        let b = render_pipeline_desc(
+            47,
+            &[
+                (enable, 1),
+                (PIPELINE_TAG_VERTEX_FUNC, 11),
+                (PIPELINE_TAG_FRAGMENT_FUNC, 12),
+            ],
+        );
+        let cap = crate::observe::FailCapture::start();
+        assert!(
+            decode_render_pipeline_descriptor(&b).is_err(),
+            "{enable:#04x} must refuse the pipeline"
+        );
+        // Named, not merely refused: the tag and its first value are what let a
+        // reader identify the next one without a debugger.
+        let line = cap
+            .lines()
+            .into_iter()
+            .find(|l| l.contains("pipeline_descriptor_field_dropped"))
+            .unwrap_or_else(|| panic!("{enable:#04x} refused without naming itself"));
+        assert!(line.contains(&format!("tag={enable:#04x}")), "{line}");
+    }
 }
 
 #[test]

--- a/crates/reims-vgpu/src/runtime/draw/mod.rs
+++ b/crates/reims-vgpu/src/runtime/draw/mod.rs
@@ -1361,14 +1361,25 @@ pub(crate) fn load_render_pipeline<M: HostMemory + HostOps>(
                 return None;
             }
         };
-    let Ok(p) = decode_render_pipeline_descriptor(&desc) else {
-        report.reason(
-            task_id,
-            pipeline_ref,
-            crate::observe::ladder_slug!("", desc_decode),
-            &format!("desc_len={}", desc.len()),
-        );
-        return None;
+    let p = match decode_render_pipeline_descriptor(&desc) {
+        Ok(p) => p,
+        Err(status) => {
+            // The decoder's own name for what it refused, carried through rather
+            // than collapsed into `desc_decode`. Without it this line said only
+            // that a 292-byte descriptor did not decode, and finding out *why*
+            // meant correlating its `t=` against an `OFF type7_pipeline_shape`
+            // line in the same millisecond — which is how the alpha-test and
+            // logic-op tags were found and is not a step the next reader should
+            // have to repeat.
+            use crate::observe::Decline;
+            report.reason(
+                task_id,
+                pipeline_ref,
+                crate::observe::ladder_slug!("", desc_decode),
+                &format!("desc_len={} decode={}", desc.len(), status.slug()),
+            );
+            return None;
+        }
     };
     // Both stages are required to build a pipeline, and the two are reported
     // apart because they are different guest mistakes — the compute sibling

--- a/crates/reims-vgpu/src/runtime/draw/tests.rs
+++ b/crates/reims-vgpu/src/runtime/draw/tests.rs
@@ -251,6 +251,45 @@ fn strided_window_extent_measures_padded_rows_and_refuses_unrepresentable_stride
     assert_eq!(strided_window_extent(64, 0, 4, 256), None);
     // Single-byte texels (the type-5 NV12 luma plane) take every stride.
     assert_eq!(strided_window_extent(64, 4, 1, 64), Some((256, 0)));
+    // The block-aware level form, on the geometry the gather refused for a
+    // whole session: a 64x64 BC3 level is 16 rows of 16 blocks. Tight rows
+    // report `bufferRowLength = 0`; a padded stride reports it in **texels**
+    // (Vulkan's unit even for compressed copies) and block-aligned, so 320
+    // bytes of stride over 16-byte blocks is 20 blocks = 80 texels. A stride
+    // that does not divide into whole blocks cannot describe a block row and
+    // refuses rather than rounding into a shifted image.
+    let bc3 = crate::contract::pixel_format::block_geometry(
+        crate::contract::pixel_format::MTL_FORMAT_BC3_RGBA,
+    )
+    .unwrap();
+    let level = |bpr: u64| crate::runtime::decode::resource::TextureLevelLayout {
+        offset: 0,
+        size: 4096,
+        row_stride: bpr,
+        width: 64,
+        height: 64,
+        depth: 1,
+    };
+    assert_eq!(
+        strided_level_extent(&level(256), bc3),
+        Some((4096, 0)),
+        "sixteen tight block rows of 256 bytes, not sixty-four texel rows"
+    );
+    assert_eq!(
+        strided_level_extent(&level(320), bc3),
+        Some((320 * 15 + 256, 80)),
+        "a padded block row reports its stride in block-aligned texels"
+    );
+    assert_eq!(
+        strided_level_extent(&level(250), bc3),
+        None,
+        "a stride below one tight block row is not a level"
+    );
+    assert_eq!(
+        strided_level_extent(&level(264), bc3),
+        None,
+        "a stride that is not whole blocks cannot describe a block row"
+    );
     assert_eq!(strided_window_extent(64, 4, 1, 96), Some((96 * 3 + 64, 96)));
 }
 
@@ -480,7 +519,15 @@ fn linear_volume_gather_carries_every_depth_plane() {
         height,
         depth,
     };
-    let (span, row_length) = strided_level_extent(&layout, 4).unwrap();
+    let (span, row_length) = strided_level_extent(
+        &layout,
+        pixel_format::BlockGeometry {
+            width: 1,
+            height: 1,
+            bytes: 4,
+        },
+    )
+    .unwrap();
     assert_eq!(span, row_stride * u64::from(height) * u64::from(depth));
     assert_eq!(row_length, 0);
 }
@@ -3121,6 +3168,180 @@ fn mrt_draw_request_type8_swizzled_view_rejected_as_color_rt() {
         )
         .is_none(),
         "swizzled type-8 must not resolve as color RT"
+    );
+}
+
+/// The six faces of a cube texture load in slice order, one face-stride apart.
+///
+/// The regression this pins is the missing car model: Asphalt 8's paint shader
+/// samples a BC3 cube environment map, `sampled_image_shape` refused `Cube`,
+/// and — because a failed record abandons the rest of its serialized pass —
+/// the one refusal cost 44 of the packet's 87 draws every frame.
+///
+/// Two halves, because they fail differently. The RGBA8 case checks *content*:
+/// each face is filled with its own byte, so a wrong stride shows as face N
+/// carrying face M's bytes rather than as a length mismatch. The BC3 case
+/// checks the *stride arithmetic itself* at the allocation boundary: a 64x64
+/// BC3 face is 16 block rows of 256 bytes — 4096, not the 16384 a texel-height
+/// stride would claim — so an allocation sized exactly for six faces passes and
+/// one byte less refuses on the sixth by name.
+#[cfg(feature = "backend-vulkan")]
+#[test]
+fn a_cube_texture_loads_six_faces_in_slice_order() {
+    use crate::contract::endian::{st16, st32, st64};
+    use crate::contract::pixel_format::{MTL_FORMAT_BC3_RGBA, MTL_FORMAT_RGBA8_UNORM};
+    use crate::runtime::decode::resource::{
+        list_object_entry_offset, LINEAR_DESC_HANDLE, LINEAR_DESC_SIZE, OBJECT_LIST_ENTRY_LEN,
+        OBJECT_TYPE_TEXTURE, RESOURCE_PAGE_SHIFT, TEXTURE_DESC_BASE_LEN, TEXTURE_DESC_HEIGHT,
+        TEXTURE_DESC_PIXEL_FORMAT, TEXTURE_DESC_ROW_STRIDE, TEXTURE_DESC_WIDTH,
+    };
+    use texture_view::{load_cube_faces, LinearLoadRefusal, NativeUploads};
+
+    // One writer for both cases: descriptor + object-list entry.
+    let install = |state: &mut DeviceState,
+                   host: &mut FakeHost,
+                   tex_ref: u32,
+                   w: u32,
+                   h: u32,
+                   bpr: u32,
+                   fmt: u16,
+                   alloc: u64,
+                   handle: u32| {
+        let mut desc = vec![0u8; TEXTURE_DESC_BASE_LEN];
+        st64(&mut desc[LINEAR_DESC_SIZE..], alloc);
+        st32(&mut desc[LINEAR_DESC_HANDLE..], handle);
+        st32(&mut desc[TEXTURE_DESC_ROW_STRIDE..], bpr);
+        st32(&mut desc[TEXTURE_DESC_WIDTH..], w);
+        st32(&mut desc[TEXTURE_DESC_HEIGHT..], h);
+        st16(&mut desc[TEXTURE_DESC_PIXEL_FORMAT..], fmt);
+        let desc_gva = 0x280u64;
+        write_task_gva_arm64e(host, &state.tasks[1], desc_gva, &desc);
+        let off = list_object_entry_offset(tex_ref, 256).unwrap();
+        let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
+        let packed = (OBJECT_TYPE_TEXTURE as u32) | ((TEXTURE_DESC_BASE_LEN as u32) << 8);
+        st32(&mut list_entry[0..], packed);
+        list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
+        write_task_gva_arm64e(host, &state.tasks[1], off, &list_entry);
+    };
+
+    // --- RGBA8 8x8: content proves the face order and the stride ------------
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    let (w, h, bpr) = (8u32, 8u32, 32u32);
+    let face_bytes = (bpr * h) as usize;
+    let handle = 8u32;
+    install(
+        &mut state,
+        &mut host,
+        7,
+        w,
+        h,
+        bpr,
+        MTL_FORMAT_RGBA8_UNORM,
+        (face_bytes as u64) * 6,
+        handle,
+    );
+    let data_gva = (handle as u64) << RESOURCE_PAGE_SHIFT;
+    for face in 0u8..6 {
+        let fill = vec![(face + 1) * 10; face_bytes];
+        write_task_gva_arm64e(
+            &mut host,
+            &state.tasks[1],
+            data_gva + (face as u64) * face_bytes as u64,
+            &fill,
+        );
+    }
+    let (bytes, format) = load_cube_faces(
+        &mut state,
+        &mut host,
+        1,
+        7,
+        NativeUploads::NONE,
+        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+    )
+    .expect("six RGBA8 faces load");
+    assert_eq!(
+        format.layout(),
+        crate::contract::pixel_format::TexelLayout::Rgba8
+    );
+    assert_eq!(bytes.len(), face_bytes * 6, "six tight faces, in one buffer");
+    for face in 0u8..6 {
+        let seg = &bytes[face as usize * face_bytes..(face as usize + 1) * face_bytes];
+        assert!(
+            seg.iter().all(|&b| b == (face + 1) * 10),
+            "face {face} must carry its own slice's bytes"
+        );
+    }
+
+    // --- BC3 64x64: the face stride is block rows, at the allocation edge ---
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    let bc_face = 256u64 * 16; // 16 block rows of 256 bytes: 4096, not 16384.
+    install(
+        &mut state,
+        &mut host,
+        9,
+        64,
+        64,
+        256,
+        MTL_FORMAT_BC3_RGBA,
+        bc_face * 6,
+        8,
+    );
+    let native_bc = NativeUploads {
+        block_compressed: true,
+        ..NativeUploads::NONE
+    };
+    let (bytes, format) = load_cube_faces(
+        &mut state,
+        &mut host,
+        1,
+        9,
+        native_bc,
+        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+    )
+    .expect("an allocation sized exactly for six BC3 faces loads");
+    assert_eq!(
+        format.layout(),
+        crate::contract::pixel_format::TexelLayout::Bc3Rgba
+    );
+    assert_eq!(bytes.len() as u64, bc_face * 6);
+
+    // One byte short of six faces: face five's span crosses the allocation and
+    // refuses by name, which is the failure mode a wrong stride must take —
+    // never shifted faces.
+    let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
+    let mut host = FakeHost::new();
+    gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
+    assert!(state.set_object_list(1, 0, 256));
+    install(
+        &mut state,
+        &mut host,
+        9,
+        64,
+        64,
+        256,
+        MTL_FORMAT_BC3_RGBA,
+        bc_face * 6 - 1,
+        8,
+    );
+    assert!(
+        matches!(
+            load_cube_faces(
+                &mut state,
+                &mut host,
+                1,
+                9,
+                native_bc,
+                crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+            ),
+            Err(LinearLoadRefusal::SpanExceedsAllocation { .. })
+        ),
+        "the sixth face must refuse past the allocation, not read past it"
     );
 }
 
@@ -6080,8 +6301,9 @@ fn a_draw_skipped_after_an_engine_refusal_is_counted_with_the_vertices_it_cost()
             slot: 0,
             texture_ref: 7,
             // 64x64 BGRA8 at a tight stride is exactly one 16 KiB page of the
-            // rig's walkable task, so the CLEAR seed Store lands and the tail's
-            // `any_store` precondition is met.
+            // rig's walkable task. The eager CLEAR seed is off by default now,
+            // so nothing stores and the tail reports NoMetal — the counter this
+            // test is about ticks on that same tail either way.
             target_gva: StoreRig::gva(1),
             row_stride: 64 * 4,
             width: 64,
@@ -6103,8 +6325,9 @@ fn a_draw_skipped_after_an_engine_refusal_is_counted_with_the_vertices_it_cost()
     drop(cap);
 
     assert!(
-        matches!(st, EncodeStatus::Ok),
-        "the CLEAR seed Store landed, so the record stored: {st:?}"
+        matches!(st, EncodeStatus::NoMetal("draw_vk_nothing_stored")),
+        "with the eager seed off nothing stored, and the tail says so by name \
+         (exec's clear fallback is what lands the clear for this packet): {st:?}"
     );
     assert!(
         lines.iter().any(|l| {
@@ -6843,12 +7066,18 @@ fn a_depth_attachment_is_keyed_on_the_guest_texture_the_pass_bound() {
         "a stencil-carrying depth attachment is its own resident"
     );
 
-    // No depth texture in the pass descriptor: nothing to key a resident on, and
-    // the engine's transient fallback is what runs.
-    assert_eq!(
-        id(&req(0, 1024, 768), false),
-        None,
-        "an unbound depth attachment names no resident"
+    // No depth texture in the pass descriptor: the resident is keyed on the
+    // pass's own geometry instead of on a texture, so the records of one
+    // serialized pass still share a single depth attachment. This used to be
+    // `None`, which handed every record its own empty transient buffer and lost
+    // occlusion between them — see
+    // `an_anonymous_depth_attachment_is_chain_stable_per_geometry` for the
+    // stability half of the rule; here the point is only that the anonymous
+    // key stays out of the texture namespace.
+    let anonymous = id(&req(0, 1024, 768), false).expect("an unbound depth still keys a resident");
+    assert!(
+        matches!(anonymous, TargetIdentity::Anonymous { .. }),
+        "an unbound depth attachment must not invent a texture identity: {anonymous:?}"
     );
     assert_eq!(
         depth_chain_identity(
@@ -6862,8 +7091,9 @@ fn a_depth_attachment_is_keyed_on_the_guest_texture_the_pass_bound() {
             },
             false
         ),
-        None,
-        "and neither does a pass with no depth attachment at all"
+        Some(anonymous),
+        "an absent depth attachment keys the same pass-geometry resident as a \
+         ref-0 one: the two spellings mean the same pass shape"
     );
 }
 

--- a/crates/reims-vgpu/src/runtime/draw/texture_view.rs
+++ b/crates/reims-vgpu/src/runtime/draw/texture_view.rs
@@ -422,6 +422,19 @@ pub(crate) enum ViewSampleRefusal {
     BaseUndeclared { base: u16 },
     ViewUndeclared { view: u16 },
     WidthMismatch { base_bpp: u32, view_bpp: u32 },
+    /// The two formats occupy the same bytes per addressable unit but address a
+    /// different **grid** of texels with them — one is block-compressed and the
+    /// other is not.
+    ///
+    /// Distinct from [`Self::WidthMismatch`] because the two numbers that
+    /// variant prints would be *equal* here and read as a contradiction:
+    /// `BC3_RGBA` and `RGBA32Float` are both sixteen bytes a unit, and one of
+    /// them spends those bytes on sixteen texels. Reinterpreting either as the
+    /// other is not a view of one allocation.
+    GridMismatch {
+        base_compressed: bool,
+        view_compressed: bool,
+    },
 }
 
 impl std::fmt::Display for ViewSampleRefusal {
@@ -439,14 +452,36 @@ impl std::fmt::Display for ViewSampleRefusal {
                     "view_width_mismatch base_bpp={base_bpp} view_bpp={view_bpp}"
                 )
             }
+            Self::GridMismatch {
+                base_compressed,
+                view_compressed,
+            } => {
+                write!(
+                    f,
+                    "view_grid_mismatch base_compressed={base_compressed} \
+                     view_compressed={view_compressed}"
+                )
+            }
         }
     }
 }
 
 /// Pick the sample format for a type-8 view over base storage.
 ///
-/// Metal texture views require the view format to be bpp-compatible with the base.
-/// Unknown formats (no `bytes_per_pixel`) fail visibly. `None` override inherits base.
+/// Metal texture views require the view format to be storage-compatible with the
+/// base. Compatibility is compared as a whole [`pixel_format::BlockGeometry`] —
+/// the grid *and* the bytes — rather than as a bytes-per-texel, because a
+/// block-compressed format has no bytes-per-texel at all and comparing two
+/// `None`s would have admitted a `BC1`-as-`BC3` reinterpretation while refusing
+/// every compressed texture outright.
+///
+/// That refusal was not theoretical: before this took the block form, **every**
+/// BC texture failed here as `linear_load_view_bpp_mismatch` — with no view
+/// override in play, because the base alone has no texel width — so a compressed
+/// bind never reached the loader at all.
+///
+/// Unknown formats (no [`pixel_format::block_geometry`]) fail visibly. `None`
+/// override inherits base.
 ///
 /// Almost every caller only needs "may I", which is what this answers. A caller
 /// that has to *print* a refusal wants [`effective_view_sample_format_reasoned`]
@@ -462,14 +497,22 @@ pub(crate) fn effective_view_sample_format_reasoned(
     view_fmt: Option<u16>,
 ) -> Result<u16, ViewSampleRefusal> {
     let sample = view_fmt.unwrap_or(base_fmt);
-    let base_bpp = pixel_format::bytes_per_pixel(base_fmt)
+    let base_block = pixel_format::block_geometry(base_fmt)
         .ok_or(ViewSampleRefusal::BaseUndeclared { base: base_fmt })?;
-    let sample_bpp = pixel_format::bytes_per_pixel(sample)
+    let sample_block = pixel_format::block_geometry(sample)
         .ok_or(ViewSampleRefusal::ViewUndeclared { view: sample })?;
-    if base_bpp != sample_bpp {
+    if base_block.bytes != sample_block.bytes {
         return Err(ViewSampleRefusal::WidthMismatch {
-            base_bpp,
-            view_bpp: sample_bpp,
+            base_bpp: base_block.bytes,
+            view_bpp: sample_block.bytes,
+        });
+    }
+    // Equal bytes over a different grid is its own refusal — see
+    // [`ViewSampleRefusal::GridMismatch`].
+    if (base_block.width, base_block.height) != (sample_block.width, sample_block.height) {
+        return Err(ViewSampleRefusal::GridMismatch {
+            base_compressed: base_block.is_compressed(),
+            view_compressed: sample_block.is_compressed(),
         });
     }
     Ok(sample)
@@ -634,11 +677,83 @@ pub(crate) fn load_linear_texture_host<M: HostMemory + HostOps>(
         task_id,
         texture_ref,
         level,
+        0,
         format_override,
         native,
         site,
     )
     .ok()
+}
+
+/// Load all six faces of a cube texture, tightly packed face after face — the
+/// layer order `VkBufferImageCopy` consumes with `layerCount = 6`.
+///
+/// Metal stores a cube as a six-slice array, and this device's measured
+/// array-packing rule (see [`load_linear_texture_impl`]'s `face` parameter) puts
+/// each face one face-stride after the last. Each face rides the ordinary 2D
+/// loader, so every conversion arm — native BC blocks, BGRA8, the RGBA8 convert
+/// fallback — serves a cube exactly as it serves the equivalent 2D texture, and
+/// a divergence between the two is not expressible.
+///
+/// Level 0 only, which is what the sampled bind path uploads for every shape
+/// (the engine creates its sampled images with one mip). The faces must agree
+/// on their byte layout by construction — one descriptor, one format — so the
+/// per-face formats are asserted equal rather than reconciled.
+// The Vulkan bind path is the only caller; the Metal arm's cube support is
+// native and never reloads faces on the CPU, so ungated this is dead code
+// there — which the cross-compiled clippy run is what catches.
+#[cfg(feature = "backend-vulkan")]
+pub(crate) fn load_cube_faces<M: HostMemory + HostOps>(
+    state: &mut DeviceState,
+    host: &mut M,
+    task_id: u32,
+    texture_ref: u32,
+    native: NativeUploads,
+    site: crate::runtime::render_writeback::SettleSite,
+) -> Result<(Vec<u8>, SampledByteFormat), LinearLoadRefusal> {
+    /// Faces of a cube. Not configurable: five is not a cube and neither is
+    /// seven, and the engine refuses `cube` images whose layer count is not
+    /// exactly this.
+    const CUBE_FACES: u32 = 6;
+    let mut packed: Vec<u8> = Vec::new();
+    let mut format: Option<SampledByteFormat> = None;
+    for face in 0..CUBE_FACES {
+        let (bytes, byte_format) = load_linear_texture_impl(
+            state,
+            host,
+            task_id,
+            texture_ref,
+            0,
+            face,
+            None,
+            native,
+            site,
+        )?;
+        match format {
+            None => {
+                // Sized once, from the first face: the five remaining reads of
+                // one descriptor cannot legally differ in length.
+                packed.reserve_exact(bytes.len() * (CUBE_FACES as usize - 1));
+                format = Some(byte_format);
+            }
+            Some(first) => {
+                // One descriptor, one format — a disagreement here is this
+                // loader's own bug, not the guest's, so it is a refusal rather
+                // than a debug assertion that vanishes in release.
+                if first.layout() != byte_format.layout() {
+                    return Err(LinearLoadRefusal::RowConvertUnsupported {
+                        format: 0,
+                    });
+                }
+            }
+        }
+        packed.extend_from_slice(&bytes);
+    }
+    let format = format.ok_or(LinearLoadRefusal::ZeroExtent {
+        width: 0,
+        height: 0,
+    })?;
+    Ok((packed, format))
 }
 
 /// Which non-RGBA8 sampled layouts a caller of the linear loaders will carry.
@@ -667,6 +782,18 @@ pub(crate) struct NativeUploads {
     /// `f16_to_unorm8_lut`, which clamps to `[0, 1]` and quantizes to 256
     /// levels; see [`pixel_format::TexelLayout::cpu_loader_arm_is_lossy`].
     pub float16: bool,
+    /// Upload the guest's BC (DXT / S3TC) blocks verbatim as the matching
+    /// `VK_FORMAT_BC*_BLOCK`.
+    ///
+    /// Unlike the two above this is not a saved pass or an exactness question —
+    /// it is the **only** path. There is no CPU decompressor here and there will
+    /// not be one, so a host that clears this flag loses the texture and says
+    /// so; see [`pixel_format::TexelLayout::has_cpu_loader_arm`], which answers
+    /// `false` for every BC layout. Set from
+    /// `engine::supports_block_compressed_sampled`, which is one Vulkan feature
+    /// for the whole family. Desktop GPUs have it; Apple GPUs carry ASTC
+    /// instead and read `false`.
+    pub block_compressed: bool,
 }
 
 impl NativeUploads {
@@ -675,6 +802,7 @@ impl NativeUploads {
     pub const NONE: Self = Self {
         bgra8: false,
         float16: false,
+        block_compressed: false,
     };
 
     /// Native BGRA8 only — the answer this parameter carried when it was a
@@ -689,6 +817,7 @@ impl NativeUploads {
     pub const BGRA8: Self = Self {
         bgra8: true,
         float16: false,
+        block_compressed: false,
     };
 
     /// Every native layout the loaders can produce.
@@ -701,6 +830,7 @@ impl NativeUploads {
     pub const ALL: Self = Self {
         bgra8: true,
         float16: true,
+        block_compressed: true,
     };
 }
 
@@ -719,6 +849,15 @@ pub(crate) fn linear_native_upload_format(
     native: NativeUploads,
 ) -> Option<TexelLayout> {
     use pixel_format::SampledClass;
+    // The compressed families are answered before the sampled class, because
+    // that vocabulary has no block in it and because the answer here is not an
+    // optimisation: a BC bind is native or it is a refusal. `None` when the host
+    // cannot sample the family sends it to the convert path, which declines by
+    // name for a format with no CPU loader arm — which is what a refusal looks
+    // like on this rail.
+    if let Some(layout) = pixel_format::block_compressed_layout(sample_format) {
+        return native.block_compressed.then_some(layout);
+    }
     // The decode contract's sampled class is the one rule for "which channel
     // order and width is this"; it folds each sRGB format onto its linear
     // sibling's layout, which is right — they share a layout. The qualifier is
@@ -745,6 +884,12 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     task_id: u32,
     texture_ref: u32,
     level: u32,
+    // Array slice / cube face to read. Slices pack as contiguous images at each
+    // mip — the rule `blit_exec`'s array copies measured against live guest
+    // traffic (opcode 0x12c, slices 1 and 2 at exact one-image offsets) — so a
+    // face is the level's own read one face-stride further in. 0 is every
+    // pre-existing caller, and everything below is unchanged for it.
+    face: u32,
     format_override: Option<u16>,
     native: NativeUploads,
     site: crate::runtime::render_writeback::SettleSite,
@@ -803,8 +948,30 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
         .ok_or(R::SizeOverflow)?;
     // Every depth plane belongs to the level; only the final plane's final-row
     // padding lies outside the bytes this loader reads.
-    let span = layout.slice_read_span(tight).ok_or(R::SizeOverflow)?;
-    let end = layout.offset.saturating_add(span);
+    //
+    // Counted in rows of storage rather than rows of texels, so a
+    // block-compressed level does not claim four times its own extent and get
+    // refused against the allocation the guest sized correctly.
+    let storage_rows = pixel_format::tight_row_count(h, base_fmt).ok_or(R::FormatBppUnknown {
+        format: base_fmt,
+    })?;
+    // One face-stride per slice past the level base. The stride is a whole
+    // image *including* its final row's padding — the packing rule is
+    // contiguous images, so face N+1 starts where face N's allocation ends,
+    // not where its last read ends. Zero for face 0, which is every 2D caller.
+    let face_off = if face == 0 {
+        0
+    } else {
+        bpr.checked_mul(u64::from(storage_rows))
+            .and_then(|stride| stride.checked_mul(u64::from(planes)))
+            .and_then(|stride| stride.checked_mul(u64::from(face)))
+            .ok_or(R::SizeOverflow)?
+    };
+    let gva = gva.checked_add(face_off).ok_or(R::SizeOverflow)?;
+    let span = layout
+        .slice_read_span_rows(storage_rows, tight)
+        .ok_or(R::SizeOverflow)?;
+    let end = layout.offset.saturating_add(face_off).saturating_add(span);
     if tex.allocation_size != 0 && end > tex.allocation_size {
         return Err(R::SpanExceedsAllocation {
             end,
@@ -856,11 +1023,11 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     // `need_rgba` is the RGBA8 figure. The tight-row check is the same
     // agreement one step earlier — a source row that is not exactly one tight
     // row of the upload layout cannot be copied straight through.
-    if let Some(fmt) = linear_native_upload_format(sample_fmt, native).filter(|fmt| {
-        (tight as u64) == (w as u64).saturating_mul(fmt.bytes_per_texel() as u64)
-    }) {
+    if let Some(fmt) = linear_native_upload_format(sample_fmt, native)
+        .filter(|fmt| fmt.tight_row_bytes(w) == Some(tight))
+    {
         let row_bytes = tight as usize;
-        let rows = (h as usize)
+        let rows = (fmt.tight_row_count(h) as usize)
             .checked_mul(planes as usize)
             .ok_or(R::SizeOverflow)?;
         let out_len = row_bytes.checked_mul(rows).ok_or(R::SizeOverflow)?;
@@ -890,7 +1057,7 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
     }
     let mut rgba = vec![0u8; need_rgba];
     let mut row = vec![0u8; tight as usize];
-    let rows = h.checked_mul(planes).ok_or(R::SizeOverflow)?;
+    let rows = storage_rows.checked_mul(planes).ok_or(R::SizeOverflow)?;
     for row_index in 0..rows {
         let row_gva = (row_index as u64)
             .checked_mul(bpr)
@@ -934,7 +1101,16 @@ where
     let tight = pixel_format::tight_row_bytes(width, sample_format).ok_or(R::FormatBppUnknown {
         format: sample_format,
     })?;
-    let rows = height.checked_mul(planes).ok_or(R::SizeOverflow)?;
+    // Rows of storage, not rows of texels: a BC level is a quarter as tall in
+    // blocks as it is in texels, rounded up. `tight_row_count` is the one
+    // spelling of that and it answers `height` for every uncompressed format,
+    // so this is the same read it always was for them.
+    let rows = pixel_format::tight_row_count(height, sample_format)
+        .ok_or(R::FormatBppUnknown {
+            format: sample_format,
+        })?
+        .checked_mul(planes)
+        .ok_or(R::SizeOverflow)?;
     let native_len = (tight as u64)
         .checked_mul(rows as u64)
         .and_then(host_alloc_len)
@@ -1006,6 +1182,166 @@ where
 mod texture_view_split_tests {
     use super::*;
     use crate::runtime::decode::resource::TextureViewDescriptor;
+
+    /// View compatibility is a whole storage grid, which is what lets a
+    /// compressed texture past this gate at all.
+    ///
+    /// The blocker this pins: the check compared `bytes_per_pixel`, and a BC
+    /// format has none — so **every** compressed texture was refused here as
+    /// `linear_load_view_bpp_mismatch` with no view override in play, because
+    /// the base format alone could not answer. A compressed bind never reached
+    /// the loader, and it would have read as "BC is unsupported" rather than as
+    /// this one gate.
+    ///
+    /// The two mismatch directions matter separately and the second is why this
+    /// is a grid and not a byte count: `BC3_RGBA` and `RGBA32Float` are both
+    /// sixteen bytes per addressable unit, and one of them spends them on
+    /// sixteen texels.
+    #[test]
+    fn a_view_is_compatible_by_storage_grid_not_by_texel_width() {
+        use crate::contract::pixel_format as pf;
+
+        // No override: the base format alone must pass, which is the case that
+        // was refusing every compressed texture.
+        assert_eq!(
+            effective_view_sample_format(pf::MTL_FORMAT_BC3_RGBA, None),
+            Some(pf::MTL_FORMAT_BC3_RGBA)
+        );
+        for &format in &[
+            pf::MTL_FORMAT_BC1_RGBA,
+            pf::MTL_FORMAT_BC1_RGBA_SRGB,
+            pf::MTL_FORMAT_BC4_R_SNORM,
+            pf::MTL_FORMAT_BC6H_RGB_FLOAT,
+            pf::MTL_FORMAT_BC7_RGBA_UNORM_SRGB,
+        ] {
+            assert_eq!(
+                effective_view_sample_format(format, None),
+                Some(format),
+                "{format:#x} must pass its own compatibility gate"
+            );
+        }
+        // The transfer-function view of one allocation is compatible: same grid,
+        // same bytes.
+        assert_eq!(
+            effective_view_sample_format(
+                pf::MTL_FORMAT_BC3_RGBA,
+                Some(pf::MTL_FORMAT_BC3_RGBA_SRGB)
+            ),
+            Some(pf::MTL_FORMAT_BC3_RGBA_SRGB)
+        );
+        // Different weight class in the same grid: eight bytes a block is not
+        // sixteen.
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BC1_RGBA,
+                Some(pf::MTL_FORMAT_BC3_RGBA)
+            ),
+            Err(ViewSampleRefusal::WidthMismatch {
+                base_bpp: 8,
+                view_bpp: 16
+            })
+        ));
+        // Same bytes, different grid — the case a byte-count comparison would
+        // have admitted, and the reason `GridMismatch` exists.
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BC3_RGBA,
+                Some(pf::MTL_FORMAT_RGBA32_FLOAT)
+            ),
+            Err(ViewSampleRefusal::GridMismatch {
+                base_compressed: true,
+                view_compressed: false
+            })
+        ));
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_RGBA32_FLOAT,
+                Some(pf::MTL_FORMAT_BC3_RGBA)
+            ),
+            Err(ViewSampleRefusal::GridMismatch {
+                base_compressed: false,
+                view_compressed: true
+            })
+        ));
+        // And the uncompressed rule is unchanged in both directions.
+        assert_eq!(
+            effective_view_sample_format(
+                pf::MTL_FORMAT_BGRA8_UNORM,
+                Some(pf::MTL_FORMAT_RGBA8_UNORM)
+            ),
+            Some(pf::MTL_FORMAT_RGBA8_UNORM)
+        );
+        assert!(matches!(
+            effective_view_sample_format_reasoned(
+                pf::MTL_FORMAT_BGRA8_UNORM,
+                Some(pf::MTL_FORMAT_RGBA16_FLOAT)
+            ),
+            Err(ViewSampleRefusal::WidthMismatch { .. })
+        ));
+    }
+
+    /// A BC bind is native or it is nothing, and the host capability is what
+    /// decides which.
+    ///
+    /// There is no CPU decompressor here, so unlike the BGRA8 and half-float
+    /// flags this one does not choose between a fast path and a slow one — it
+    /// chooses between the guest keeping its texture and losing it. That makes
+    /// the gate load-bearing rather than a performance switch, which is why it
+    /// is asserted in both directions: a `Some` on a host that cannot sample the
+    /// family would create an image in a format the driver never advertised.
+    #[test]
+    fn a_compressed_bind_is_native_or_refused() {
+        use crate::contract::pixel_format::{self as pf, TexelLayout};
+
+        let capable = NativeUploads {
+            block_compressed: true,
+            ..NativeUploads::BGRA8
+        };
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BC3_RGBA, capable),
+            Some(TexelLayout::Bc3Rgba)
+        );
+        // The sRGB spelling folds onto the same layout — identical blocks — and
+        // the qualifier is carried by `SampledByteFormat`'s source format.
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BC3_RGBA_SRGB, capable),
+            Some(TexelLayout::Bc3Rgba)
+        );
+        // Every family, so a member admitted to the contract and forgotten here
+        // fails rather than silently refusing at run time.
+        for format in [
+            pf::MTL_FORMAT_BC1_RGBA,
+            pf::MTL_FORMAT_BC2_RGBA,
+            pf::MTL_FORMAT_BC4_R_UNORM,
+            pf::MTL_FORMAT_BC5_RG_SNORM,
+            pf::MTL_FORMAT_BC6H_RGB_UFLOAT,
+            pf::MTL_FORMAT_BC7_RGBA_UNORM,
+        ] {
+            assert_eq!(
+                linear_native_upload_format(format, capable),
+                pf::block_compressed_layout(format),
+                "{format:#x} must reach the native rail on a capable host"
+            );
+            // A host without the family refuses, and `NativeUploads::BGRA8` is
+            // exactly such a host: the flag defaults off.
+            assert_eq!(
+                linear_native_upload_format(format, NativeUploads::BGRA8),
+                None,
+                "{format:#x} must not be bound on a host that cannot sample it"
+            );
+            assert_eq!(linear_native_upload_format(format, NativeUploads::NONE), None);
+        }
+        // The gate is per family, not per call: an uncompressed format is
+        // unaffected by it in either direction.
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BGRA8_UNORM, capable),
+            Some(TexelLayout::Bgra8)
+        );
+        assert_eq!(
+            linear_native_upload_format(pf::MTL_FORMAT_BGRA8_UNORM, NativeUploads::NONE),
+            None
+        );
+    }
 
     #[test]
     fn view_pixel_format_override_effective() {

--- a/crates/reims-vgpu/src/runtime/draw/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/draw/vulkan.rs
@@ -28,15 +28,21 @@ struct SampledImageShape {
 
 /// Map a translated SPIR-V sampled-image dimensionality onto the Vulkan image
 /// shape the sampled-draw path builds. `None` is a shape the path cannot yet
-/// express (`Cube` / `CubeArray`); the caller declines it by name so the gap
-/// stays visible instead of binding the wrong view type.
+/// express (`CubeArray`); the caller declines it by name so the gap stays
+/// visible instead of binding the wrong view type.
+///
+/// `Cube` maps to a six-layer cube image — the engine below has carried the
+/// whole cube rail (`CUBE_COMPATIBLE` creation, `CUBE` view, the
+/// layers-is-six and square-face validations) for as long as this function has
+/// been refusing to name it. What a cube bind additionally needs is six faces
+/// of bytes, which the caller loads through
+/// [`texture_view::load_cube_faces`] when this shape comes back; the shape
+/// alone must not be read as "the ladder's one-face bytes are fine".
 fn sampled_image_shape(
     kind: crate::runtime::spirv_bind::SampledImageKind,
 ) -> Option<SampledImageShape> {
     use crate::runtime::spirv_bind::SampledImageKind;
-    // Plain 2D, which every other shape is a single flag away from. `cube` is
-    // false in all of them: the two cube kinds decline below rather than
-    // reaching here, so nothing this function returns ever sets it.
+    // Plain 2D, which every other shape is a single flag away from.
     let d2 = SampledImageShape {
         arrayed: false,
         volume: false,
@@ -65,7 +71,15 @@ fn sampled_image_shape(
             ..d2
         },
         SampledImageKind::D3 => SampledImageShape { volume: true, ..d2 },
-        SampledImageKind::Cube | SampledImageKind::CubeArray => return None,
+        SampledImageKind::Cube => SampledImageShape {
+            cube: true,
+            layers: 6,
+            ..d2
+        },
+        // A cube array needs 6*n layers and n is the descriptor's array length,
+        // which this decoder does not read; no guest has been measured sending
+        // one. The refusal keeps the gap named.
+        SampledImageKind::CubeArray => return None,
     })
 }
 
@@ -122,9 +136,27 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
     let mut engine_refusal: Option<&'static str> = None;
     // Solid CLEAR seed Stores only when this record owns guest writeback
     // (last of a serialized chain, or unified always-writeback).
+    //
+    // The recipe capture for the clear-only exit is *outside* the landing gate:
+    // that exit hands the clear colour to the next record's seed whether or not
+    // this device eagerly writes it into guest pages, and capturing it inside
+    // the gate is how turning the eager write off would silently break record
+    // chaining too.
     crate::runtime::chain_phase::enter(crate::runtime::chain_phase::Phase::PrepSeed);
+    if writeback_guest {
+        if let Some(c0) = colors.first() {
+            if crate::contract::pass_action::store_action_publishes_single_sample(c0.store_action)
+                && (c0.load_action == MTL_LOAD_ACTION_CLEAR
+                    || c0.load_action == MTL_LOAD_ACTION_DONT_CARE)
+                && c0.width != 0
+                && c0.height != 0
+            {
+                color0_solid = Some((c0.width, c0.height, c0.clear_color));
+            }
+        }
+    }
     if writeback_guest && clear_seed_enabled() {
-        for (i, c) in colors.iter().enumerate() {
+        for c in colors.iter() {
             // Reports an out-of-contract value; the gate below is unchanged, and
             // it is the site that disagrees with this module's writeback loop
             // about what such a value means. See `super::store_action_in_contract`.
@@ -140,11 +172,6 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             if c.width == 0 || c.height == 0 {
                 continue;
             }
-            // Neither writer below takes a full-surface RGBA copy — the GVA
-            // landing repeats a single row and the type-11 landing builds its own
-            // image in the mapping's order — so the only reader of one is the
-            // clear-only exit, and it is the one place that builds it.
-            let solid = (i == 0).then_some((c.width, c.height, c.clear_color));
             // Which branch this loop actually takes, how many bytes it lands and
             // what the landing costs. `prep_seed_us` is 8.6 µs of a 41 µs chain
             // on the `blur=40` dial and rebuilding the images without their two
@@ -205,9 +232,6 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             };
             if ok {
                 any_store = true;
-                if i == 0 {
-                    color0_solid = solid;
-                }
                 crate::observe::line(format!(
                     "linux_clear_store mid={} gva={:#x} {}x{} pipe={} load={}",
                     c.mapping_id, c.target_gva, c.width, c.height, req.pipeline_ref, c.load_action
@@ -718,55 +742,61 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
         }
     }
 
+    // The skipped-draw census sits above the `any_store` split, because the
+    // split no longer decides whether a draw was skipped — only whether a CLEAR
+    // seed happened to land first. When the eager seed was unconditional this
+    // block lived inside the seeded arm, and turning the seed off (its default
+    // now) silently retired the only instrument that counts what an engine
+    // refusal costs the guest.
+    if req.vertex_count > 0 || req.indexed.is_some() {
+        // This used to end in the literal `(m2v pending)`, which was a
+        // hardcoded guess and was wrong. The tail is reached whenever the
+        // engine draw did not land, for any reason, and a translation still
+        // being in flight is only one of them — on a driven macos-26 boot
+        // the guess accounted for **none** of the 114 lines it printed.
+        // Pipeline 160 alone produced 105 of them, from t=36351 to
+        // t=112002, while its one translation was queued at t=36340 and
+        // reported `done ... ok` at t=36351. The real refusals were a
+        // sampled-texture validation check and the driver quarantine.
+        //
+        // `refused_by` is deliberately not spelled `reason=`: the census
+        // ranks fail-channel lines on that key, and the underlying slug is
+        // already counted once at its own emitter. Naming it twice would
+        // make one refusal read as two.
+        crate::observe::fail(format!(
+            "linux_clear_store draws_skipped reason=draws_skipped_after_engine_refusal \
+             pipe={} vtx={} refused_by={}",
+            req.pipeline_ref,
+            req.vertex_count,
+            engine_refusal.unwrap_or("engine_draw_not_attempted")
+        ));
+        // The line above dedupes on `(pipeline, slug)` and the count does
+        // not, so the two answer different questions and only this one can
+        // be added up. Reading the line count as the draw count understates
+        // it by however many times one pipeline was refused — which on a
+        // rail that composites the same layer every frame is the entire
+        // magnitude. Nothing else in the census counts a draw the engine
+        // refused, so "what did this refusal cost the guest" had no
+        // instrument at all; a bare zero here now means no draw was
+        // skipped, rather than meaning nobody was counting.
+        //
+        // The vertices are banded beside the draws because a skipped
+        // six-vertex full-screen quad and a skipped fifty-four-vertex pass
+        // are the same 1 in a draw count and are not the same loss.
+        //
+        // Deliberately **not** split by `engine_refusal` here. That slug is
+        // already this crate's vocabulary and is counted at its own
+        // emitter, so keying a census entry on it would merge two
+        // populations under one name and make one refusal read as two —
+        // the same reason `refused_by=` above is not spelled `reason=`.
+        // The split lives on the fail line; the magnitude lives here.
+        crate::runtime::drain::note_store_route("draws_skipped_after_engine_refusal");
+        crate::runtime::drain::note_store_route_n(
+            "draws_skipped_after_engine_refusal_vertices",
+            u64::from(req.vertex_count),
+        );
+    }
     if any_store {
-        if req.vertex_count > 0 || req.indexed.is_some() {
-            // This used to end in the literal `(m2v pending)`, which was a
-            // hardcoded guess and was wrong. The tail is reached whenever the
-            // engine draw did not land, for any reason, and a translation still
-            // being in flight is only one of them — on a driven macos-26 boot
-            // the guess accounted for **none** of the 114 lines it printed.
-            // Pipeline 160 alone produced 105 of them, from t=36351 to
-            // t=112002, while its one translation was queued at t=36340 and
-            // reported `done ... ok` at t=36351. The real refusals were a
-            // sampled-texture validation check and the driver quarantine.
-            //
-            // `refused_by` is deliberately not spelled `reason=`: the census
-            // ranks fail-channel lines on that key, and the underlying slug is
-            // already counted once at its own emitter. Naming it twice would
-            // make one refusal read as two.
-            crate::observe::fail(format!(
-                "linux_clear_store draws_skipped reason=draws_skipped_after_engine_refusal \
-                 pipe={} vtx={} refused_by={}",
-                req.pipeline_ref,
-                req.vertex_count,
-                engine_refusal.unwrap_or("engine_draw_not_attempted")
-            ));
-            // The line above dedupes on `(pipeline, slug)` and the count does
-            // not, so the two answer different questions and only this one can
-            // be added up. Reading the line count as the draw count understates
-            // it by however many times one pipeline was refused — which on a
-            // rail that composites the same layer every frame is the entire
-            // magnitude. Nothing else in the census counts a draw the engine
-            // refused, so "what did this refusal cost the guest" had no
-            // instrument at all; a bare zero here now means no draw was
-            // skipped, rather than meaning nobody was counting.
-            //
-            // The vertices are banded beside the draws because a skipped
-            // six-vertex full-screen quad and a skipped fifty-four-vertex pass
-            // are the same 1 in a draw count and are not the same loss.
-            //
-            // Deliberately **not** split by `engine_refusal` here. That slug is
-            // already this crate's vocabulary and is counted at its own
-            // emitter, so keying a census entry on it would merge two
-            // populations under one name and make one refusal read as two —
-            // the same reason `refused_by=` above is not spelled `reason=`.
-            // The split lives on the fail line; the magnitude lives here.
-            crate::runtime::drain::note_store_route("draws_skipped_after_engine_refusal");
-            crate::runtime::drain::note_store_route_n(
-                "draws_skipped_after_engine_refusal_vertices",
-                u64::from(req.vertex_count),
-            );
-        }
         // The one exit that hands the seed on: this record encoded no draw, so
         // the solid colour it landed *is* this chain's colour-0 content, and the
         // next record loads it as its seed. Built here rather than in the loop
@@ -3323,21 +3353,50 @@ pub(super) fn strided_window_extent(w: u32, h: u32, bpp: u64, bpr: u64) -> Optio
 }
 
 /// Byte window and Vulkan row pitch for one complete linear texture level.
-/// Depth planes are consecutive at `row_stride * height`; only the final
+/// Depth planes are consecutive at `row_stride * rows`; only the final
 /// plane's final-row padding is outside the sampled window.
+///
+/// Takes the layout's storage **grid** rather than a bytes-per-texel, so a
+/// block-compressed level is described in its own units: rows of blocks (a
+/// quarter of the texel height), a tight row of `blocks_across * block.bytes`,
+/// and a `bufferRowLength` converted back to **texels** — Vulkan's unit for
+/// that field even on compressed copies, where it must be a multiple of the
+/// block width. An uncompressed block is 1x1, for which every expression below
+/// reduces to exactly what [`strided_window_extent`] computes; that helper
+/// keeps its texel spelling because its other callers are rails a compressed
+/// format cannot reach (type-11/type-5 surfaces, whose formats have a
+/// bytes-per-texel by construction).
+///
+/// This is the arithmetic that kept BC textures off the zero-copy gather:
+/// with texel math a 2048x2048 BC3 level claimed four times its own rows and
+/// sixteen times its bytes, so the rail refused (`zc_lin_block_compressed`)
+/// and every bind fell to the CPU re-read + memcmp rung — measured at 53 % of
+/// the drain thread's whole second on a driven race, with the host GPU 6 %
+/// busy.
 pub(super) fn strided_level_extent(
     layout: &crate::runtime::decode::resource::TextureLevelLayout,
-    bpp: u64,
+    block: pixel_format::BlockGeometry,
 ) -> Option<(u64, u32)> {
-    let (last_plane, row_length_texels) = strided_window_extent(
-        layout.width,
-        layout.height,
-        bpp,
-        layout.row_stride,
-    )?;
+    let bytes = u64::from(block.bytes);
+    let bpr = layout.row_stride;
+    let tight = u64::from(block.blocks_across(layout.width)).checked_mul(bytes)?;
+    let rows = block.block_rows(layout.height);
+    if bpr < tight || bytes == 0 || !bpr.is_multiple_of(bytes) || rows == 0 {
+        return None;
+    }
+    let last_plane = bpr
+        .checked_mul(u64::from(rows.checked_sub(1)?))?
+        .checked_add(tight)?;
+    let row_length_texels = if bpr == tight {
+        0
+    } else {
+        u32::try_from(bpr / bytes)
+            .ok()?
+            .checked_mul(block.width)?
+    };
     let preceding_planes = u64::from(layout.planes() - 1)
-        .checked_mul(layout.row_stride)?
-        .checked_mul(u64::from(layout.height))?;
+        .checked_mul(bpr)?
+        .checked_mul(u64::from(rows))?;
     Some((preceding_planes.checked_add(last_plane)?, row_length_texels))
 }
 
@@ -4346,7 +4405,14 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
             (layout, format, components)
         }
     };
-    let bpp = native.bytes_per_texel();
+    // The block-compressed layouts ride this rail in their own units — see
+    // `strided_level_extent`, which speaks the layout's storage grid. The
+    // refusal that used to sit here ("falling to the CPU rail costs one upload
+    // per texture") was measured wrong on the workload that mattered: the CPU
+    // rung's *staleness check* re-reads and byte-compares the full span per
+    // **bind**, not per texture, and a driven Asphalt 8 race paid ~11 800 such
+    // binds a second — 53 % of the drain thread — for textures whose bytes
+    // never changed.
     let Some((gva, layout)) = tex.level_gva(0, state.page_shift) else {
         crate::runtime::drain::note_store_route("zc_lin_no_level_gva");
         return None;
@@ -4356,8 +4422,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
         crate::runtime::drain::note_store_route("zc_lin_no_extent");
         return None;
     }
-    let Some((span, row_length_texels)) = strided_level_extent(layout, bpp as u64)
-    else {
+    let Some((span, row_length_texels)) = strided_level_extent(layout, native.block()) else {
         crate::runtime::drain::note_store_route("zc_lin_unstrideable");
         return None;
     };
@@ -4871,11 +4936,17 @@ fn native_scratch_to_upload(
 ) -> Option<(Vec<u8>, TexelLayout)> {
     let native = native_uploads_for(sample_fmt);
     let bpr = bpr as usize;
+    // Both the row width and the row *count* are the upload layout's own, which
+    // for a block-compressed layout is a row of blocks and a quarter of the
+    // texel height. Spelled `tight_row_bytes` / `tight_row_count` rather than
+    // `w * bytes_per_texel` and `h` so the compressed and uncompressed families
+    // are one expression — the texel form is correct for one of them and short
+    // by four in each axis for the other.
     if let Some(fmt) = linear_native_upload_format(sample_fmt, native)
-        .filter(|fmt| tight == (w as u64).saturating_mul(fmt.bytes_per_texel() as u64))
+        .filter(|fmt| fmt.tight_row_bytes(w).map(u64::from) == Some(tight))
     {
         let row_bytes = tight as usize;
-        let rows = (h as usize).checked_mul(planes as usize)?;
+        let rows = (fmt.tight_row_count(h) as usize).checked_mul(planes as usize)?;
         let mut out = vec![0u8; row_bytes.checked_mul(rows)?];
         for row_index in 0..rows {
             let src = row_index.checked_mul(bpr)?;
@@ -4933,6 +5004,13 @@ fn native_scratch_to_upload(
 /// answer for — so keying on it is the same rule stated once, not a fast path
 /// that could disagree with the slow one.
 fn native_uploads_for(sample_format: u16) -> NativeUploads {
+    // A compressed format has to ask, and it is not in `narrows_to_unorm8`'s
+    // set: that set is the formats whose CPU arm is *lossy*, and a BC format has
+    // no CPU arm at all. Asked first so the keyed fast path below keeps meaning
+    // what its doc says it means.
+    if pixel_format::is_block_compressed(sample_format) {
+        return native_uploads_asking_host();
+    }
     if !pixel_format::narrows_to_unorm8(sample_format) {
         return NativeUploads::BGRA8;
     }
@@ -4955,6 +5033,11 @@ fn native_uploads_asking_host() -> NativeUploads {
         // would be two fields nobody could point at a host that needed them.
         float16: engine::supports_sampled_layout_linear_filter(TexelLayout::Rgba16Float)
             && engine::supports_sampled_layout_linear_filter(TexelLayout::Rg16Float),
+        // One flag for BC1 through BC7 because Vulkan gates them behind one
+        // feature — see `caps::device_features::DeviceFeatures::
+        // texture_compression_bc`. A per-family flag would be ten fields nobody
+        // could point at a host that needed them.
+        block_compressed: engine::supports_block_compressed_sampled(),
         ..NativeUploads::BGRA8
     }
 }
@@ -5022,7 +5105,18 @@ fn load_linear_guest_memoized<M: HostMemory + HostOps>(
     // an image the guest sized to `offset + read_span` exactly is refused here
     // and served by the general loader below, which uses the tighter rule. That
     // is a slower path, not lost work.
-    let span = bpr.checked_mul(h as u64)?.checked_mul(u64::from(planes))?;
+    // Rows of **storage**, not rows of texels. A block-compressed level is a
+    // quarter as tall in rows as it is in texels, so the texel form claimed four
+    // times this level's extent and refused it against the allocation the guest
+    // sized correctly: a 64x64 BC3 texture with `bpr=256` and `alloc=4096`
+    // scored 16 384 here and declined, which cost the whole sampled bind
+    // (`draw_prepare_texture_resolve_missing`, `reason=linear_sample`) with
+    // nothing naming the arithmetic. `tight_row_count` answers `h` for every
+    // uncompressed format, so this is the same span it always was for them.
+    let storage_rows = pixel_format::tight_row_count(h, declared_format)?;
+    let span = bpr
+        .checked_mul(u64::from(storage_rows))?
+        .checked_mul(u64::from(planes))?;
     let native_len = host_alloc_len(span)?;
     if tex.allocation_size != 0 && layout.offset.saturating_add(span) > tex.allocation_size {
         return None;
@@ -7416,6 +7510,69 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         })
                         .unwrap_or(source_planes);
                 }
+                // A cube bind replaces the ladder's bytes outright: everything
+                // above loaded exactly one image, and a cube is six. The reload
+                // costs one extra CPU read of the level per bind — cube maps on
+                // this workload are 64x64 BC3, 24 KiB — and the engine's
+                // content-keyed sampled cache absorbs the GPU upload, so the
+                // cost does not scale with draws. The identity is dropped with
+                // the old bytes: it named the one-face read, and carrying it
+                // over would let a memoized single face satisfy a six-face bind.
+                //
+                // A cube whose source is a render target stays refused by
+                // name: a resident holds one 2D image and cannot produce six
+                // faces, and binding face 0 six times is a wrong image rather
+                // than a fallback. A zero-copy gather source is *replaced*, not
+                // refused — its runs describe the same guest bytes the reload
+                // reads, just through a rail that can only express one image —
+                // which is how the first live cube bind actually arrived: an
+                // RGBA8 cube rode the gather and the reload is what serves it.
+                let (source, sampled_vk_format, byte_origin, bytes_identity, tw, th) = if !cube {
+                    (source, sampled_vk_format, byte_origin, bytes_identity, tw, th)
+                } else {
+                    if source_is_target {
+                        return Err(DrawError::DrawPreparation(
+                            DrawPreparationDecline::TextureDimensionUnsupported {
+                                stage: if frag_stage { "fragment" } else { "vertex" },
+                                index,
+                                texture_ref,
+                                binding: img_bind,
+                                kind: "Cube(resident source)".to_string(),
+                            },
+                        ));
+                    }
+                    match texture_view::load_cube_faces(
+                        state,
+                        host,
+                        req.task_id,
+                        texture_ref,
+                        native_uploads_asking_host(),
+                        crate::runtime::render_writeback::SettleSite::LinearTextureSampled,
+                    ) {
+                        Ok((faces, byte_format)) => (
+                            crate::backend::vulkan::engine::SampledSource::Bytes(
+                                std::sync::Arc::new(faces),
+                            ),
+                            translate::pixel::vk_sampled_bytes(byte_format),
+                            crate::backend::vulkan::engine::SampledByteOrigin::LinearTexture,
+                            None,
+                            tw,
+                            th,
+                        ),
+                        Err(refusal) => {
+                            use crate::observe::Decline;
+                            return Err(DrawError::DrawPreparation(
+                                DrawPreparationDecline::TextureDimensionUnsupported {
+                                    stage: if frag_stage { "fragment" } else { "vertex" },
+                                    index,
+                                    texture_ref,
+                                    binding: img_bind,
+                                    kind: format!("Cube({})", refusal.slug()),
+                                },
+                            ));
+                        }
+                    }
+                };
                 // A Vulkan 1D image is defined to have height 1; the descriptor
                 // may report the LUT's texel count in either axis, so collapse
                 // to a single row and fold the other axis into the width the
@@ -7546,8 +7703,13 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                 cube: shape.cube,
                 one_dim: shape.one_dim,
                 multisampled: false,
+                // One texel per layer, because the byte-length validation
+                // charges every layer: a cube's neutral substitute is six
+                // texels, not one. `layers` is 1 for every other shape here, so
+                // the repeat is the identity for them.
                 source: crate::backend::vulkan::engine::SampledSource::Bytes(std::sync::Arc::new(
-                    crate::contract::pixel_format::solid_rgba8(1, 1, &[0.0; 4]),
+                    crate::contract::pixel_format::solid_rgba8(1, 1, &[0.0; 4])
+                        .repeat(shape.layers.max(1) as usize),
                 )),
                 byte_origin: crate::backend::vulkan::engine::SampledByteOrigin::Synthetic,
                 format: ash::vk::Format::R8G8B8A8_UNORM,
@@ -8432,6 +8594,23 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                                 .as_ref()
                                 .map(|d| (d.clear_depth as f32, d.load_action))
                                 .unwrap_or((1.0, MTL_LOAD_ACTION_CLEAR));
+                            // A record that continues a serialized render pass
+                            // shares the pass's depth attachment with the
+                            // records before it, so it LOADs whatever they
+                            // tested and wrote — the exact rule the record loop
+                            // already forces on every colour attachment at
+                            // `di > 0`, and depth was the attachment it missed.
+                            // Without it each record re-CLEARed (or re-created)
+                            // the depth buffer and inter-record occlusion was
+                            // lost. `honours_load` still gates on the resident
+                            // actually holding content, so a chain whose first
+                            // record failed degrades to CLEAR by name instead
+                            // of loading an undefined image.
+                            let load_action = if req.continues_render_pass {
+                                MTL_LOAD_ACTION_LOAD
+                            } else {
+                                load_action
+                            };
                             // `MTLLoadActionLoad` is carried through as the
                             // guest wrote it. Whether it can be *honoured* is
                             // not decidable here — it needs the depth resident's
@@ -8980,7 +9159,10 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
 /// lifetime is safe on portability-subset devices because the final record
 /// materializes guest bytes before the packet completes.
 /// The registry resident this draw's **depth** attachment renders into, if the
-/// guest's pass descriptor named a depth texture.
+/// guest's pass descriptor named a depth texture — and a **stable anonymous
+/// identity** when it did not, so a serialized pass's records still share one
+/// depth attachment. `None` is now only a pass with no colour extent to size a
+/// buffer by.
 ///
 /// The depth buffer is a guest resource with a guest lifetime. A pass descriptor
 /// binds `MTLRenderPassDepthAttachment.texture`, this device decodes its ref, and
@@ -9024,21 +9206,47 @@ pub(super) fn depth_chain_identity(
     req: &DrawEncodeRequest,
     with_stencil: bool,
 ) -> Option<crate::backend::vulkan::engine::TargetIdentity> {
-    let depth = req.depth_attach.as_ref()?;
-    if depth.texture_ref == 0 {
-        return None;
-    }
     let c0 = req.colors.first()?;
     let (width, height) = (c0.width, c0.height);
     if width == 0 || height == 0 {
         return None;
     }
-    Some(crate::backend::vulkan::engine::TargetIdentity::Texture {
-        ref_: depth.texture_ref,
-        width,
-        height,
-        generation: 0,
-        stencil: with_stencil,
+    if let Some(depth) = req.depth_attach.as_ref().filter(|d| d.texture_ref != 0) {
+        return Some(crate::backend::vulkan::engine::TargetIdentity::Texture {
+            ref_: depth.texture_ref,
+            width,
+            height,
+            generation: 0,
+            stencil: with_stencil,
+        });
+    }
+    // No named depth texture. This used to be `None`, which handed the engine a
+    // fresh transient buffer **per record** — and a serialized Metal render
+    // pass is one pass with one depth attachment, so a 3D scene split across
+    // records lost occlusion between them: a later record's geometry drew
+    // through an earlier record's, which on a live garage scene rendered the
+    // driver through the car body. `vk_alloc_sites` read the same story as an
+    // allocation storm: `transient_depth` at ~45 000 a session against a rail
+    // whose own doc expects it near zero.
+    //
+    // The identity is anonymous but **stable per pass geometry**: every term in
+    // the slot is a decoded pass value (colour extent, stencil aspect), so two
+    // records of one chain — and two passes of the same shape — resolve the
+    // same resident, and the registry's own geometry check recreates it when
+    // the shape changes. Contents never leak between passes the guest can
+    // observe: a pass's first record still carries the guest's own load action
+    // (CLEAR on every measured workload), and a guest asking LOAD on a depth
+    // buffer it never named is loading contents it never wrote — the same
+    // undefined-by-its-own-choice reading the generation-zero argument above
+    // rests on.
+    //
+    // The high bit keeps this out of the engine's other `Anonymous` slots,
+    // which count up from zero.
+    Some(crate::backend::vulkan::engine::TargetIdentity::Anonymous {
+        slot: (1u64 << 63)
+            | (u64::from(width) << 32)
+            | (u64::from(height) << 1)
+            | u64::from(with_stencil),
     })
 }
 
@@ -11788,14 +11996,71 @@ mod vulkan_split_tests {
         }
     }
 
+    /// A pass's records share one depth attachment, named or not.
+    ///
+    /// The regression this pins rendered the driver through the car: an
+    /// anonymous depth (`depth_attach` absent or ref 0) returned `None`, the
+    /// engine allocated a fresh transient depth **per record**, and a
+    /// serialized pass lost occlusion between its records —
+    /// `vk_alloc_sites transient_depth` at ~45 000 a session against a rail
+    /// documented as near-zero.
+    ///
+    /// The anonymous identity must be a pure function of decoded pass values
+    /// (extent, stencil aspect): stable across records and passes of one shape,
+    /// distinct across shapes, and out of the engine's counting `Anonymous`
+    /// slots.
     #[test]
-    fn sampled_image_shape_declines_cube_shapes_by_name() {
+    fn an_anonymous_depth_attachment_is_chain_stable_per_geometry() {
+        use crate::backend::vulkan::engine::TargetIdentity;
+        let req = |w: u32, h: u32| {
+            let mut r = DrawEncodeRequest::default();
+            r.colors.push(ColorRtRequest {
+                width: w,
+                height: h,
+                ..Default::default()
+            });
+            r
+        };
+        let a = depth_chain_identity(&req(1280, 720), false).expect("anonymous depth resolves");
+        let b = depth_chain_identity(&req(1280, 720), false).expect("same shape resolves");
+        assert_eq!(a, b, "one shape, one identity — that is the whole fix");
+        assert!(
+            matches!(a, TargetIdentity::Anonymous { slot } if slot >> 63 == 1),
+            "anonymous depth lives in the tagged half of the slot space: {a:?}"
+        );
+        // Different extent, different identity; same extent with a stencil
+        // aspect is a different image and so a different identity too.
+        assert_ne!(a, depth_chain_identity(&req(1920, 1080), false).unwrap());
+        assert_ne!(a, depth_chain_identity(&req(1280, 720), true).unwrap());
+        // A named depth texture keeps its own namespace, untouched by this.
+        let mut named = req(64, 64);
+        named.depth_attach = Some(crate::runtime::decode::render::DepthAttachment {
+            texture_ref: 42,
+            ..Default::default()
+        });
+        assert!(matches!(
+            depth_chain_identity(&named, false),
+            Some(TargetIdentity::Texture { ref_: 42, .. })
+        ));
+        // And no colour extent is still no identity: nothing sizes the buffer.
+        assert_eq!(depth_chain_identity(&DrawEncodeRequest::default(), false), None);
+    }
+
+    #[test]
+    fn sampled_image_shape_names_the_cube_and_declines_its_array() {
         use crate::runtime::spirv_bind::SampledImageKind;
 
-        // Cube sampling is not expressed on the sampled-draw path yet; the
-        // shape stays `None` so the caller declines it visibly rather than
-        // binding a 2D view under a cube sampler.
-        assert!(sampled_image_shape(SampledImageKind::Cube).is_none());
+        // A cube is a six-layer cube image, exactly — the engine refuses any
+        // other layer count for a cube — and it is not spelled as an array:
+        // `CUBE` and `TYPE_2D_ARRAY` are different view types and the flags
+        // drive that choice one-to-one.
+        let cube = sampled_image_shape(SampledImageKind::Cube).expect("cube is expressible");
+        assert_eq!(
+            (cube.cube, cube.arrayed, cube.volume, cube.one_dim, cube.layers),
+            (true, false, false, false, 6)
+        );
+        // A cube array needs 6*n layers and n is a descriptor field this
+        // decoder does not read; the refusal keeps that gap named.
         assert!(sampled_image_shape(SampledImageKind::CubeArray).is_none());
     }
     /// An MRT secondary attachment is named by ITS OWN guest pages.
@@ -11893,15 +12158,39 @@ mod vulkan_split_tests {
 /// process.
 ///
 /// Read once. The arms differ in what reaches the guest's pages, so a boot that
-/// flipped it midway would be two devices in one log — and the arm that does not
-/// write is an ablation whose damage is only visible in a photograph, so it has
-/// to hold for the whole boot the photograph is of.
+/// flipped it midway would be two devices in one log.
+///
+/// # The default is now OFF, and the argument is structural, not a timing
+///
+/// The eager seed pre-writes every writeback-owning record's full clear frame
+/// into guest pages before the engine runs — ~3.7 MB a pass, measured at
+/// **~550 ms of every drain-thread second** on a driven Asphalt 8 race, the
+/// single largest cost left on the rail after the BC gather landed. Both jobs
+/// it was doing are done elsewhere:
+///
+/// * **Success**: the record's own Store covers the identical extent
+///   (`store_gva_frame_direct` and the type-11 writeback both land the whole
+///   `width x height`), so every seeded byte was overwritten.
+/// * **Failure**: `runtime::exec`'s fallback applies the pass's clears through
+///   `apply_clear` whenever a packet lands zero draws — "for any draw-fail
+///   class, not only NoMetal", per its own comment — which is the case the
+///   seed's early landing was insurance for.
+///
+/// The chaining recipe (`color0_solid`) is captured outside this gate, so the
+/// clear-only exit still hands the next record its seed either way.
+///
+/// What the OFF arm genuinely gives up: a packet where an *early* record's
+/// engine draw succeeds and a *later* record fails leaves the target holding
+/// the early records' rendered content instead of the clear — which is more of
+/// the guest's work on screen, not less. `REIMS_VGPU_CLEAR_SEED=on` restores
+/// the old eager write for an A/B; damage from either arm is only visible in a
+/// photograph, so hold the arm for the whole boot the photograph is of.
 fn clear_seed_enabled() -> bool {
     use std::sync::OnceLock;
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| {
         let (state, value) = crate::env::read(crate::env::CLEAR_SEED);
-        let on = !matches!(state, crate::env::Switch::Off);
+        let on = matches!(state, crate::env::Switch::On);
         crate::observe::off(format!(
             "clear_seed on={on} switch={state:?} value={}",
             value.unwrap_or_else(|| "<unset>".into())

--- a/crates/reims-vgpu/src/runtime/objects/mod.rs
+++ b/crates/reims-vgpu/src/runtime/objects/mod.rs
@@ -657,8 +657,8 @@ pub fn device_desc_format_to_mtl(raw: u32) -> u16 {
 /// Unknown formats fail closed.
 pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
     use crate::contract::pixel_format::{
-        MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_R8_UNORM, MTL_FORMAT_RG8_UNORM, MTL_FORMAT_RGBA16_FLOAT,
-        MTL_FORMAT_RGBA8_UNORM,
+        MTL_FORMAT_BGR10A2_UNORM, MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_R8_UNORM,
+        MTL_FORMAT_RG8_UNORM, MTL_FORMAT_RGBA16_FLOAT, MTL_FORMAT_RGBA8_UNORM,
     };
     if pixel_format == 0 {
         return 0;
@@ -686,6 +686,30 @@ pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
         0x5247_4241 => MTL_FORMAT_RGBA8_UNORM,
         // 'RGhA' / half-float variants seen as AhGR in notes
         0x5247_6841 | 0x4168_4752 => MTL_FORMAT_RGBA16_FLOAT,
+        // 'l10r' — `kCVPixelFormatType_ARGB2101010LEPacked`. One single-plane
+        // 32-bit little-endian word per texel: two bits of alpha in the high
+        // bits, then ten each of red, green and blue, with blue in the low
+        // bits. That is `MTLPixelFormatBGR10A2Unorm`'s word exactly, which is
+        // also `VK_FORMAT_A2R10G10B10_UNORM_PACK32`'s — see
+        // `contract::pixel_format::MTL_FORMAT_BGR10A2_UNORM` and
+        // `backend::vulkan::translate::pixel`, which already paired those two.
+        //
+        // Two independent sources agree on it, which is why it is stated rather
+        // than proposed. A driven macos-13 x86/Vulkan boot running Asphalt 8
+        // declares its 1280x720 render surface with this FourCC and then binds a
+        // **type-5 reference-texture view** over the same allocation whose own
+        // `pixel_format` field reads `0x5e` — the guest naming `BGR10A2Unorm`
+        // itself, reported as `rt_type5_view_differs sid=117 view=1280x720
+        // fmt=0x5e ... base fmt=0x0`. The surface geometry closes it: the type-4
+        // record's `bytes_per_row` is 5120 over a width of 1280, which is four
+        // bytes a texel, and its `length` 0x384000 is that stride times 720.
+        //
+        // Before this arm the surface reached `draw::render_target`'s
+        // `rt_type4_base_format` as a zero — that resolve's typed refusal for a
+        // multi-plane or unknown-FourCC surface — so **every** draw of the frame
+        // failed and the game's window was black. One 100 s capture of it held
+        // 20 822 `draw_fail_clear_fallback` records and 0 successful draws.
+        0x6c31_3072 => MTL_FORMAT_BGR10A2_UNORM,
         // Single-plane R8 / RG8 OSTypes used as plane textures (not biplanar media fourcc).
         // 'L008' / common R8 fourccs are rare on type-4; MTL ordinals already handled above.
         // 'R8  ' / 'RG08' if ever seen as OSType:

--- a/crates/reims-vgpu/src/runtime/objects/tests.rs
+++ b/crates/reims-vgpu/src/runtime/objects/tests.rs
@@ -455,6 +455,58 @@ fn decode_type4_plane0() {
     );
 }
 
+/// An `'l10r'` render surface reaches a colour attachment, end to end.
+///
+/// The bug class: a guest game creates its render surface as a single-plane
+/// `kCVPixelFormatType_ARGB2101010LEPacked` IOSurface, this table answered 0 for
+/// it, and 0 out of this table is `draw::render_target`'s
+/// `rt_type4_base_format` refusal — so every draw of every frame failed and the
+/// window was black. Two tables had to answer for that to stop, and a test on
+/// either one alone would have passed while the window stayed black, so this
+/// walks the whole chain the resolve walks.
+///
+/// The geometry is the surface measured on the boot that found it: width 1280 at
+/// a 5120-byte row is four bytes a texel, which is what the packed word is, and
+/// it is the reading that says this FourCC is not a multi-plane media format
+/// wearing a colour name.
+#[test]
+fn an_l10r_surface_resolves_as_a_packed_ten_bit_colour_attachment() {
+    use crate::contract::pixel_format as pf;
+
+    const FOURCC_L10R: u32 = 0x6c31_3072;
+    let built = Type4Builder::new(0x384000, 0x100, FOURCC_L10R, 1).plane(0, 0, 1280, 720, 5120, 0);
+    let surf = decode_type4_surface(built.bytes()).expect("type4 decodes");
+    assert!(
+        !type4_is_multiplanar(&surf),
+        "a packed single-plane colour surface must not read as biplanar"
+    );
+
+    // Step one: the FourCC names a Metal format at all. A zero here is the
+    // refusal the resolve turns into a dropped colour attachment.
+    let mtl = iosurface_pixel_format_to_mtl(surf.pixel_format);
+    assert_eq!(mtl, pf::MTL_FORMAT_BGR10A2_UNORM, "'l10r' must name BGR10A2Unorm");
+
+    // Step two: that format is one this device will render into, which is what
+    // `translate::pixel::color_attachment` derives its answer from. Both steps
+    // were missing and either one alone leaves the frame black.
+    assert_eq!(
+        pf::render_target_bpp(mtl),
+        Some(4),
+        "a named format this device will not render into is still a black window"
+    );
+    // Step three: the frame can be landed in the guest's own pages by a copy
+    // that converts nothing, which is the only lossless route for a format whose
+    // channels do not sit on byte boundaries.
+    assert_eq!(
+        pf::store_texel_order(mtl),
+        Some(pf::TexelLayout::Bgr10a2Unorm)
+    );
+    // The row stride the surface declared is the tight stride for this format at
+    // this width, so the reading above is the surface's own and not an
+    // assumption about what a packed word costs.
+    assert_eq!(pf::tight_row_bytes(surf.width, mtl), Some(surf.bytes_per_row));
+}
+
 #[test]
 fn fourcc_420f_not_bgra_and_multiplanar() {
     assert_eq!(iosurface_pixel_format_to_mtl(IOSURFACE_FOURCC_420F), 0);


### PR DESCRIPTION
## What this is

Six decode/contract gaps and two drain-thread performance costs on the x86 macOS / Linux Vulkan pathway, each diagnosed from the device's own typed refusals on a driven 3D workload (macos-13 rail, NVIDIA host) and fixed in the owning type, with tests that fail without the change. Together they take real-world Metal 3D content from refusing every draw to executing with **zero failed draws over whole boots**.

## Contract gaps (in the order the refusals surfaced them)

1. **`'l10r'` IOSurface FourCC** (`kCVPixelFormatType_ARGB2101010LEPacked`) was unmapped in `objects::iosurface_pixel_format_to_mtl`, so any surface declared with it hit `rt_type4_base_format`'s refusal and every draw into it failed. Now `MTLPixelFormatBGR10A2Unorm`, corroborated by the guest's own type-5 view (`fmt=0x5e`) and the surface's 4-byte/texel geometry. The format joins `render_target_bpp`, `store_texel_order` (the byte copy is the only lossless rail for a packed word), `sampled_class`, and the CPU conversion rails, with a bit-exact round-trip test.
2. **The texture descriptor's `mipmapLevelCount` is one byte, not a u16** — the byte above it carries an undecoded field, so a 7-level pyramid decoded as 32 775 levels and the shifted format trailer landed a megabyte past the body: the descriptor then carried no pixel format and the bind refused. The body-length identity `116+(n−1)·36` pins the width on four guest-sent descriptors; the undecoded neighbour is reported by name.
3. **Pipeline TLV tags `0x2e`/`0x37`** are `alphaTestFunction`/`logicOperation`, identified by driving `-[_MTLDevice serializeRenderPipelineDescriptor:]` in the guest with one setter perturbed per fork (the full ~30-tag map is recorded at `note_pipeline_tlv_fields`). The two values are benign — their enables (`0x2d`/`0x2f`) are absent on the measured traffic and stay refused — so pipelines carrying them decode instead of losing every draw.
4. **The BC1–BC7 block-compressed family** enters the contract as `BlockGeometry`: `bytes_per_pixel` stays `None` for every BC format on purpose, and `block_geometry`/`tight_row_bytes`/`tight_row_count` are the one sizing vocabulary both families share (an uncompressed block is 1×1). Gated on `VkPhysicalDeviceFeatures::textureCompressionBC` — asked, enabled, and published through `DeviceCapabilitySnapshot`; Apple/MoltenVK hosts read false and refuse by name. The per-layout capability masks narrowed to `TexelLayout::UNCOMPRESSED_COUNT` (the packed word's `const` assertion caught the overflow). The blit texture-to-texture copy converts to block space once at the top; the buffer↔texture blit rails refuse compressed by name; view compatibility compares whole storage grids, so equal bytes over a different grid is its own refusal.
5. **Cube maps on the sampled rail**: `sampled_image_shape` names `Cube` as a six-layer cube image (the engine had carried CUBE creation and layers-is-six validation all along), and `texture_view::load_cube_faces` reads the six faces one face-stride apart — the contiguous-image array packing `blit_exec` measured against live traffic, block-rows corrected. The bind replaces the ladder's one-image source for `Bytes` and `GuestRuns` sources; a resident `Target` cube stays refused by name.
6. **A serialized render pass's records share one depth attachment**: anonymous depth now keys a stable pass-geometry resident instead of a fresh transient per record (`vk_alloc_sites transient_depth` read ~45 000/session against a rail documented near zero — inter-record occlusion was silently lost), and continuation records force depth LOAD exactly as the record loop already forced colour LOAD.

## Drain-thread performance

Measured mid-workload: host GPU 6% busy, drain duty 0.91 — the device was CPU-bound on its own thread.

- **BC binds ride the zero-copy gather**: `strided_level_extent` and the engine's GuestRuns validation speak block units, retiring a per-bind CPU re-read + memcmp that cost 53% of every drain second (~11 800 binds/s on textures whose bytes never change). `sampled_us` 530 ms/s → 3–58 ms/s.
- **The eager CLEAR-seed Store defaults off** (`REIMS_VGPU_CLEAR_SEED=on` restores it for A/B): a successful record's Store overwrites the identical extent and `exec`'s `apply_clear` covers zero-draw packets, so its ~550 ms/s of guest-page writes bought nothing. The chaining recipe is captured outside the gate and the skipped-draw census was hoisted above the `any_store` split it had been quietly living under. `prep_seed_us` 550 ms/s → ~0.2 ms/s; drain duty 0.91 → 0.09–0.44.

## Verification

- `cargo test` (vulkan,host-window): 2208 lib + 97 other targets green, serial.
- Feature matrix compiles on all three arms; clippy `-D warnings` on all three arms adds **no findings** over the pre-existing set (19 vulkan / 17 metal, all `uninlined_format_args`/`dead_code` in untouched lines).
- Live driven boots on the macos-13 rail at each step: `mrt_request` failures 7 226 → 0, `draw_load_pipeline desc_decode` 1 348 → 0, `tex_bad_bpp` 448 → 0, whole-boot `draws_fail` → 0, `transient_depth` → 0.

**Not verified**: the arm64/Metal pathways beyond cross-compiled clippy + `cargo check` (no Apple host here); the wire-fixture oracle tests (fixtures absent on this checkout, reported ignored); sustained-animation-probe A/B for the two perf changes (measured through the censuses instead); `REIMS_VGPU_GUEST_IMPORT=off` copying-rail boots for the BC gather.
