### PR TITLE
Windows host port (WSL/Windows + WHPX + native Vulkan)

### DIFF
--- a/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/context.rs
@@ -790,7 +790,12 @@ impl DeviceContext {
                 ash::khr::xcb_surface::NAME,
                 ash::khr::wayland_surface::NAME,
             ];
-            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            // VK_KHR_win32_surface is the Windows host-window surface
+            // extension; one arm per OS keeps each list exactly what that
+            // loader can advertise.
+            #[cfg(target_os = "windows")]
+            let platform: &[&CStr] = &[ash::khr::win32_surface::NAME];
+            #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
             let platform: &[&CStr] = &[];
             let available: Vec<&CStr> = platform
                 .iter()

--- a/crates/reims-vgpu/src/host_window/present.rs
+++ b/crates/reims-vgpu/src/host_window/present.rs
@@ -710,6 +710,14 @@ fn build_event_loop() -> Result<EventLoop<FramePublished>, WindowError> {
         EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
         EventLoopBuilderExtWayland::with_any_thread(&mut builder, true);
     }
+    #[cfg(target_os = "windows")]
+    {
+        use winit::platform::windows::EventLoopBuilderExtWindows;
+        // Windows refuses a non-main-thread event loop unless the application
+        // opts in explicitly; reims owns a dedicated window thread on every
+        // host, so this is the same opt-in the X11/Wayland arms make above.
+        EventLoopBuilderExtWindows::with_any_thread(&mut builder, true);
+    }
     builder
         .build()
         .map_err(|e| WindowError::EventLoopBuild(e.to_string()))

--- a/crates/reims-vgpu/src/lib.rs
+++ b/crates/reims-vgpu/src/lib.rs
@@ -54,16 +54,18 @@ compile_error!(
      any other host."
 );
 
-// Vulkan reaches the GPU through MoltenVK on macOS and a native ICD on Linux.
-// Any other host is untested rather than known-broken — name it here so a new
-// port is a deliberate edit to this list, not an accident.
+// Vulkan reaches the GPU through MoltenVK on macOS and a native ICD on
+// Linux; Windows hosts use their native ICDs (NVIDIA/AMD/Intel ship
+// VK_KHR_win32_surface and Vulkan 1.2+). Any other host is untested rather
+// than known-broken — name it here so a new port is a deliberate edit to this
+// list, not an accident.
 #[cfg(all(
     feature = "backend-vulkan",
-    not(any(target_os = "macos", target_os = "linux"))
+    not(any(target_os = "macos", target_os = "linux", target_os = "windows"))
 ))]
 compile_error!(
-    "backend-vulkan is supported on target_os = \"macos\" (MoltenVK) and \
-     target_os = \"linux\" (native ICD) only"
+    "backend-vulkan is supported on target_os = \"macos\" (MoltenVK), \
+     target_os = \"linux\", and target_os = \"windows\" (native ICDs)"
 );
 
 pub mod contract;

--- a/scripts/qemu-build/qemu-build.sh
+++ b/scripts/qemu-build/qemu-build.sh
@@ -244,9 +244,13 @@ printf '%s\n' "$STAMP_WANTED" > build/qemu-build.stamp
 printf '%s\n' "$REIMS_VGPU_BACKEND" > build/reims-vgpu-backend.stamp
 
 # --- Build ----------------------------------------------------------------------
-QEMU_BIN="$QEMU_SRC/build/qemu-system-${QEMU_TARGET}"
-echo "[qemu-build] building qemu-system-${QEMU_TARGET} (links reims-vgpu / $REIMS_VGPU_BACKEND) ..."
-ninja -C build "qemu-system-${QEMU_TARGET}"
+case "$(uname -s)" in
+  MINGW*|MSYS*) EXE_SUFFIX=".exe" ;;
+  *) EXE_SUFFIX="" ;;
+esac
+QEMU_BIN="$QEMU_SRC/build/qemu-system-${QEMU_TARGET}${EXE_SUFFIX}"
+echo "[qemu-build] building qemu-system-${QEMU_TARGET}${EXE_SUFFIX} (links reims-vgpu / $REIMS_VGPU_BACKEND) ..."
+ninja -C build "qemu-system-${QEMU_TARGET}${EXE_SUFFIX}"
 
 # --- Verify (target-specific) ---------------------------------------------------
 case "$QEMU_TARGET" in

--- a/vm/boot-windows.sh
+++ b/vm/boot-windows.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# vm/boot-windows.sh — boot the macos-13 rail on a Windows host (WHPX + native Vulkan).
+# Run from an MSYS2 MINGW64 shell. Expects the rail files under C:/hackintosh/vm/.
+set -euo pipefail
+VM_DIR="C:/hackintosh/vm"
+QEMU="${QEMU_BIN:-$(dirname "$0")/../vendor/qemu/build/qemu-system-x86_64.exe}"
+DEVICE="${DEVICE:-reims-vgpu-pci}"
+ACCEL="${ACCEL:-whpx}"
+
+ARGS=(
+  -accel "$ACCEL"
+  -m 16G
+  -cpu "Skylake-Client,-hle,-rtm,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+ssse3,+sse4.2,+popcnt,+avx,+avx2,+aes,+xsave,+xsaveopt,check"
+  -machine q35
+  -vga none
+  -device pci-bridge,chassis_nr=5,id=pci.5,bus=pcie.0,addr=1e.0
+  -device qemu-xhci,id=xhci
+  -device usb-kbd,bus=xhci.0
+  -device usb-tablet,bus=xhci.0
+  -smp 16,cores=16,sockets=1
+  -device 'isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'
+  -drive if=pflash,format=raw,readonly=on,file="$VM_DIR/OVMF_CODE_4M.fd"
+  -drive if=pflash,format=raw,file="$VM_DIR/OVMF_VARS.fd"
+  -smbios type=2
+  -device ich9-ahci,id=sata
+  -drive id=OpenCoreBoot,if=none,format=qcow2,file="$VM_DIR/OpenCore.qcow2"
+  -device ide-hd,bus=sata.2,drive=OpenCoreBoot
+  -drive id=MacHDD,if=none,format=qcow2,file="$VM_DIR/macos.img"
+  -device ide-hd,bus=sata.4,drive=MacHDD
+  -qmp tcp:127.0.0.1:4444,server=on,wait=off
+  -action reboot=shutdown
+  -netdev user,id=net0,ipv6=off,hostfwd=tcp::2222-:22
+  -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
+  -serial "file:$VM_DIR/serial-windows.log"
+)
+
+EXTRA_ARGS=()
+if [ "$DEVICE" = "reims-vgpu-pci" ]; then
+  EXTRA_ARGS=(-display none -device "reims-vgpu-pci,id=reimsvgpu,romfile=$VM_DIR/reims-vgpu-gop.rom,rombar=1,bus=pci.5,addr=00.0")
+  export REIMS_VGPU_WINDOW="${REIMS_VGPU_WINDOW:-on}"
+else
+  EXTRA_ARGS=(-display sdl -device "$DEVICE")
+fi
+
+"$QEMU" "${ARGS[@]}" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
# Windows host port (WSL/Windows + WHPX + native Vulkan)

This series enables the x86 macOS / host-Vulkan pathway on Windows hosts
(QEMU on Windows + WHPX + a native Vulkan ICD such as the NVIDIA driver).

## What works (verified on this machine)

- QEMU fork builds on Windows (MSYS2 MINGW64): qemu-system-x86_64.exe with
  tcg + whpx accelerators and the reims-vgpu-pci device linked against the
  Vulkan staticlib.
- The Rust staticlib compiles for x86_64-pc-windows-gnu (backend-vulkan,
  host-window) after the lib.rs platform gate is widened.
- The device initializes on the NVIDIA native driver: vk_caps reports
  api=1.4, host_pointer_import=supported, swapchain 1920x1080, first frame
  presented.
- With the GOP option ROM attached (boot-windows.sh), the guest firmware
  installs the reims EFI GOP and the boot loader proceeds to kernel handoff
  under both TCG and WHPX.

## Patch list

- 0001 lib.rs: allow backend-vulkan on target_os = "windows" (the comment in
  the gate says a new port is a deliberate edit to this list — this is it).
- 0002 context.rs: add the VK_KHR_win32_surface platform arm next to the
  macOS/Linux arms.
- 0003 present.rs: Windows refuses a non-main-thread winit event loop unless
  the app opts in; add the EventLoopBuilderExtWindows::with_any_thread
  opt-in, mirroring the existing X11/Wayland arms.
- 0004 qemu-build.sh: the ninja target and QEMU_BIN path carry a .exe suffix
  on MINGW/MSYS hosts.
- 0005 (qemu submodule) meson.build: Windows link arm for the Rust staticlib
  (winit/ntdll/ws2_32 system libs; -lm/-ldl do not exist on mingw).
- 0006 (qemu submodule) reims-vgpu-pci.c: guard the packed-view mmap alias
  with #if !defined(_WIN32) and return -1 on Windows — scattered GVA mappings
  take the copying rails, which the Rust side already treats as the fallback.
- boot-windows.sh (new): Windows boot script — WHPX/TCG selection, the
  standard pcibridge + GOP romfile attach, QMP over tcp (no unix sockets on
  Windows), SSH forward 2222.

## Not in this series (known follow-ups)

- The early-boot console rail on Windows: host_window_capture reports
  window_capture_unsupported; the GOP framebuffer path works, the
  capture-based console feed does not.
- A separate QEMU whpx issue (WHPX: Unexpected VP exit code 4) blocks the
  guest kernel from completing boot under WHPX; evidence package is in
  contrib/qemu-issue-bugB.md. TCG boots past the boot loader.

## Test notes

- Build: MSYS2 MINGW64 with PYTHONUTF8=1 (non-ASCII Windows locales).
- Rust deps for windows-gnu resolved via cargo registry (TUNA sparse mirror
  used in China); metal2vulkan stayed a git dependency in the WSL tree.
- The WSL/Linux KVM pathway is unaffected: cargo check on Linux passes with
  the same changes.
