### PR TITLE
Rename wire tags to their respective names

### DIFF
--- a/crates/reims-vgpu-contract/src/iosurface_pages.rs
+++ b/crates/reims-vgpu-contract/src/iosurface_pages.rs
@@ -6,9 +6,9 @@ use crate::{align_up_u64, checked_add_u64, checked_mul_u64};
 
 pub const U32_SIZE: usize = 4;
 
-/// Minimum typed type-11 object-list descriptor length (geometry prefix).
+/// Minimum typed mapper-ref-texture object-list descriptor length (geometry prefix).
 /// Live blobs are often longer (0x38/0x58) with an unused/constant tail.
-/// There is no multi-mip level-record layout on type-11: Metal rejects
+/// There is no multi-mip level-record layout on mapper-ref-texture: Metal rejects
 /// mipmapped IOSurface textures (`mipmapLevelCount > 1`).
 ///
 /// `TYPE11_` rather than `TEXTURE_DESC_`, which is what these were called.
@@ -456,12 +456,12 @@ pub fn sample_window_from_device_surface(
 ///
 /// Three ways a window is derived, in order:
 ///
-/// - **A wire-carried plane index** (type-5 record `+0x20`) names its plane
+/// - **A wire-carried plane index** (ref-texture record `+0x20`) names its plane
 ///   record directly. It is the only key that separates same-geometry planes:
 ///   a v0a8 surface's Y plane 0 and alpha plane 2 are both R8 at the luma
 ///   geometry, so the scan below matches two and takes neither.
 /// - **A single-plane surface** uses the surface-level base and pitch.
-/// - **A multi-plane surface with no wire index** (type-11) matches width,
+/// - **A multi-plane surface with no wire index** (mapper-ref-texture) matches width,
 ///   height and bytes-per-element, and takes the plane only when *exactly one*
 ///   matches.
 pub fn sample_window_from_device_desc(
@@ -534,7 +534,7 @@ pub fn sample_window_from_device_desc(
 /// The descriptor answers this exactly when it has arrived; otherwise
 /// [`packed_span_estimate`] gives a count that errs long. Either way the guest's
 /// own allocation bounds it: RE (`allocateBackingHandle`) writes the
-/// page-aligned allocation length at type-4 desc `+0`, independent of the plane
+/// page-aligned allocation length at backing desc `+0`, independent of the plane
 /// width/height/pitch filled from the per-plane getters, and we stash it as
 /// `device_desc.alloc_size`. A span past that is a span past the pages the guest
 /// allocated, so it is refused rather than clamped.
@@ -1209,7 +1209,7 @@ mod tests {
     }
 
     /// The page-sizing estimate must not reach past the wire `alloc_size`
-    /// (type-4 `length`). RE: allocateBackingHandle writes length@0
+    /// (backing `length`). RE: allocateBackingHandle writes length@0
     /// independently of plane dims.
     #[test]
     fn mapping_span_bound_rejects_a_span_past_alloc_size() {
@@ -1293,7 +1293,7 @@ mod tests {
 
     /// v0a8 (biplanar video + alpha) shape from the live apple.com hero: the
     /// Y and alpha planes share geometry and bpe, so the geometry scan is
-    /// ambiguous by construction — only an explicit wire plane index (type-5
+    /// ambiguous by construction — only an explicit wire plane index (ref-texture
     /// record `+0x20`) separates them.
     #[test]
     fn sample_window_plane_index_selects_among_same_geometry_planes() {

--- a/crates/reims-vgpu-contract/src/pixel_format.rs
+++ b/crates/reims-vgpu-contract/src/pixel_format.rs
@@ -1285,7 +1285,7 @@ impl SwizzlePlan {
     /// identically on the host format carrying it *and* the guest asked for a
     /// view swizzle on top. `A8Unorm` is the standing case: its byte rides in
     /// `R8_UNORM`, so the format contributes "alpha is in red" and the guest's
-    /// type-8 view contributes whatever it asked for. Binding either alone
+    /// texture-view contributes whatever it asked for. Binding either alone
     /// gives the shader the wrong channels.
     ///
     /// A hardware component mapping takes one plan, not two, so they have to be
@@ -1884,7 +1884,7 @@ pub fn storage_selector(format: u16) -> Option<StorageImageSelector> {
 /// IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`, which
 /// `runtime::objects::iosurface_pixel_format_to_mtl` now names — and before
 /// either half of that change every draw of the frame was refused at
-/// `draw::render_target`'s `rt_type4_base_format` and the window was black:
+/// `draw::render_target`'s `rt_backing_base_format` and the window was black:
 /// 20 822 `draw_fail_clear_fallback` records and zero successful draws in one
 /// 100 s capture. Vulkan does not *mandate* `A2R10G10B10_UNORM_PACK32` as a
 /// colour attachment the way it does `R16_SFLOAT`, so unlike the two members
@@ -2042,7 +2042,7 @@ pub fn render_target_numeric_type(format: u16) -> Option<ColorNumericType> {
 /// resident's format; say `None` and the only route left is
 /// [`convert_rgba8_to_row`], which is a CPU pass over the frame.
 ///
-/// Named once because both writeback rails ask it — the type-11 mapping rail
+/// Named once because both writeback rails ask it — the mapper-ref-texture mapping rail
 /// wants `Bgra8` specifically and the GVA rail takes whichever layout its
 /// resident was built in — and a rail that re-lists the formats drifts the
 /// first time one is added.
@@ -4458,12 +4458,11 @@ mod tests {
         ));
         assert_eq!(bgra, [3, 2, 1, 4, 7, 6, 5, 8]);
 
-        // What this list may hold is not this test's to decide: a layout is
-        // seedable exactly when `render_target_bpp` admits the guest format it
-        // stands for, and
+        // What this list may hold is not this test's to decide: a layout is seedable exactly when
+        // `render_target_bpp` admits the guest format it stands for, and
         // `translate::pixel::…::the_renderable_set_is_one_answer_and_every_member_survives_both_rails`
-        // is what holds the two together. Removing a layout from here without
-        // that test agreeing means the two have drifted again.
+        // is what holds the two together. Removing a layout from here without that test agreeing
+        // means the two have drifted again.
         for layout in [
             TexelLayout::Rg8,
             TexelLayout::R32Float,

--- a/crates/reims-vgpu-contract/src/vertex_step.rs
+++ b/crates/reims-vgpu-contract/src/vertex_step.rs
@@ -1,6 +1,6 @@
 //! `MTLVertexStepFunction` ordinals, and the step rate that pairs with each.
 //!
-//! A type-7 pipeline descriptor's buffer layout carries a step function and a
+//! A serializer-object pipeline descriptor's buffer layout carries a step function and a
 //! step rate, decoded by `crate::runtime::decode::resource` into
 //! `VertexAttribute::step_function_ordinal` and `VertexAttribute::step_rate`.
 //! The two are one rule and not two fields: `MTLVertexBufferLayoutDescriptor`

--- a/crates/reims-vgpu-env/src/lib.rs
+++ b/crates/reims-vgpu-env/src/lib.rs
@@ -465,7 +465,7 @@ pub const SCATTER_SPLIT: &str = "REIMS_VGPU_SCATTER_SPLIT";
 /// ways in one binary.
 pub const COMPUTE_SCATTER: &str = "REIMS_VGPU_COMPUTE_SCATTER";
 
-/// `off` narrows a type-11 surface Store back to copying its frame into the
+/// `off` narrows a mapper-ref-texture surface Store back to copying its frame into the
 /// guest's pages at the Store, instead of holding it in the engine resident and
 /// copying when something reads those pages.
 ///
@@ -485,7 +485,7 @@ pub const COMPUTE_SCATTER: &str = "REIMS_VGPU_COMPUTE_SCATTER";
 /// copy the lazy rail would not eventually have made.
 ///
 /// Default on, because it is the measured winner and by a margin no other rail
-/// here has produced. Twelve interleaved driven macos-13 boots: 90 % of type-11
+/// here has produced. Twelve interleaved driven macos-13 boots: 90 % of mapper-ref-texture
 /// Stores superseded before anything read their pages, `draw_us` 14.62 against
 /// 26.52 a draw, and five of six on-arm boots presenting at 105.8-109.2 Hz
 /// against a 77.2-78.6 Hz baseline. `crate::runtime::writeback_debt` carries the

--- a/crates/reims-vgpu-observe/src/sink.rs
+++ b/crates/reims-vgpu-observe/src/sink.rs
@@ -12,20 +12,20 @@
 //! | `OFF present_paint` | HostAction paint / Unchanged |
 //! | `OFF host_cache_store` | Discrete-GPU host surface cache write |
 //! | `OFF host_cache_evict` | Cache drop (unmap/delete) |
-//! | `OFF m2v_store` | metal2vulkan Store to type-11/type-4 mid (incl. is_front) |
-//! | `OFF m2v_store_gva` | metal2vulkan Store to type-2/3 GVA |
+//! | `OFF m2v_store` | metal2vulkan Store to mapper-ref-texture/backing mid (incl. is_front) |
+//! | `OFF m2v_store_gva` | metal2vulkan Store to normal-texture GVA |
 //! | `OFF m2v_load_seed` | Load seed path (host_cache vs missing) |
 //! | `OFF load_seed_black` | Deduplicated zero-RGB Load seed preserved by protocol provenance |
-//! | `OFF linear_sample` | Display-sized type-2/3 sample provenance + content census |
+//! | `OFF linear_sample` | Display-sized normal-texture sample provenance + content census |
 //! | `OFF sampled_branch_census` | Cumulative per-branch sampled-resolution counts:bytes, every 256 |
 //! | `OFF sample_alpha_mask` | Deduplicated zero-RGB/nonzero-alpha sample census; alpha is preserved |
-//! | `linear_sample_miss` | Display-sized type-2/3 sample failed, with descriptor identity |
+//! | `linear_sample_miss` | Display-sized normal-texture sample failed, with descriptor identity |
 //! | `OFF linear_coverage_gap` | Typed stage-in/shader-evaluated coverage check rejected full-display ownership |
 //! | `import_content` | Resident-to-guest Store census; display rows include exact changed/R↔B-swapped pixel counts |
 //! | `linux_m2v_resources` | Per-draw resource census; `fixed_gap=[...]` names decoded fixed state absent from the Vulkan request |
 //! | `linux_m2v_timing` | always-on stage µs: load/m2v/setup/engine/composite + total |
 //! | `OFF display_clear` | Clear-only stream Store into a display-sized mid |
-//! | `OFF rt_resolve` | Color RT lookup (type-4/5/11 → mapping_id) display-sized |
+//! | `OFF rt_resolve` | Color RT lookup (backing/5/11 → mapping_id) display-sized |
 //! | `OFF front_wb` | note_front_buffer_writeback latch / post-boundary skip |
 //! | `OFF blit` | Product blit path enter/result (buffer↔texture) |
 //!
@@ -182,7 +182,7 @@ fn emit(sink: Sink, msg: &str) {
 }
 
 /// Flood self-detector (regression guard). A per-event line wrongly routed to
-/// the always-on sink (the `type5_view_zc`/`InvalidateResources` class that
+/// the always-on sink (the `ref_texture_view_zc`/`InvalidateResources` class that
 /// buried the curated fail view under ~130k lines/boot) fires per bind/op — far
 /// above any legitimate always-on rate. This watches the **always-on** stream in
 /// the background writer thread (zero producer cost) and emits ONE
@@ -204,7 +204,7 @@ const FLOOD_THRESHOLD_PER_WINDOW: u64 = 1000;
 
 /// The flood-accounting key for an always-on line: its slug — the first
 /// whitespace token, skipping a leading `OFF ` marker. Groups a runaway line by
-/// kind (`type5_view_zc`, `map_family`, …) so the warning names the culprit.
+/// kind (`ref_texture_view_zc`, `map_family`, …) so the warning names the culprit.
 #[cfg(any(test, not(feature = "testing")))]
 fn flood_key(line: &str) -> &str {
     let slug = line.strip_prefix("OFF ").unwrap_or(line);
@@ -930,8 +930,8 @@ mod tests {
     #[test]
     fn flood_key_is_the_slug_skipping_the_off_marker() {
         assert_eq!(
-            flood_key("OFF type5_view_zc ref=355 sid=62 view=1920x1080 t=1"),
-            "type5_view_zc"
+            flood_key("OFF ref_texture_view_zc ref=355 sid=62 view=1920x1080 t=1"),
+            "ref_texture_view_zc"
         );
         assert_eq!(
             flood_key("map_family op=InvalidateResources ch=3 t=1"),

--- a/crates/reims-vgpu-wire/AGENTS.md
+++ b/crates/reims-vgpu-wire/AGENTS.md
@@ -372,7 +372,7 @@ device contract instead, and nothing here can be replayed in CI:
 
 - **The guest GPU page table** ([`crate::page_table`]) — the worked example.
 - **FIFO packet framing** (`decode/fifo.rs`) — rings, doorbells, completion stamps.
-- **Device-side descriptors reached by GVA** — the type-4/5/11 IOSurface descriptors and the
+- **Device-side descriptors reached by GVA** — the backing/5/11 IOSurface descriptors and the
   116-byte texture descriptor `decode_texture_descriptor` reads. That 116-byte record is a
   *different structure* from the 36-byte creation payload in [`crate::ops::texture`]; they are not
   two readings of one thing.
@@ -412,7 +412,7 @@ So several modules split rather than staying whole:
 |---|---|
 | x86 PTE format *and* the multi-level walk (`page_table`) | the translation cache, and mapping a walk failure to a typed refusal |
 | object-list entry: 12 bytes, `[type\|desc_len]` + `desc_gva` | which task's list to read, and the lifetime of what it names |
-| type-4 descriptor layout | the 256-task search for which list holds it |
+| backing descriptor layout | the 256-task search for which list holds it |
 | IOSurface page-table entry | `build_table_plan`'s `MappingInternal` field chase (arm64 only) |
 
 The rule for `GuestMemory` implementations is in its module doc and is worth repeating because this

--- a/crates/reims-vgpu-wire/src/device_desc.rs
+++ b/crates/reims-vgpu-wire/src/device_desc.rs
@@ -1,5 +1,7 @@
-//! Device-side descriptors reached by GVA: the type-4 surface backing record
-//! and the type-5 reference-texture handle.
+//! Device-side descriptors reached by GVA: the backing record
+//! (`APVObjectType` 4) and the ref-texture handle (5). Both are x86-only —
+//! an arm64 guest reaches an IOSurface through the mapper-ref texture (11)
+//! instead. See `runtime::decode::resource` for the tag table.
 //!
 //! # Provenance
 //!
@@ -26,7 +28,7 @@
 //! Align-1 views with fallible constructors are worth as much on an unverified
 //! format as on a verified one: the bytes are guest-controlled either way.
 //!
-//! # Type-4 — surface backing (`allocateBackingHandle`)
+//! # Backing — surface backing (`allocateBackingHandle`)
 //!
 //! ```text
 //! +0x00  u64  length          byte length of the backing
@@ -44,10 +46,10 @@
 //! available; they are not *known* to be padding, which is why the device still
 //! reports the undecoded span rather than shrinking the record around it.
 //!
-//! # Type-5 — reference texture handle (`allocateRefTextureHandle`)
+//! # Ref-texture — reference texture handle (`allocateRefTextureHandle`)
 //!
 //! ```text
-//! +0x00  u32  surface_id      IOSurface::getSurfaceID() = the type-4 object id
+//! +0x00  u32  surface_id      IOSurface::getSurfaceID() = the backing object id
 //! +0x04  u32  owner_task      task whose object list holds that surface
 //! +0x08       args            serialized texture args, length desc_len - 8
 //! ```
@@ -57,7 +59,7 @@
 //! ```text
 //! +0x00  u32  kind            0x2f observed
 //! +0x04  u32  blob_len        == desc_len - 8
-//! +0x08  u32  own_ref         the type-5 object's own ref
+//! +0x08  u32  own_ref         the ref-texture object's own ref
 //! +0x0c       record          the serialized plane/view texture record
 //! ```
 //!
@@ -81,19 +83,19 @@
 use crate::le::{U16le, U32le, U64le};
 use crate::view::{view, view_at, Wire, WireError};
 
-/// Wire object type for surface / IOSurface backing.
-pub const OBJECT_TYPE_SURFACE: u8 = 4;
-/// Wire object type for a reference-texture handle.
+/// Wire object type for an IOSurface backing record (`APVObjectBacking`).
+pub const OBJECT_TYPE_BACKING: u8 = 4;
+/// Wire object type for a ref-texture handle (`APVObjectRefTexture`).
 pub const OBJECT_TYPE_REF_TEXTURE: u8 = 5;
 
-/// Header of a type-4 surface backing descriptor, up to the plane array.
+/// Header of a backing descriptor, up to the plane array.
 ///
 /// `plane_count` is `u8` on the wire and the three bytes after it are the
 /// undecoded interior the module doc describes — they are part of this struct
 /// so that `size_of` is the offset of plane 0 and the two cannot drift.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Type4SurfaceHeader {
+pub struct BackingHeader {
     /// Byte length of the backing. Zero is not a surface this device accepts.
     pub length: U64le,
     /// First guest page frame of the backing. Zero is not a surface either;
@@ -115,28 +117,28 @@ pub struct Type4SurfaceHeader {
 }
 
 // SAFETY: align-1 `le` scalars plus `u8`, which is align-1 and all-bytes-valid.
-unsafe impl Wire for Type4SurfaceHeader {}
+unsafe impl Wire for BackingHeader {}
 
-/// One type-4 plane record.
+/// One backing plane record.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Type4PlaneRecord {
+pub struct BackingPlaneRecord {
     /// Byte offset of the plane within the backing.
     pub offset: U32le,
     pub width: U32le,
     pub height: U32le,
     /// `getPlaneBytesPerRow` in the low 24 bits, `getPlaneBytesPerElement` in
     /// the high 8. Packed on the wire, so the two are read through
-    /// [`Type4PlaneRecord::bytes_per_row`] and
-    /// [`Type4PlaneRecord::bytes_per_element`] rather than by masking at each
+    /// [`BackingPlaneRecord::bytes_per_row`] and
+    /// [`BackingPlaneRecord::bytes_per_element`] rather than by masking at each
     /// call site.
     pub packed_bpr: U32le,
 }
 
 // SAFETY: four align-1 all-bytes-valid `le` scalars.
-unsafe impl Wire for Type4PlaneRecord {}
+unsafe impl Wire for BackingPlaneRecord {}
 
-impl Type4PlaneRecord {
+impl BackingPlaneRecord {
     /// Low 24 bits of `packed_bpr`.
     pub fn bytes_per_row(&self) -> u32 {
         self.packed_bpr.get() & 0x00ff_ffff
@@ -153,42 +155,42 @@ impl Type4PlaneRecord {
 /// cap. A descriptor declaring more is corrupt, not wider.
 pub const TYPE4_PLANE_CAP: usize = 8;
 
-/// Byte stride between type-4 plane records.
-pub const TYPE4_PLANE_STRIDE: usize = core::mem::size_of::<Type4PlaneRecord>();
+/// Byte stride between backing plane records.
+pub const TYPE4_PLANE_STRIDE: usize = core::mem::size_of::<BackingPlaneRecord>();
 
 /// Offset of plane 0, i.e. the length of the header before it.
-pub const TYPE4_PLANES: usize = core::mem::size_of::<Type4SurfaceHeader>();
+pub const TYPE4_PLANES: usize = core::mem::size_of::<BackingHeader>();
 
-/// Shortest type-4 descriptor that carries a header and one plane.
+/// Shortest backing descriptor that carries a header and one plane.
 pub const TYPE4_MIN_LEN: usize = TYPE4_PLANES + TYPE4_PLANE_STRIDE;
 
-/// Byte length of a type-4 descriptor declaring `plane_count` planes.
+/// Byte length of a backing descriptor declaring `plane_count` planes.
 ///
 /// The device's own census reads this as exact for every descriptor it has
 /// seen: `len` is the header plus the declared planes, with nothing after.
-pub const fn type4_len_for(plane_count: usize) -> usize {
+pub const fn backing_len_for(plane_count: usize) -> usize {
     TYPE4_PLANES + plane_count * TYPE4_PLANE_STRIDE
 }
 
-/// View the header of a type-4 surface descriptor.
-pub fn type4_header(desc: &[u8]) -> Result<&Type4SurfaceHeader, WireError> {
-    view::<Type4SurfaceHeader>(desc)
+/// View the header of a backing record descriptor.
+pub fn backing_header(desc: &[u8]) -> Result<&BackingHeader, WireError> {
+    view::<BackingHeader>(desc)
 }
 
-/// View plane `index` of a type-4 surface descriptor.
+/// View plane `index` of a backing record descriptor.
 ///
 /// Fails rather than truncating when the blob does not reach the record: a
 /// declared plane whose bytes are absent is a descriptor this device could not
 /// decode, not a plane of zero size.
-pub fn type4_plane(desc: &[u8], index: usize) -> Result<&Type4PlaneRecord, WireError> {
-    view_at::<Type4PlaneRecord>(desc, TYPE4_PLANES + index * TYPE4_PLANE_STRIDE)
+pub fn backing_plane(desc: &[u8], index: usize) -> Result<&BackingPlaneRecord, WireError> {
+    view_at::<BackingPlaneRecord>(desc, TYPE4_PLANES + index * TYPE4_PLANE_STRIDE)
 }
 
-/// Header of a type-5 reference-texture descriptor.
+/// Header of a ref-texture descriptor.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Type5Header {
-    /// `IOSurface::getSurfaceID()` — the type-4 heap object id this handle
+pub struct RefTextureHeader {
+    /// `IOSurface::getSurfaceID()` — the backing heap object id this handle
     /// references.
     pub surface_id: U32le,
     /// The task whose object list holds that surface.
@@ -203,41 +205,41 @@ pub struct Type5Header {
 }
 
 // SAFETY: two align-1 all-bytes-valid `le` scalars.
-unsafe impl Wire for Type5Header {}
+unsafe impl Wire for RefTextureHeader {}
 
-/// Offset of `surface_id` within a type-5 descriptor.
+/// Offset of `surface_id` within a ref-texture descriptor.
 ///
 /// Derived from the view rather than stated, so a fixture carrying live wire
 /// bytes can name the field without restating the layout. Fixtures keep their
 /// literal bytes on purpose — they are what the guest emitted, and bytes
 /// assembled to satisfy the reader would agree with it whether or not it is
 /// right — but the *offsets they index by* must still come from one place.
-pub const TYPE5_SURFACE_ID: usize = core::mem::offset_of!(Type5Header, surface_id);
-/// Offset of `owner_task` within a type-5 descriptor. See
+pub const TYPE5_SURFACE_ID: usize = core::mem::offset_of!(RefTextureHeader, surface_id);
+/// Offset of `owner_task` within a ref-texture descriptor. See
 /// [`TYPE5_SURFACE_ID`].
-pub const TYPE5_OWNER_TASK: usize = core::mem::offset_of!(Type5Header, owner_task);
+pub const TYPE5_OWNER_TASK: usize = core::mem::offset_of!(RefTextureHeader, owner_task);
 
-/// Offset of the serialized args blob within a type-5 descriptor.
-pub const TYPE5_ARGS: usize = core::mem::size_of::<Type5Header>();
+/// Offset of the serialized args blob within a ref-texture descriptor.
+pub const TYPE5_ARGS: usize = core::mem::size_of::<RefTextureHeader>();
 
-/// Header of the type-5 args blob.
+/// Header of the ref-texture args blob.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Type5ArgsHeader {
+pub struct RefTextureArgsHeader {
     /// Kind tag. `0x2f` observed.
     pub kind: U32le,
     /// Blob length, observed equal to `desc_len - TYPE5_ARGS`.
     pub blob_len: U32le,
-    /// The type-5 object's own ref, the same convention the type-11 texture
+    /// The ref-texture object's own ref, the same convention the mapper-ref-texture
     /// descriptor uses for its object-ref field.
     pub own_ref: U32le,
 }
 
 // SAFETY: three align-1 all-bytes-valid `le` scalars.
-unsafe impl Wire for Type5ArgsHeader {}
+unsafe impl Wire for RefTextureArgsHeader {}
 
-/// Offset of the serialized texture record within a type-5 descriptor.
-pub const TYPE5_ARG_RECORD: usize = TYPE5_ARGS + core::mem::size_of::<Type5ArgsHeader>();
+/// Offset of the serialized texture record within a ref-texture descriptor.
+pub const TYPE5_ARG_RECORD: usize = TYPE5_ARGS + core::mem::size_of::<RefTextureArgsHeader>();
 
 /// Record tag for an IOSurface plane view.
 pub const TYPE5_RECORD_TAG_PLANE: u8 = 0x42;
@@ -248,7 +250,7 @@ pub const TYPE5_RECORD_TAG_PLANE: u8 = 0x42;
 /// same view.
 pub const TYPE5_RECORD_TAG_COLOR_VIEW: u8 = 0x62;
 
-/// The serialized texture record inside a type-5 args blob, to the end of
+/// The serialized texture record inside a ref-texture args blob, to the end of
 /// `depth`.
 ///
 /// `plane_index` is deliberately not a field: it sits at
@@ -257,7 +259,7 @@ pub const TYPE5_RECORD_TAG_COLOR_VIEW: u8 = 0x62;
 /// it.
 #[repr(C)]
 #[derive(Debug)]
-pub struct Type5TextureRecord {
+pub struct RefTextureRecord {
     /// [`TYPE5_RECORD_TAG_PLANE`] or [`TYPE5_RECORD_TAG_COLOR_VIEW`]. Any other
     /// value is an unknown record: fail closed rather than invent geometry.
     pub tag: u8,
@@ -271,19 +273,19 @@ pub struct Type5TextureRecord {
 }
 
 // SAFETY: two `u8` and three align-1 `le` scalars, all bytes valid.
-unsafe impl Wire for Type5TextureRecord {}
+unsafe impl Wire for RefTextureRecord {}
 
-impl Type5TextureRecord {
+impl RefTextureRecord {
     /// Whether the tag is one of the two forms this device decodes.
     pub fn tag_is_known(&self) -> bool {
         self.tag == TYPE5_RECORD_TAG_PLANE || self.tag == TYPE5_RECORD_TAG_COLOR_VIEW
     }
 }
 
-/// Bytes of a type-5 texture record up to and including `depth`.
-pub const TYPE5_RECORD_MIN_LEN: usize = core::mem::size_of::<Type5TextureRecord>();
+/// Bytes of a ref-texture record up to and including `depth`.
+pub const TYPE5_RECORD_MIN_LEN: usize = core::mem::size_of::<RefTextureRecord>();
 
-/// Offset of the plane index within a type-5 texture record.
+/// Offset of the plane index within a ref-texture record.
 ///
 /// The `newTextureWithDescriptor:iosurface:plane:` plane argument. A live
 /// three-plane census settles it: Y blobs carry 0, the RG8 chroma blob carries
@@ -291,27 +293,27 @@ pub const TYPE5_RECORD_MIN_LEN: usize = core::mem::size_of::<Type5TextureRecord>
 /// tell Y from alpha, so this field is the only wire key for it.
 pub const TYPE5_RECORD_PLANE: usize = 0x20;
 
-/// View the header of a type-5 descriptor.
-pub fn type5_header(desc: &[u8]) -> Result<&Type5Header, WireError> {
-    view::<Type5Header>(desc)
+/// View the header of a ref-texture descriptor.
+pub fn ref_texture_header(desc: &[u8]) -> Result<&RefTextureHeader, WireError> {
+    view::<RefTextureHeader>(desc)
 }
 
-/// View the serialized texture record of a type-5 descriptor.
-pub fn type5_texture_record(desc: &[u8]) -> Result<&Type5TextureRecord, WireError> {
-    view_at::<Type5TextureRecord>(desc, TYPE5_ARG_RECORD)
+/// View the serialized texture record of a ref-texture descriptor.
+pub fn ref_texture_record(desc: &[u8]) -> Result<&RefTextureRecord, WireError> {
+    view_at::<RefTextureRecord>(desc, TYPE5_ARG_RECORD)
 }
 
-/// The plane index a type-5 descriptor's record names, when it carries one.
+/// The plane index a ref-texture descriptor's record names, when it carries one.
 ///
 /// `None` for a blob that stops before the field — pre-plane descriptors and
 /// test fixtures — which the caller reads as plane 0.
-pub fn type5_record_plane_index(desc: &[u8]) -> Option<u32> {
+pub fn ref_texture_record_plane_index(desc: &[u8]) -> Option<u32> {
     view_at::<U32le>(desc, TYPE5_ARG_RECORD + TYPE5_RECORD_PLANE)
         .ok()
         .map(|w| w.get())
 }
 
-/// Assemble a type-4 descriptor by the format's own rules, for tests.
+/// Assemble a backing descriptor by the format's own rules, for tests.
 ///
 /// The counterpart of [`crate::page_table::Builder`], and here for the same
 /// reason: a test that writes `st64(&mut desc[TYPE4_LEN..], ..)` is writing
@@ -322,16 +324,16 @@ pub fn type5_record_plane_index(desc: &[u8]) -> Option<u32> {
 /// It is deliberately not `cfg(test)`: `reims-vgpu`'s own tests are a different
 /// crate's, and they are the ones that were spelling the offsets.
 #[derive(Debug)]
-pub struct Type4Builder {
+pub struct BackingBuilder {
     bytes: [u8; TYPE4_BUILDER_CAP],
     len: usize,
 }
 
-/// Longest descriptor [`Type4Builder`] can assemble: header plus every plane
+/// Longest descriptor [`BackingBuilder`] can assemble: header plus every plane
 /// IOSurface can declare.
 pub const TYPE4_BUILDER_CAP: usize = TYPE4_PLANES + TYPE4_PLANE_CAP * TYPE4_PLANE_STRIDE;
 
-impl Type4Builder {
+impl BackingBuilder {
     /// A descriptor with a header and room for `planes` plane records.
     ///
     /// `plane_count` is written as given, including a value over
@@ -347,7 +349,7 @@ impl Type4Builder {
         bytes[0x10] = plane_count;
         Self {
             bytes,
-            len: type4_len_for(reserve),
+            len: backing_len_for(reserve),
         }
     }
 
@@ -388,26 +390,26 @@ impl Type4Builder {
     }
 }
 
-/// Assemble a type-5 descriptor by the format's own rules, for tests.
+/// Assemble a ref-texture descriptor by the format's own rules, for tests.
 ///
-/// Same purpose as [`Type4Builder`]: the descriptor's three nested headers were
+/// Same purpose as [`BackingBuilder`]: the descriptor's three nested headers were
 /// being written by hand at their offsets, which is the reader's own arithmetic
 /// spelled a second time.
 #[derive(Debug)]
-pub struct Type5Builder {
+pub struct RefTextureBuilder {
     bytes: [u8; TYPE5_BUILDER_CAP],
     len: usize,
 }
 
-/// Longest descriptor [`Type5Builder`] assembles: through the plane index.
+/// Longest descriptor [`RefTextureBuilder`] assembles: through the plane index.
 pub const TYPE5_BUILDER_CAP: usize = TYPE5_ARG_RECORD + TYPE5_RECORD_PLANE + 4;
 
-impl Type5Builder {
+impl RefTextureBuilder {
     /// A descriptor naming `surface_id`, owned by `owner_task`, whose args
     /// blob carries a texture record of `tag`.
     ///
     /// The blob length is written as the args bytes actually present, which is
-    /// what the live wire carries; use [`Type5Builder::with_len`] to produce a
+    /// what the live wire carries; use [`RefTextureBuilder::with_len`] to produce a
     /// descriptor that disagrees with itself.
     pub fn new(surface_id: u32, owner_task: u32, own_ref: u32, tag: u8) -> Self {
         let mut bytes = [0u8; TYPE5_BUILDER_CAP];
@@ -433,7 +435,7 @@ impl Type5Builder {
     }
 
     /// Write the record's undecoded byte at `+0x01`, for the same reason as
-    /// [`Type5Builder::trailer`].
+    /// [`RefTextureBuilder::trailer`].
     pub fn unknown(mut self, unknown: u8) -> Self {
         self.bytes[TYPE5_ARG_RECORD + 0x01] = unknown;
         self
@@ -479,16 +481,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn what_the_type5_builder_writes_is_what_the_views_read() {
-        let d = Type5Builder::new(77, 0, 4242, TYPE5_RECORD_TAG_COLOR_VIEW)
+    fn what_the_ref_texture_builder_writes_is_what_the_views_read() {
+        let d = RefTextureBuilder::new(77, 0, 4242, TYPE5_RECORD_TAG_COLOR_VIEW)
             .geometry(80, 1024, 768, 1)
             .plane_index(2);
         let desc = d.bytes();
 
-        let h = type5_header(desc).expect("header");
+        let h = ref_texture_header(desc).expect("header");
         assert_eq!((h.surface_id.get(), h.owner_task.get()), (77, 0));
 
-        let args = view_at::<Type5ArgsHeader>(desc, TYPE5_ARGS).expect("args header");
+        let args = view_at::<RefTextureArgsHeader>(desc, TYPE5_ARGS).expect("args header");
         assert_eq!(args.kind.get(), 0x2f);
         assert_eq!(args.own_ref.get(), 4242);
         assert_eq!(
@@ -497,7 +499,7 @@ mod tests {
             "the blob length is the args bytes present, which is what the wire carries"
         );
 
-        let rec = type5_texture_record(desc).expect("record");
+        let rec = ref_texture_record(desc).expect("record");
         assert!(rec.tag_is_known());
         assert_eq!(
             (
@@ -508,27 +510,27 @@ mod tests {
             ),
             (80, 1024, 768, 1)
         );
-        assert_eq!(type5_record_plane_index(desc), Some(2));
+        assert_eq!(ref_texture_record_plane_index(desc), Some(2));
     }
 
     /// The builder writes what the views read — the only thing that makes
     /// either of them worth anything.
     #[test]
     fn what_the_builder_writes_is_what_the_views_read() {
-        let d = Type4Builder::new(0x8000, 0x1234, 0x4247_5241, 2)
+        let d = BackingBuilder::new(0x8000, 0x1234, 0x4247_5241, 2)
             .plane(0, 0, 1920, 1080, 1920 * 4, 4)
             .plane(1, 0x1000, 960, 540, 960 * 2, 2);
         let desc = d.bytes();
-        assert_eq!(desc.len(), type4_len_for(2));
+        assert_eq!(desc.len(), backing_len_for(2));
 
-        let h = type4_header(desc).expect("header");
+        let h = backing_header(desc).expect("header");
         assert_eq!(h.length.get(), 0x8000);
         assert_eq!(h.backing_pfn.get(), 0x1234);
         assert_eq!(h.pixel_format.get(), 0x4247_5241);
         assert_eq!(h.plane_count, 2);
         assert_eq!(h.reserved, [0, 0, 0]);
 
-        let p0 = type4_plane(desc, 0).expect("plane 0");
+        let p0 = backing_plane(desc, 0).expect("plane 0");
         assert_eq!(
             (
                 p0.offset.get(),
@@ -539,7 +541,7 @@ mod tests {
             ),
             (0, 1920, 1080, 1920 * 4, 4)
         );
-        let p1 = type4_plane(desc, 1).expect("plane 1");
+        let p1 = backing_plane(desc, 1).expect("plane 1");
         assert_eq!(
             (
                 p1.offset.get(),
@@ -551,17 +553,17 @@ mod tests {
             (0x1000, 960, 540, 960 * 2, 2)
         );
         // Plane 2 was never reserved, so its record is off the end.
-        assert!(type4_plane(desc, 2).is_err());
+        assert!(backing_plane(desc, 2).is_err());
     }
 
     /// A plane count the guest could not honestly mean is written as given.
     #[test]
     fn the_builder_writes_an_over_cap_plane_count_without_clamping_it() {
-        let d = Type4Builder::new(0x1000, 0x100, 0x4247_5241, 12);
-        assert_eq!(type4_header(d.bytes()).expect("header").plane_count, 12);
+        let d = BackingBuilder::new(0x1000, 0x100, 0x4247_5241, 12);
+        assert_eq!(backing_header(d.bytes()).expect("header").plane_count, 12);
         assert_eq!(
             d.bytes().len(),
-            type4_len_for(TYPE4_PLANE_CAP),
+            backing_len_for(TYPE4_PLANE_CAP),
             "the bytes stop at the cap even when the count does not"
         );
     }
@@ -578,31 +580,31 @@ mod tests {
     fn the_layout_matches_the_offsets_the_device_contract_states() {
         use core::mem::offset_of;
 
-        assert_eq!(offset_of!(Type4SurfaceHeader, length), 0x00);
-        assert_eq!(offset_of!(Type4SurfaceHeader, backing_pfn), 0x08);
-        assert_eq!(offset_of!(Type4SurfaceHeader, pixel_format), 0x0c);
-        assert_eq!(offset_of!(Type4SurfaceHeader, plane_count), 0x10);
-        assert_eq!(offset_of!(Type4SurfaceHeader, reserved), 0x11);
+        assert_eq!(offset_of!(BackingHeader, length), 0x00);
+        assert_eq!(offset_of!(BackingHeader, backing_pfn), 0x08);
+        assert_eq!(offset_of!(BackingHeader, pixel_format), 0x0c);
+        assert_eq!(offset_of!(BackingHeader, plane_count), 0x10);
+        assert_eq!(offset_of!(BackingHeader, reserved), 0x11);
         assert_eq!(TYPE4_PLANES, 0x14);
         assert_eq!(TYPE4_PLANE_STRIDE, 0x10);
         assert_eq!(TYPE4_MIN_LEN, 0x24);
-        assert_eq!(offset_of!(Type4PlaneRecord, offset), 0x00);
-        assert_eq!(offset_of!(Type4PlaneRecord, width), 0x04);
-        assert_eq!(offset_of!(Type4PlaneRecord, height), 0x08);
-        assert_eq!(offset_of!(Type4PlaneRecord, packed_bpr), 0x0c);
+        assert_eq!(offset_of!(BackingPlaneRecord, offset), 0x00);
+        assert_eq!(offset_of!(BackingPlaneRecord, width), 0x04);
+        assert_eq!(offset_of!(BackingPlaneRecord, height), 0x08);
+        assert_eq!(offset_of!(BackingPlaneRecord, packed_bpr), 0x0c);
 
-        assert_eq!(offset_of!(Type5Header, surface_id), 0x00);
-        assert_eq!(offset_of!(Type5Header, owner_task), 0x04);
+        assert_eq!(offset_of!(RefTextureHeader, surface_id), 0x00);
+        assert_eq!(offset_of!(RefTextureHeader, owner_task), 0x04);
         assert_eq!(TYPE5_ARGS, 0x08);
-        assert_eq!(offset_of!(Type5ArgsHeader, kind), 0x00);
-        assert_eq!(offset_of!(Type5ArgsHeader, blob_len), 0x04);
-        assert_eq!(offset_of!(Type5ArgsHeader, own_ref), 0x08);
+        assert_eq!(offset_of!(RefTextureArgsHeader, kind), 0x00);
+        assert_eq!(offset_of!(RefTextureArgsHeader, blob_len), 0x04);
+        assert_eq!(offset_of!(RefTextureArgsHeader, own_ref), 0x08);
         assert_eq!(TYPE5_ARG_RECORD, 0x14);
-        assert_eq!(offset_of!(Type5TextureRecord, tag), 0x00);
-        assert_eq!(offset_of!(Type5TextureRecord, pixel_format), 0x02);
-        assert_eq!(offset_of!(Type5TextureRecord, width), 0x04);
-        assert_eq!(offset_of!(Type5TextureRecord, height), 0x08);
-        assert_eq!(offset_of!(Type5TextureRecord, depth), 0x0c);
+        assert_eq!(offset_of!(RefTextureRecord, tag), 0x00);
+        assert_eq!(offset_of!(RefTextureRecord, pixel_format), 0x02);
+        assert_eq!(offset_of!(RefTextureRecord, width), 0x04);
+        assert_eq!(offset_of!(RefTextureRecord, height), 0x08);
+        assert_eq!(offset_of!(RefTextureRecord, depth), 0x0c);
         assert_eq!(TYPE5_RECORD_MIN_LEN, 0x10);
     }
 
@@ -615,22 +617,22 @@ mod tests {
     #[test]
     fn a_short_descriptor_is_refused_rather_than_read_past() {
         let desc = [0u8; 0x40];
-        assert!(type4_header(&desc[..TYPE4_PLANES]).is_ok());
-        assert!(type4_header(&desc[..TYPE4_PLANES - 1]).is_err());
-        assert!(type4_plane(&desc[..TYPE4_MIN_LEN], 0).is_ok());
-        assert!(type4_plane(&desc[..TYPE4_MIN_LEN - 1], 0).is_err());
-        assert!(type4_plane(&desc, 1).is_ok());
-        assert!(type4_plane(&desc[..TYPE4_MIN_LEN], 1).is_err());
+        assert!(backing_header(&desc[..TYPE4_PLANES]).is_ok());
+        assert!(backing_header(&desc[..TYPE4_PLANES - 1]).is_err());
+        assert!(backing_plane(&desc[..TYPE4_MIN_LEN], 0).is_ok());
+        assert!(backing_plane(&desc[..TYPE4_MIN_LEN - 1], 0).is_err());
+        assert!(backing_plane(&desc, 1).is_ok());
+        assert!(backing_plane(&desc[..TYPE4_MIN_LEN], 1).is_err());
 
-        assert!(type5_header(&desc[..TYPE5_ARGS]).is_ok());
-        assert!(type5_header(&desc[..TYPE5_ARGS - 1]).is_err());
+        assert!(ref_texture_header(&desc[..TYPE5_ARGS]).is_ok());
+        assert!(ref_texture_header(&desc[..TYPE5_ARGS - 1]).is_err());
         let record_end = TYPE5_ARG_RECORD + TYPE5_RECORD_MIN_LEN;
-        assert!(type5_texture_record(&desc[..record_end]).is_ok());
-        assert!(type5_texture_record(&desc[..record_end - 1]).is_err());
+        assert!(ref_texture_record(&desc[..record_end]).is_ok());
+        assert!(ref_texture_record(&desc[..record_end - 1]).is_err());
 
         // The plane index sits past the record, so a blob that stops at the
         // record has no plane to report and must say `None` rather than 0.
-        assert_eq!(type5_record_plane_index(&desc[..record_end]), None);
+        assert_eq!(ref_texture_record_plane_index(&desc[..record_end]), None);
     }
 
     /// `bytes_per_row` and `bytes_per_element` share one wire word, and the
@@ -644,7 +646,7 @@ mod tests {
         let mut desc = [0u8; TYPE4_MIN_LEN];
         desc[TYPE4_PLANES + 0x0c..TYPE4_PLANES + 0x10]
             .copy_from_slice(&0xab_123456u32.to_le_bytes());
-        let plane = type4_plane(&desc, 0).expect("one plane fits");
+        let plane = backing_plane(&desc, 0).expect("one plane fits");
         assert_eq!(plane.bytes_per_row(), 0x123456);
         assert_eq!(plane.bytes_per_element(), 0xab);
     }
@@ -661,7 +663,7 @@ mod tests {
         ] {
             desc[TYPE5_ARG_RECORD] = tag;
             assert_eq!(
-                type5_texture_record(&desc)
+                ref_texture_record(&desc)
                     .expect("full record")
                     .tag_is_known(),
                 known,
@@ -670,16 +672,16 @@ mod tests {
         }
     }
 
-    /// The declared length of a type-4 descriptor is its header plus its
+    /// The declared length of a backing descriptor is its header plus its
     /// planes, and nothing checked that against the stride before.
     #[test]
     fn a_descriptors_length_is_its_header_plus_its_planes() {
-        assert_eq!(type4_len_for(0), TYPE4_PLANES);
-        assert_eq!(type4_len_for(1), TYPE4_MIN_LEN);
+        assert_eq!(backing_len_for(0), TYPE4_PLANES);
+        assert_eq!(backing_len_for(1), TYPE4_MIN_LEN);
         // The two shapes the live census produced: a single-plane 'BGRA'
         // surface at 36 bytes and a biplanar '420f' one at 52.
-        assert_eq!(type4_len_for(1), 36);
-        assert_eq!(type4_len_for(2), 52);
-        assert_eq!(type4_len_for(TYPE4_PLANE_CAP), TYPE4_PLANES + 8 * 0x10);
+        assert_eq!(backing_len_for(1), 36);
+        assert_eq!(backing_len_for(2), 52);
+        assert_eq!(backing_len_for(TYPE4_PLANE_CAP), TYPE4_PLANES + 8 * 0x10);
     }
 }

--- a/crates/reims-vgpu-wire/src/ops/info.rs
+++ b/crates/reims-vgpu-wire/src/ops/info.rs
@@ -63,7 +63,7 @@ pub const QUERY_TOTAL_LEN: u32 = 24;
 ///
 /// `reims_vgpu::runtime::icb` decodes the `0x1d1` case at exactly these three
 /// offsets and this length — **and reads the last two as something else.** It
-/// calls them `buffer_ref` ("the type-1 object-list ref of the ICB command
+/// calls them `buffer_ref` ("the buffer object-list ref of the ICB command
 /// backing buffer") and `gpu_address` ("guest GPU/VA of the backing"), then
 /// binds them as the ICB's command memory. Agreeing on where a field is and
 /// disagreeing on what it means is the drift this crate exists to catch, and it

--- a/crates/reims-vgpu-wire/src/ops/texture.rs
+++ b/crates/reims-vgpu-wire/src/ops/texture.rs
@@ -605,7 +605,7 @@ mod tests {
         b[4..8].copy_from_slice(&NEW_TEXTURE_WIDE_TOTAL_LEN.to_le_bytes());
         b[8..12].copy_from_slice(&3u32.to_le_bytes()); // object_ref
         let d = 12; // payload + object_ref
-        b[d] = 0x42; // type 2, GPU-optimized contents, bit 7 clear
+        b[d] = 0x42; // texture, GPU-optimized contents, bit 7 clear
         b[d + 1..d + 3].copy_from_slice(&80u16.to_le_bytes());
         b[d + 3..d + 7].copy_from_slice(&5u32.to_le_bytes());
         b[d + 7..d + 11].copy_from_slice(&0x1111u32.to_le_bytes());
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn the_packed_word_splits_into_type_flags_usage_and_format() {
-        // 0x005005c2: type 2, GPU-optimized contents, flags 0b00, usage 5,
+        // 0x005005c2: texture, GPU-optimized contents, flags 0b00, usage 5,
         // format 80 — the shape the oracle's baseline produced. Bit 7 is set
         // here because `0xc2` is what a `0xAA`-filled arena produced; the view
         // must read the same fields whatever that bit holds, which is what the

--- a/crates/reims-vgpu-wire/src/ops/texture_view.rs
+++ b/crates/reims-vgpu-wire/src/ops/texture_view.rs
@@ -40,7 +40,7 @@
 //! # How the layout was derived
 //!
 //! Perturbation. The ranged form was captured twice with every field different
-//! — format 70/10, type 2/3, level base 3/1, level count 2/7, slice base 5/2,
+//! — format 70/10, normal-texture, level base 3/1, level count 2/7, slice base 5/2,
 //! slice count 4/6 — so no two fields hold the same value in either case and a
 //! view that swapped `levels` for `slices`, or a base for a count, reports a
 //! pair no case produced. The Objective-C encoding declares both ranges as

--- a/crates/reims-vgpu-wire/tests/oracle_fixtures.rs
+++ b/crates/reims-vgpu-wire/tests/oracle_fixtures.rs
@@ -1880,7 +1880,7 @@ const KNOWN_CAPABILITY_DELTAS: &[KnownDelta] = &[
                emits one record. `blit_begin_segment_protected` and `..._alt` \
                pin the burst, `..._flag_set` and `..._protection_zero` pin the \
                two single-record arms. `reims-vgpu`'s decode::stream already \
-               skipped type 5 correctly and its own doc's prediction was right.",
+               skipped ref-texture correctly and its own doc's prediction was right.",
     },
 ];
 

--- a/crates/reims-vgpu/src/backend/metal/mtl_enum.rs
+++ b/crates/reims-vgpu/src/backend/metal/mtl_enum.rs
@@ -20,7 +20,7 @@
 //! - **Five of the sites had no check at all.** The two vertex-descriptor
 //!   builders (`backend::metal::render::make_vertex_descriptor` and
 //!   `runtime::icb::metal_vertex_descriptor_from_attrs_for_draw`) transmuted a
-//!   type-7 pipeline descriptor's `format` and `step_function` words straight
+//!   serializer-object pipeline descriptor's `format` and `step_function` words straight
 //!   through, and those are guest bytes with no producer-side clamp anywhere.
 //!
 //! ## Where the variant lists come from

--- a/crates/reims-vgpu/src/backend/metal/render.rs
+++ b/crates/reims-vgpu/src/backend/metal/render.rs
@@ -468,7 +468,7 @@ fn make_vertex_descriptor(
             );
         }
         // The format and step-function words come straight off the guest's
-        // type-7 pipeline descriptor and nothing upstream clamps them, so both
+        // serializer-object pipeline descriptor and nothing upstream clamps them, so both
         // are converted before anything is encoded. Neither had any check at
         // all before; the location and buffer index above did.
         let Some(format) = mtl_enum::vertex_format(attr.format) else {
@@ -866,7 +866,7 @@ fn bind_storage_buffers(
             // this index is `MTLBufferLayoutStrideDynamic`, exactly as the
             // compute rail's `metal_compute_attribute_stride_without_dynamic_layout`
             // states for `MTLBufferLayoutDescriptor`. This rail's vertex
-            // descriptor is built from the type-7 attribute block and never
+            // descriptor is built from the serializer-object attribute block and never
             // declares a dynamic layout, so the selector would raise an
             // NSException — a process abort, not an error return.
             //

--- a/crates/reims-vgpu/src/backend/metal/runtime.rs
+++ b/crates/reims-vgpu/src/backend/metal/runtime.rs
@@ -13,7 +13,7 @@
 //! [`crate::runtime::guest_ram`], whose `GuestRamImport`/`GuestSlice` pair is
 //! the bound, sized to one RAMBlock with a single bounds-checking constructor.
 //!
-//! An earlier type-11 attachment cache did alias guest pages here
+//! An earlier mapper-ref-texture attachment cache did alias guest pages here
 //! (`mach_vm_remap` view → no-copy MTLBuffer → linear texture view) and was
 //! deleted. It is worth being exact about why, because the reason is not the
 //! aliasing: that cache retained a remap view per fragmented map until

--- a/crates/reims-vgpu/src/backend/mod.rs
+++ b/crates/reims-vgpu/src/backend/mod.rs
@@ -114,7 +114,7 @@ pub mod metal;
 pub mod vulkan;
 
 use crate::model::{ComputeStorageResidencyKey, DeviceInfoLimits, DeviceState};
-use crate::runtime::blit_exec::{BlitStatus, LinearTextureLevel, Type11Texture};
+use crate::runtime::blit_exec::{BlitStatus, LinearTextureLevel, MapperRefTexture};
 use crate::runtime::compute_exec::{ComputeAccum, ComputeStatus, ResidentServe};
 use crate::runtime::compute_session::ComputeSession;
 use crate::runtime::decode::blit::Command as BlitCommand;
@@ -285,7 +285,7 @@ pub(crate) trait Backend: Copy {
         None
     }
 
-    /// [`Self::try_copy_whole_plane_on_gpu`] for a type-11 source landing in a
+    /// [`Self::try_copy_whole_plane_on_gpu`] for a mapper-ref-texture source landing in a
     /// guest-linear destination, which resolves its endpoints differently.
     #[allow(
         clippy::too_many_arguments,
@@ -297,7 +297,7 @@ pub(crate) trait Backend: Copy {
         _host: &mut M,
         _task_id: u32,
         _destination_ref: u32,
-        _src: &Type11Texture,
+        _src: &MapperRefTexture,
         _dst: &LinearTextureLevel,
     ) -> Option<BlitStatus> {
         None
@@ -446,7 +446,7 @@ pub(crate) trait Backend: Copy {
         false
     }
 
-    /// Count whether this rail already holds a type-11 surface's content.
+    /// Count whether this rail already holds a mapper-ref-texture surface's content.
     ///
     /// Census only: it changes no decision, and the caller copies the same bytes
     /// either way. A rail with no resident registry records nothing rather than
@@ -1135,7 +1135,7 @@ impl Backend for SelectedBackend {
         host: &mut M,
         task_id: u32,
         destination_ref: u32,
-        src: &Type11Texture,
+        src: &MapperRefTexture,
         dst: &LinearTextureLevel,
     ) -> Option<BlitStatus> {
         match self {

--- a/crates/reims-vgpu/src/backend/vulkan/caps/memory_topology.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/caps/memory_topology.rs
@@ -572,7 +572,7 @@ pub(crate) mod fixtures {
     ///
     /// **Nothing here carries `HOST_COHERENT` and `HOST_CACHED` together**, and
     /// that is the load-bearing property. The previous version of this fixture
-    /// gave type 1 both bits — invented, not measured — which made every
+    /// gave buffer both bits — invented, not measured — which made every
     /// `MemoryClass::Readback` selection test pass while the real device fell
     /// through to uncached type 0 on every allocation. A fixture more capable
     /// than the hardware it stands for cannot fail the way the hardware does.
@@ -931,7 +931,7 @@ mod tests {
     fn type_bits_mask_is_respected() {
         let props = apple_m3_max();
         let req = MemoryTopology::Unified.request(MemoryClass::Readback);
-        // Mask out type 1 (the only host-visible type) → no candidate at all.
+        // Mask out buffer (the only host-visible type) → no candidate at all.
         assert_eq!(pick_index(&props, 0b101, &req), None);
         // Allow it again and it is chosen.
         assert_eq!(pick_index(&props, 0b010, &req), Some(1));

--- a/crates/reims-vgpu/src/backend/vulkan/engine/caches.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/caches.rs
@@ -2483,7 +2483,7 @@ impl ObjectCaches {
             .front_face(translate::raster::vk_front_face(key.front_face_ccw))
             .line_width(1.0);
         // `rasterSampleCount` is a property of `MTLRenderPipelineDescriptor`,
-        // so it reaches this device inside the type-7 pipeline's own
+        // so it reaches this device inside the serializer-object pipeline's own
         // compact-TLV block. The pass key carries that decoded count, and the
         // render-pass attachment is created with the same value; unsupported
         // count/attachment combinations are refused before either object is

--- a/crates/reims-vgpu/src/backend/vulkan/engine/draw_phase.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/draw_phase.rs
@@ -173,7 +173,7 @@
 //! ## That repair was built, and it is the cache half that fails
 //!
 //! The paragraph this replaces said the gather path had no content cache at all
-//! and that it was *not* established whether the type-11 seed witness could
+//! and that it was *not* established whether the mapper-ref-texture seed witness could
 //! cover these run lists, "the first thing to check before building on this".
 //! Both are answered. [`crate::runtime::gather_witness`] covers them —
 //! `GatherWindow` carries the window's `gpas` alongside its `runs`, so the

--- a/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/exec.rs
@@ -4002,10 +4002,10 @@ pub(crate) unsafe fn execute_draw_inner(
                         crate::runtime::drain::note_store_route(match direct.origin {
                             super::SampledByteOrigin::LinearTexture => "sampled_direct_linear",
                             super::SampledByteOrigin::SurfaceGuestFallback => {
-                                "sampled_direct_type11"
+                                "sampled_direct_mapper_ref_texture"
                             }
                             super::SampledByteOrigin::SerializedSurfaceView => {
-                                "sampled_direct_type5"
+                                "sampled_direct_ref_texture"
                             }
                             _ => "sampled_direct_other",
                         });
@@ -5781,7 +5781,7 @@ pub(crate) unsafe fn execute_draw_inner(
     //
     // That is a reading about the workload and **not** a licence to delete the
     // tail. `skip_readback` has to be decided before submit, and a Store that
-    // neither defer rail can take still has to land its pixels: a type-11 Store
+    // neither defer rail can take still has to land its pixels: a mapper-ref-texture Store
     // always defers (`draw::vulkan` records why), but a GVA Store whose
     // `row_stride` is short of the format's tight row bytes fails
     // `gva_store_defer_eligible` and keeps its readback. Delete this and that

--- a/crates/reims-vgpu/src/backend/vulkan/engine/gpu_span.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/gpu_span.rs
@@ -118,7 +118,7 @@
 //! **A draw submission is 96.9 % of this device's GPU time**, and the guest-page
 //! writeback — the rail several sessions treated as the largest GPU cost — is
 //! 3.6 %. That is not a refutation of those sessions: it is what
-//! [`crate::runtime::writeback_debt`] *did*, by eliding 90 % of type-11 Stores.
+//! [`crate::runtime::writeback_debt`] *did*, by eliding 90 % of mapper-ref-texture Stores.
 //! The remaining Store submissions are 72 a second against 1 961 draw ones.
 //!
 //! `readback` and `compute` at exactly zero are healthy zeros on this workload,

--- a/crates/reims-vgpu/src/backend/vulkan/engine/host_ram.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/host_ram.rs
@@ -639,7 +639,7 @@ pub enum GuestWriteDecline {
     /// lives.
     ///
     /// Stated as a disagreement between the two rather than as "the resident is
-    /// not BGRA", because both orders reach this call: a type-11 mapping's pages
+    /// not BGRA", because both orders reach this call: a mapper-ref-texture mapping's pages
     /// are guest scanout order and a GVA render target's are whatever the guest
     /// declared for it. A rail that spelled the rule as one fixed order refused
     /// every RGBA destination it could have served unchanged.

--- a/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/mod.rs
@@ -1876,7 +1876,7 @@ pub fn execute_compute_request(req: &ComputeRequest) -> Result<ComputeOutput, Co
 
 /// Measure-only: does the target registry hold **content_ready** for this identity?
 ///
-/// Used by type-11 sample dig (`sample_src=… resident_ready=`) to detect the
+/// Used by mapper-ref-texture sample dig (`sample_src=… resident_ready=`) to detect the
 /// resident-vs-guest split without a full readback. Does not create devices or
 /// allocate; returns false if the engine is uninit or the key is absent.
 /// Whether the window presenter would take this resident for a present at
@@ -2121,7 +2121,7 @@ pub fn resident_absent_after_reclaim(
 /// `None` when the identity is absent, evicted, or has not been vouched for
 /// since its last draw.
 ///
-/// Compared by the type-11 LOAD against
+/// Compared by the mapper-ref-texture LOAD against
 /// [`crate::model::MappingEntry::surface_content_epoch`]: equal means the
 /// resident already holds exactly the bytes a CPU seed would upload, so the
 /// pass may load straight from the resident and skip the upload. Every way the
@@ -2593,7 +2593,7 @@ pub fn supports_block_compressed_sampled() -> bool {
 /// a fallback, it is the host window holding its previous retain until some
 /// later frame happens to be readable. That was survivable while every resident
 /// this could name was created in guest scanout order; it stopped being so once
-/// a type-11 mapping's resident follows the format the mapping declares, because
+/// a mapper-ref-texture mapping's resident follows the format the mapping declares, because
 /// a scanout plane declared at anything else would have frozen the window
 /// outright. So the readback's own reported order decides, and a resident that
 /// is not already BGRA8 pays one exchange — [`read_target`]'s rail has already

--- a/crates/reims-vgpu/src/backend/vulkan/engine/pools/images_and_registry.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/pools/images_and_registry.rs
@@ -866,7 +866,7 @@ impl ResourcePools {
     ///   ago, so it carries no content stamp and no epoch; nothing has
     ///   transitioned it, so its layout is `UNDEFINED`; and no window holds it,
     ///   so it is unpinned. These are not defaults a creation site may pick —
-    ///   `registry_mark_ready_at` and the type-11 LOAD gate read them, and an arm
+    ///   `registry_mark_ready_at` and the mapper-ref-texture LOAD gate read them, and an arm
     ///   that guessed differently would be
     ///   answering a question the others think they already asked.
     /// - **The diagnostic clock belongs to the registry.** `last_touch_ms` comes
@@ -1942,12 +1942,11 @@ impl ResourcePools {
             .is_some_and(|slot| slot.content_ready)
     }
 
-    /// Pin/unpin a resident render target against LRU eviction (deferred
-    /// render Stores). Pins are counted, not boolean: a surface can have several
-    /// deferred windows armed at once and each holds one count, so the slot
-    /// stays protected until every holder unpins. Returns false when the identity is absent or (for pinning) its
-    /// content is not ready — callers must fall back to the synchronous
-    /// Store. Unpin saturates at zero (a spurious unpin never underflows).
+    /// Pin/unpin a resident render target against LRU eviction (deferred render Stores). Pins are
+    /// counted, not boolean: a surface can have several deferred windows armed at once and each
+    /// holds one count, so the slot stays protected until every holder unpins. Returns false when
+    /// the identity is absent or (for pinning) its content is not ready — callers must fall back to
+    /// the synchronous Store. Unpin saturates at zero (a spurious unpin never underflows).
     ///
     /// # An unpin at zero is reported, not absorbed
     ///
@@ -2817,7 +2816,7 @@ pub(super) mod pin_count_tests {
 
     /// A draw into this identity invalidates any stamp on it. The image's
     /// pixels just changed, and until something publishes them as the mapping's
-    /// content the type-11 LOAD gate must not treat them as current — otherwise
+    /// content the mapper-ref-texture LOAD gate must not treat them as current — otherwise
     /// an intermediate record's output is loaded as though it were the guest's
     /// prior frame.
     ///
@@ -3185,7 +3184,7 @@ pub(super) mod pin_count_tests {
     /// pixels, no layout transition behind it and no window holding it.
     ///
     /// Each of these four is read by a different rail — `registry_mark_ready`,
-    /// the type-11 LOAD gate's epoch check, the barrier tracker and the idle
+    /// the mapper-ref-texture LOAD gate's epoch check, the barrier tracker and the idle
     /// drain — so an arm that registered a slot with any of them set differently
     /// would be answering a question the other rails believe they already asked.
     #[test]
@@ -3593,7 +3592,8 @@ pub(super) mod pin_count_tests {
         let mut pools = ResourcePools::new();
         admit(&mut pools, surf(1), 10, 0); // aged, non-pinned  -> victim
         admit(&mut pools, surf(2), 10, 1); // aged but PINNED   -> kept
-                                           // now = 10 + AGE + 1 so slot 1's cutoff is crossed; a fresh slot is not.
+                                           // now = 10 + AGE + 1 so slot 1's cutoff is crossed; a
+                                           // fresh slot is not.
         let now = 10 + IDLE_MAINTENANCE_START_MS + 1;
         admit(&mut pools, surf(3), now, 0); // fresh            -> kept
         assert!(pools.plan_idle_maintenance(now), "maintenance pass is due");

--- a/crates/reims-vgpu/src/backend/vulkan/engine/pools/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/pools/mod.rs
@@ -1235,7 +1235,7 @@ pub(crate) struct SampledSlot {
     /// descriptor types, so a recycled slot must never cross that boundary.
     pub one_dim: bool,
     pub format: ash::vk::Format,
-    /// The view's component mapping, from the decoded type-8 swizzle. Part of
+    /// The view's component mapping, from the decoded texture-view swizzle. Part of
     /// the pool key because it is baked into the `VkImageView`: a recycled slot
     /// whose view swizzles differently would silently remap a later bind's
     /// channels. Identity is the overwhelmingly common case and keeps its own
@@ -1478,9 +1478,9 @@ struct ResidentSampledSlot {
     last_touch_ms: u64,
 }
 
-/// Geometry+format key for storage-image pool free lists. Compute images are
-/// single-layer 2D by contract (see [`crate::backend::vulkan::engine::ComputeStorageImageResource`]),
-/// so geometry is exactly width × height.
+/// Geometry+format key for storage-image pool free lists. Compute images are single-layer 2D by
+/// contract (see [`crate::backend::vulkan::engine::ComputeStorageImageResource`]), so geometry is
+/// exactly width × height.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct StorageImageKey {
     pub width: u32,
@@ -1885,7 +1885,7 @@ pub(crate) struct ResidentTargetSlot {
     /// `None` is the fail-closed default and it is what every reset restores:
     /// slot creation, image recycle, and both `registry_mark_ready*` arms — so
     /// a draw that stores into this identity without going on to publish the
-    /// mapping's content leaves the slot unvouched, and the type-11 LOAD gate
+    /// mapping's content leaves the slot unvouched, and the mapper-ref-texture LOAD gate
     /// falls back to its CPU seed. An `Option` rather than a sentinel because
     /// epoch 0 ("nothing published since attach") is a legal *mapping* value
     /// and a bare `0 == 0` would match an image that was never stamped at all.

--- a/crates/reims-vgpu/src/backend/vulkan/engine/pools/submission_and_buffers.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/pools/submission_and_buffers.rs
@@ -3860,7 +3860,7 @@ impl ResourcePools {
                 .image(image)
                 .view_type(view_type)
                 .format(vk_format)
-                // The decoded type-8 view swizzle, performed by the hardware at
+                // The decoded texture-view swizzle, performed by the hardware at
                 // sample time. Identity for every ordinary bind. The format
                 // contributes no mapping of its own: `translate::pixel`'s
                 // sampled rail admits only formats whose Metal channels sit

--- a/crates/reims-vgpu/src/backend/vulkan/engine/types.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/engine/types.rs
@@ -1205,7 +1205,7 @@ pub struct SampledImageResource {
     /// Optional identity fast path for [`SampledSource::Bytes`] (see
     /// [`SampledContentIdentity`]); `None` keeps the content-addressed path.
     pub identity: Option<SampledContentIdentity>,
-    /// Decoded type-8 view swizzle, applied as the image view's component
+    /// Decoded texture-view swizzle, applied as the image view's component
     /// mapping so the GPU performs it at sample time. Identity (the default)
     /// creates the same view as before. Doing this on the view rather than by
     /// rewriting texels is what lets a swizzled texture stay on whatever
@@ -1762,7 +1762,7 @@ pub struct ComputeBufferOutput {
 
 /// Storage image for compute. Formats mirror the live `simg_u32_to_vk_storage` map.
 ///
-/// Single-layer 2D only: a compute texture binding is staged from one type-11
+/// Single-layer 2D only: a compute texture binding is staged from one mapper-ref-texture
 /// plane window or one linear GVA level, both of which are a flat `width ×
 /// height` rectangle. There is no decoded slice or depth axis on this rail, so
 /// the engine builds `TYPE_2D` unconditionally.
@@ -1784,7 +1784,7 @@ pub struct ComputeStorageImageResource {
     pub bytes: Vec<u8>,
     /// Where the post-dispatch pixels go. See [`ComputeImageDestination`].
     pub destination: ComputeImageDestination,
-    /// Exact type-11 resource lifetime/view contract for persistent GPU
+    /// Exact mapper-ref-texture resource lifetime/view contract for persistent GPU
     /// storage. `None` keeps the conservative transient upload path.
     pub residency: Option<ComputeStorageResidency>,
     /// The caller skipped reading guest pages into `bytes` because the
@@ -2067,7 +2067,7 @@ impl StorageImageFormat {
 /// this rail's resolution outside this rail.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum TargetIdentity {
-    /// Type-4 mapping / surface id namespace.
+    /// Backing mapping / surface id namespace.
     Surface {
         id: u32,
         width: u32,
@@ -2076,7 +2076,7 @@ pub enum TargetIdentity {
         /// This target's resident image format, from the pixel format the
         /// mapping declares for its own plane.
         ///
-        /// A type-11 mapping is not BGRA8 by its contract, which is what this
+        /// A mapper-ref-texture mapping is not BGRA8 by its contract, which is what this
         /// namespace assumed for as long as it held no format: it declares a
         /// format, `mapping_write` reads that declaration to lay out the
         /// writeback, and macOS 26 declares `MTLPixelFormatRGBA16Float` for
@@ -2092,7 +2092,7 @@ pub enum TargetIdentity {
         /// its destination cannot disagree about what the guest asked for.
         format: vk::Format,
     },
-    /// Type-2/3 texture ref namespace.
+    /// normal texture ref namespace.
     Texture {
         ref_: u32,
         width: u32,
@@ -2337,7 +2337,7 @@ impl TargetIdentity {
     ///
     /// Each namespace answers it from what it knows:
     ///
-    /// * `Surface` backs a type-11 guest IOSurface, whose plane carries a
+    /// * `Surface` backs a mapper-ref-texture guest IOSurface, whose plane carries a
     ///   declared pixel format exactly as a GVA target does — usually guest
     ///   scanout order, and not always.
     /// * `Gva` is a render target the guest declared a pixel format for, and
@@ -2971,7 +2971,7 @@ mod tests {
     ///
     /// `Surface` answers from the format its mapping declared, and one
     /// constructed at the scanout format reports BGRA: every CPU consumer of a
-    /// type-11 composite Store is declared in guest scanout order, so an RGBA
+    /// mapper-ref-texture composite Store is declared in guest scanout order, so an RGBA
     /// resident under a scanout-declared mapping costs a whole-frame exchange
     /// per Store.
     ///

--- a/crates/reims-vgpu/src/backend/vulkan/mod.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/mod.rs
@@ -28,7 +28,7 @@ use crate::backend::{
     StampOrdering,
 };
 use crate::model::{ComputeStorageResidencyKey, DeviceInfoLimits, DeviceState};
-use crate::runtime::blit_exec::{self, BlitStatus, LinearTextureLevel, Type11Texture};
+use crate::runtime::blit_exec::{self, BlitStatus, LinearTextureLevel, MapperRefTexture};
 use crate::runtime::compute_exec::{self, ComputeAccum, ComputeStatus, ResidentServe};
 use crate::runtime::compute_session::ComputeSession;
 use crate::runtime::decode::blit::Command as BlitCommand;
@@ -325,7 +325,7 @@ impl Backend for VulkanBackend {
         host: &mut M,
         task_id: u32,
         destination_ref: u32,
-        src: &Type11Texture,
+        src: &MapperRefTexture,
         dst: &LinearTextureLevel,
     ) -> Option<BlitStatus> {
         blit_exec::vulkan::try_copy_t11_plane_to_linear_on_gpu(

--- a/crates/reims-vgpu/src/backend/vulkan/translate/blend.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/translate/blend.rs
@@ -86,7 +86,7 @@ pub fn operation(mtl: u32) -> Result<BlendOp, TranslateReason> {
     })
 }
 
-/// A whole decoded type-7 colour-attachment blend descriptor.
+/// A whole decoded serializer-object colour-attachment blend descriptor.
 ///
 /// Fails on the first unrepresentable component rather than substituting a
 /// default for it — a blend that silently becomes `ONE, ZERO` is a rendering

--- a/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/translate/pixel.rs
@@ -691,7 +691,7 @@ pub fn color_attachment(
 /// reads — so asking it was a render-target question about a destination that is
 /// not one, and the answer was `FormatNeedsConversion` for every 32-bit-per-
 /// channel plane. On a driven macos-13 boot that was all five remaining compute
-/// readbacks: four linear at `MTLPixelFormatRGBA32Float` and one type-11 at
+/// readbacks: four linear at `MTLPixelFormatRGBA32Float` and one mapper-ref-texture at
 /// `MTLPixelFormatRGBA32Uint` whose source image held `R32G32B32A32_UINT`, the
 /// very texel the guest had declared.
 ///
@@ -1034,7 +1034,7 @@ fn srgb_decline(f: &PixelFormat, mtl: u16) -> Option<TranslateReason> {
 /// it in hardware.
 ///
 /// The plan passed in is **already folded**: the caller composes the decoded
-/// type-8 view swizzle over the format's own channel remap with
+/// texture-view swizzle over the format's own channel remap with
 /// [`crate::contract::pixel_format::SwizzlePlan::after`], because a
 /// `VkComponentMapping` can express one plan and a bind may need both. This
 /// function does no composing of its own and must not start — it would then be
@@ -1079,7 +1079,7 @@ pub fn vk_component_mapping(plan: &SwizzlePlan) -> vk::ComponentMapping {
 /// non-identity format instead of admitting one it could not describe.
 ///
 /// The sampled rail relies on that: it takes the plan from [`sampled_pixels`]
-/// and folds it under the decoded type-8 swizzle (see [`vk_component_mapping`]),
+/// and folds it under the decoded texture-view swizzle (see [`vk_component_mapping`]),
 /// which it can only do because the plan travels with the layout instead of
 /// being re-derived downstream. This predicate is now a *reader* of the same
 /// fact rather than a gate on it, and a test holds the two in agreement.
@@ -2597,7 +2597,7 @@ mod tests {
                 // `'l10r'` IOSurface — `kCVPixelFormatType_ARGB2101010LEPacked`
                 // — is what Asphalt 8 renders into on a macos-13 x86/Vulkan
                 // boot, and every draw of it failed at
-                // `draw::render_target`'s `rt_type4_base_format` until the
+                // `draw::render_target`'s `rt_backing_base_format` until the
                 // FourCC and `render_target_bpp` both named it.
                 //
                 // Unlike every other member here this one is not a format
@@ -2818,7 +2818,7 @@ mod tests {
         assert_ne!(SCANOUT_FORMAT, RESIDENT_RGBA_FORMAT);
     }
 
-    /// A sampled bind's view mapping is the decoded type-8 swizzle and nothing
+    /// A sampled bind's view mapping is the decoded texture-view swizzle and nothing
     /// else. Identity in, identity out — otherwise every ordinary bind would
     /// pay for a feature almost none of them use.
     #[test]

--- a/crates/reims-vgpu/src/backend/vulkan/translate/reason.rs
+++ b/crates/reims-vgpu/src/backend/vulkan/translate/reason.rs
@@ -154,7 +154,7 @@ pub enum TranslateReason {
     UnknownSamplerAddressMode(u32),
     /// `MTLSamplerBorderColor` value outside the SDK enum.
     UnknownSamplerBorderColor(u32),
-    /// A type-8 view swizzle selector outside the decoded contract's range.
+    /// A texture-view swizzle selector outside the decoded contract's range.
     UnknownSwizzleSelector(u8),
     /// The device does not advertise the requested `VkFormat` as a vertex
     /// buffer format, and no portable substitute exists for it.

--- a/crates/reims-vgpu/src/device/display_surface.rs
+++ b/crates/reims-vgpu/src/device/display_surface.rs
@@ -138,7 +138,7 @@ pub fn device_scanout_may_paint(id: u64, mapping_id: u32) -> Option<bool> {
 /// screenshot heuristic:
 ///
 /// - `frame_flush_seen` (DisplaySwap / x86 present): product owns the console.
-/// - Else if `early_front_latched` (same-geom type-11 front writeback): the
+/// - Else if `early_front_latched` (same-geom mapper-ref-texture front writeback): the
 ///   product early paint, logo + pill, before the swap.
 /// - Else: BAR1 / guest-programmed `efi_fb_start` (UEFI + PE log console).
 ///

--- a/crates/reims-vgpu/src/device/tests.rs
+++ b/crates/reims-vgpu/src/device/tests.rs
@@ -98,7 +98,7 @@ fn window_publish_key_advances_for_in_place_present() {
     );
 }
 
-/// A lazy type-11 Store publishes new pixels without writing a guest page, so
+/// A lazy mapper-ref-texture Store publishes new pixels without writing a guest page, so
 /// the mapping's `content_generation` holds still across frames that genuinely
 /// differ — and the host window's publish key must move anyway.
 ///

--- a/crates/reims-vgpu/src/device/window_publish.rs
+++ b/crates/reims-vgpu/src/device/window_publish.rs
@@ -40,7 +40,7 @@ pub(super) fn window_frame_key(present: &crate::model::PresentState) -> WindowFr
     (
         present.frame_mapping,
         present.frame_generation,
-        // The pixel stamp beside the page stamp. A lazy type-11 Store publishes
+        // The pixel stamp beside the page stamp. A lazy mapper-ref-texture Store publishes
         // a new frame without writing a guest page, so `frame_generation` holds
         // still across frames that genuinely differ and this is the only term
         // that moves — see `PresentState::frame_content_epoch`.

--- a/crates/reims-vgpu/src/model/mod.rs
+++ b/crates/reims-vgpu/src/model/mod.rs
@@ -15,11 +15,11 @@ pub(crate) use regs::*;
 // `mod`, so this is the only path those links can name — and rustc's
 // unused-import lint cannot see a doc link, so it will call this dead.
 pub use state::{
-    ChannelRing, ComputeStorageResidencyKey, DeviceId, DeviceState, ExecFault, FailEvent, GfxRegs,
-    GuestLinearMemo, GvaBacking, GvaEvictionWitness, GvaHostView, HostLinearTexture, HostSurface,
-    MapperCapture, MappingEntry, PacketFault, PresentBacking, PresentState, RenderFlushWitness,
-    ResourceValidity, SurfaceWriteKind, TaskEntry, TaskResource, TaskResourceLifetimeRef,
-    TaskSamplerState, TaskTable, Type4Walk, UnimplementedCommand, FENCE_DOMAIN_BLIT,
+    BackingWalk, ChannelRing, ComputeStorageResidencyKey, DeviceId, DeviceState, ExecFault,
+    FailEvent, GfxRegs, GuestLinearMemo, GvaBacking, GvaEvictionWitness, GvaHostView,
+    HostLinearTexture, HostSurface, MapperCapture, MappingEntry, PacketFault, PresentBacking,
+    PresentState, RenderFlushWitness, ResourceValidity, SurfaceWriteKind, TaskEntry, TaskResource,
+    TaskResourceLifetimeRef, TaskSamplerState, TaskTable, UnimplementedCommand, FENCE_DOMAIN_BLIT,
     FENCE_DOMAIN_COMPUTE, FENCE_DOMAIN_EVENT, FENCE_DOMAIN_RENDER, GVA_ENCODE_CACHE_BYTE_CAP,
     GVA_EVICTION_WITNESS_KEYS,
 };
@@ -61,7 +61,7 @@ impl Device {
 
     /// Reset after releasing every HostOps view owned by this guest lifetime.
     pub fn reset_with_host<H: HostOps>(&mut self, host: &mut H) -> usize {
-        // Backend aliases (notably Metal type-11 textures) must die before the
+        // Backend aliases (notably Metal mapper-ref-textures) must die before the
         // underlying contiguous guest-memory views are unmapped.
         self.backend().reset();
         let views = self.state.take_all_host_views();
@@ -107,7 +107,7 @@ impl Device {
 
     /// BH body: drain pending work.
     ///
-    /// `state.texture_to_mapping` is the authoritative type-11 ref → mapping
+    /// `state.texture_to_mapping` is the authoritative mapper-ref-texture ref → mapping
     /// table and is read directly by `runtime/draw`. This used to also
     /// copy it into the backend on every drain, into a map nothing ever read.
     pub fn drain<H: runtime::host::HostMemory + HostOps>(&mut self, host: &mut H) {

--- a/crates/reims-vgpu/src/model/regs.rs
+++ b/crates/reims-vgpu/src/model/regs.rs
@@ -186,7 +186,7 @@ pub fn accept_child_channel(channel_id: u32, site: &'static str) -> bool {
 /// sentinel-aware reader will ever consult.
 ///
 /// Four callers knew that and six did not: `runtime::texture` and the two
-/// type-4 backing paths in `runtime::objects` refused zero, while the five
+/// backing paths in `runtime::objects` refused zero, while the five
 /// `DeviceState` mutators and `mapper::capture_published_request` bounded the
 /// id from above only.
 ///
@@ -198,7 +198,7 @@ pub fn accept_child_channel(channel_id: u32, site: &'static str) -> bool {
 /// full `u32`, and no other structure in the device is sized by mapping id — so
 /// the bound allocated nothing, protected nothing, and its only effect was that
 /// a guest naming id 4096 had its MAP, UNMAP, MappingInternal attach, device
-/// descriptor and geometry silently refused, and every type-4 surface backing
+/// descriptor and geometry silently refused, and every backing record
 /// with it. A mapping id is a full `u32` on the wire; the guest chooses it and
 /// the device is not entitled to an opinion about how large it is.
 ///

--- a/crates/reims-vgpu/src/model/state.rs
+++ b/crates/reims-vgpu/src/model/state.rs
@@ -82,7 +82,7 @@ impl PacketFault {
 /// Which check refused to execute a decoded child-channel command.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExecFault {
-    /// A type-2 indirect exec packet shorter than its declared descriptor.
+    /// A texture indirect exec packet shorter than its declared descriptor.
     Indirect2Short,
 }
 
@@ -494,7 +494,7 @@ pub struct TaskEntry {
 /// for one of them to have branched on.
 ///
 /// The two full-range probes in `runtime::objects` are the visible win.
-/// `type4_claimant_tasks` walked all 256 ids and `type4_probe_order` chained
+/// `backing_claimant_tasks` walked all 256 ids and `backing_probe_order` chained
 /// `1..256`; both now walk the live ids, because the ids in between were
 /// refused by the liveness test at the probe and contributed nothing. Same
 /// answer, and the walk is the size of the guest's task set instead of a
@@ -580,11 +580,11 @@ pub struct TaskResource {
     /// total decoder refuses, and keep that refusal too so those consumers do
     /// not silently widen the total contract.
     decoded: OnceLock<Result<Descriptor, ResourceDecodeStatus>>,
-    /// Type-11 construction side effects, completed once for this resource
+    /// Mapper-ref-texture construction side effects, completed once for this resource
     /// lifetime. The mapping id is immutable construction state; physical
     /// backing replacement invalidates the mapping's pages without rebuilding
     /// the texture object.
-    type11_mapping: OnceLock<u32>,
+    mapper_ref_texture_mapping: OnceLock<u32>,
     /// Identity whose strong lifetime is exactly this serialized resource.
     /// Direct backend objects keep only a weak reference, so deletion—not an
     /// arbitrary idle timeout—makes them reclaimable.
@@ -610,7 +610,7 @@ impl TaskResource {
             entry,
             descriptor,
             decoded: OnceLock::new(),
-            type11_mapping: OnceLock::new(),
+            mapper_ref_texture_mapping: OnceLock::new(),
             lifetime: Arc::new(TaskResourceLifetime::new()),
             #[cfg(feature = "backend-vulkan")]
             resident_targets: Mutex::new(HashMap::new()),
@@ -634,12 +634,12 @@ impl TaskResource {
         }
     }
 
-    pub(crate) fn registered_type11_mapping(&self) -> Option<u32> {
-        self.type11_mapping.get().copied()
+    pub(crate) fn registered_mapper_ref_texture_mapping(&self) -> Option<u32> {
+        self.mapper_ref_texture_mapping.get().copied()
     }
 
-    pub(crate) fn register_type11_mapping(&self, mapping_id: u32) -> u32 {
-        *self.type11_mapping.get_or_init(|| mapping_id)
+    pub(crate) fn register_mapper_ref_texture_mapping(&self, mapping_id: u32) -> u32 {
+        *self.mapper_ref_texture_mapping.get_or_init(|| mapping_id)
     }
 
     /// Retain and classify the engine target named by this resource.
@@ -1007,7 +1007,7 @@ pub type TaskRenderPipelineStates =
 /// A depth-stencil state is an immutable object with its own explicit delete
 /// command (`OPCODE_DELETE_DEPTH_STENCIL_STATE`), exactly like a sampler state
 /// and a render pipeline state, so it belongs in this namespace and not in
-/// [`TaskResources`] — whose type mask deliberately excludes object type 7,
+/// [`TaskResources`] — whose type mask deliberately excludes object serializer-object,
 /// because that tag is also worn by mutable serializer descriptors and two
 /// reference spaces sharing one map would destroy each other's entries when
 /// their integers collide.
@@ -1231,12 +1231,12 @@ pub struct MapperCapture {
 }
 
 /// The guest page table and GPU-VA base a mapping's [`MappingEntry::
-/// page_entries`] were walked from, when the list came from a type-4 surface
+/// page_entries`] were walked from, when the list came from a backing record
 /// plan.
 ///
 /// Latched at the one site that assigns those entries so the two cannot drift
 /// apart. It exists so a later reader can *repeat* the walk without repeating
-/// the search: `resolve_type4_surface_ex` finds the surface object by probing up
+/// the search: `resolve_backing_ex` finds the surface object by probing up
 /// to 256 task object lists, and that cost is why the page list is cached rather
 /// than re-derived. The walk itself is cheap — one page-table translation per
 /// page — and it is the only thing that can say whether the cached list still
@@ -1248,7 +1248,7 @@ pub struct MapperCapture {
 /// remembering to retire a second field — the same rule
 /// [`MappingEntry::guest_write_token_gen`] states for the same reason.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Type4Walk {
+pub struct BackingWalk {
     /// Task whose page table translated the backing pages.
     pub task_id: u32,
     /// `getGPUVirtualAddress() >> page_shift` of the surface backing — page `i`
@@ -1413,14 +1413,14 @@ pub struct MappingEntry {
     /// The host framework carries the matching pair as `PGResource._hostValid` /
     /// `._guestValid`, set through `setIsHostValid:` / `setIsGuestValid:`.
     pub validity: ResourceValidity,
-    /// Epoch of this mapping's *surface content* in the sense a type-11 render
+    /// Epoch of this mapping's *surface content* in the sense a mapper-ref-texture render
     /// LOAD needs: it advances whenever the pixels that Load would seed from
     /// could have changed, wherever they live.
     ///
     /// Strictly coarser than [`Self::content_generation`], and deliberately so.
     /// `content_generation` counts writes to the mapping's *guest pages*, which
     /// misses the one publisher that writes only the host shadow: the deferred
-    /// type-11 Store stores into `surface_cache` and arms a window instead of
+    /// mapper-ref-texture Store stores into `surface_cache` and arms a window instead of
     /// scattering into guest pages. `surface_cache` holds exactly one entry per
     /// mapping, so a sibling Store at a *different* geometry replaces the entry
     /// an older geometry's resident is being compared against while
@@ -1431,7 +1431,7 @@ pub struct MappingEntry {
     /// currency nothing established.
     ///
     /// Compared against [`crate::backend::vulkan::engine::resident_content_epoch`]
-    /// to decide whether a type-11 LOAD may take `LoadOp::LoadFromTarget` and
+    /// to decide whether a mapper-ref-texture LOAD may take `LoadOp::LoadFromTarget` and
     /// skip its CPU seed entirely. Never read to decide *what* to present or
     /// draw — only whether a known-equal upload can be elided.
     pub surface_content_epoch: u32,
@@ -1503,7 +1503,7 @@ pub struct MappingEntry {
     ///
     /// The lifecycle mutators retire the token eagerly, but they are not the
     /// only writers of [`Self::page_entries`]: the mapper's plan adoption and
-    /// the type-4 page refresh both replace the list in place, and both retired
+    /// the backing page refresh both replace the list in place, and both retired
     /// the contiguous view while leaving the token behind — a token naming
     /// pages the surface no longer owns, which is the one thing it must never
     /// be. Rather than add a third and a fourth site to remember,
@@ -1516,7 +1516,7 @@ pub struct MappingEntry {
     /// [`crate::runtime::host::HostOps::guest_write_gen`] as it stood when this
     /// mapping's pixels were last published by a device Store.
     ///
-    /// The other half of the type-11 seed currency test.
+    /// The other half of the mapper-ref-texture seed currency test.
     /// [`Self::surface_content_epoch`] can only witness writers inside this
     /// crate — every caller of `mark_mapping_written` is one — and a surface's
     /// pages are plain guest RAM the guest CPU stores into with no device
@@ -1526,22 +1526,22 @@ pub struct MappingEntry {
     /// never compares equal to a live generation (the host's first readable
     /// generation is 1).
     pub guest_write_gen_at_store: u64,
-    /// Task id that last owned this surface as a type-4 `OBJECT_TYPE_SURFACE`
+    /// Task id that last owned this surface as a backing `OBJECT_TYPE_BACKING`
     /// object (0 = no non-trivial hint; task 0 is always probed first anyway).
-    /// `resolve_type4_surface_ex` probes this task right after task 0 so a
+    /// `resolve_backing_ex` probes this task right after task 0 so a
     /// per-bind present-path scan short-circuits instead of walking all 256
     /// task slots. Purely a search-order hint — a stale/wrong value only costs
     /// one extra probe before the full-table fallback re-finds the owner.
     pub owner_task_hint: u32,
-    /// How [`Self::page_entries`] were derived, when they came from a type-4
-    /// surface plan — see [`Type4Walk`]. `None` for every other source, and for
+    /// How [`Self::page_entries`] were derived, when they came from a backing
+    /// surface plan — see [`BackingWalk`]. `None` for every other source, and for
     /// a mapping whose list has been invalidated.
     ///
     /// Distinct from [`Self::owner_task_hint`], which is a *search* hint and is
     /// allowed to be wrong. This is a statement about the list that is in the
     /// entry right now: repeat this walk and you must get these entries back, or
     /// the guest has moved the surface underneath us without saying so.
-    pub type4_walk: Option<Type4Walk>,
+    pub backing_walk: Option<BackingWalk>,
 }
 
 impl MappingEntry {
@@ -1574,9 +1574,9 @@ impl MappingEntry {
 /// Three window kinds share this shape (`texture_ref` appended last so the
 /// `(mapping_id, …)` ordering prefix — and every mapping-keyed range scan —
 /// is unchanged):
-/// - **Surface window** (`mapping_id != 0`): a type-11 IOSurface view;
+/// - **Surface window** (`mapping_id != 0`): a mapper-ref-texture IOSurface view;
 ///   `texture_ref == 0`.
-/// - **Linear window** (`mapping_id == 0`): a type-2/3 raw task-GVA texture,
+/// - **Linear window** (`mapping_id == 0`): a normal-texture raw task-GVA texture,
 ///   identity-matched to its `host_linear_textures` cache entry —
 ///   `map_generation` holds the task id, `surface_offset` the level-0 GVA,
 ///   `surface_bpr` the row stride, `span_end` `row_stride * height`, and
@@ -1599,7 +1599,7 @@ pub struct ComputeStorageResidencyKey {
 }
 
 impl ComputeStorageResidencyKey {
-    /// Identity of a linear (type-2/3 raw task-GVA) texture window.
+    /// Identity of a linear (normal-texture raw task-GVA) texture window.
     #[allow(
         clippy::too_many_arguments,
         reason = "the key constructor names every wire-derived identity component"
@@ -1781,7 +1781,7 @@ pub struct HostSurface {
     /// only unique while the entry lives, and this map's entries are removed
     /// and re-created on the routine deferred-Store arm path.
     pub host_gen: u64,
-    /// Decoded object type that produced a GVA-keyed type-2/3 encode. Zero for
+    /// Decoded object type that produced a GVA-keyed normal-texture encode. Zero for
     /// surface/ref caches and for stores that did not record an owner.
     pub producer_object_type: u8,
     /// Recency stamp for the GVA cache's byte cap
@@ -1855,7 +1855,7 @@ pub struct HostSurface {
     // re-stamping on every write.
 }
 
-/// Raw type-2/3 texture content retained by the discrete backend.
+/// Raw normal texture content retained by the discrete backend.
 ///
 /// Unlike [`HostSurface`], bytes stay in the guest Metal pixel format and are
 /// tightly row-packed. The key is `(task_id, texture_ref)`; descriptor fields
@@ -1899,7 +1899,7 @@ pub struct PresentState {
     pub present_mapping: u32,
     pub host_mapping: u32,
     pub frame_flush_seen: bool,
-    /// Latest type-11 **Composite** writeback mid (logo/desktop content).
+    /// Latest mapper-ref-texture **Composite** writeback mid (logo/desktop content).
     /// Pre-boundary: sticky early feed for gfx_update when present_mapping is a
     /// ClearOnly flip buffer (dual-mid buffer-setup thrash class).
     /// Post-boundary: dual-mid *peer* tracker, read only by the failure/census
@@ -1967,7 +1967,7 @@ pub struct PresentState {
     /// different pixels", where `frame_generation` is "the guest's pages hold
     /// something different".
     ///
-    /// The two came apart when the lazy type-11 Store
+    /// The two came apart when the lazy mapper-ref-texture Store
     /// ([`crate::runtime::writeback_debt`]) started leaving a frame in the engine
     /// resident and owing the pages a copy: the pixels move every frame and the
     /// generation does not. Anything asking "is this a new frame to show" has to
@@ -2094,12 +2094,12 @@ pub struct PendingWork {
 }
 
 /// Byte cap for the guest-CPU-produced content memos (`guest_linear_memo`,
-/// `type5_view_memo`, `type11_memo`). A cap crossing evicts the coldest entries
+/// `ref_texture_view_memo`, `mapper_ref_texture_memo`). A cap crossing evicts the coldest entries
 /// down to a low-water mark — never a bulk clear — so the hot working set (and
 /// its avoided re-decode/re-convert cost) survives.
 pub const GUEST_LINEAR_MEMO_BYTE_CAP: usize = 128 << 20;
 
-/// Byte cap for the GVA-keyed type-2/3 encode cache
+/// Byte cap for the GVA-keyed normal-texture encode cache
 /// ([`DeviceState::host_gva_surfaces`]). Same basis and same value as
 /// [`GUEST_LINEAR_MEMO_BYTE_CAP`], which bounds the sibling cache holding the
 /// same class of content.
@@ -2403,22 +2403,22 @@ pub struct DeviceState {
     /// them with resource deletion or task teardown.
     #[cfg(feature = "backend-vulkan")]
     pub task_render_pipeline_states: TaskRenderPipelineStates,
-    /// Type-11 texture object ref → mapping_id: (task_id, ref) -> mapping_id.
+    /// Mapper-ref-texture object ref → mapping_id: (task_id, ref) -> mapping_id.
     pub texture_to_mapping: BTreeMap<(u32, u32), u32>,
     pub mappings: BTreeMap<u32, MappingEntry>,
     /// Host render-cache keyed by surface_id / mapping_id (Linux/Vulkan rail).
     /// See [`crate::runtime::surface_cache`] and kb tahoe-x86-host-reims_vgpu §8.5.
     /// **Surface_id namespace only** — never texture_ref (object list ids collide).
     pub host_surfaces: BTreeMap<u32, HostSurface>,
-    /// Discrete encode cache for type-2/3 GVA color targets, keyed by
+    /// Discrete encode cache for normal-texture GVA color targets, keyed by
     /// `(task_id, texture_ref)`.
     ///
     /// Object-list refs are local to a task. Separate from
-    /// [`Self::host_surfaces`] so list ids cannot clobber type-4 present mids,
+    /// [`Self::host_surfaces`] so list ids cannot clobber backing present mids,
     /// and task-qualified so one address space cannot replace or evict another
     /// task's same-numbered texture.
     pub host_texture_surfaces: BTreeMap<(u32, u32), HostSurface>,
-    /// Same type-2/3 encode content keyed by target GVA — survives texture_ref
+    /// Same normal-texture encode content keyed by target GVA — survives texture_ref
     /// rebinding / small-atlas overwrite of the ref slot.
     ///
     /// Bounded by [`GVA_ENCODE_CACHE_BYTE_CAP`] with least-recently-*used*
@@ -2458,7 +2458,7 @@ pub struct DeviceState {
     pub gva_cache_byte_cap: usize,
     /// What [`GVA_ENCODE_CACHE_BYTE_CAP`] cost, measured rather than assumed.
     pub gva_eviction_witness: GvaEvictionWitness,
-    /// Raw compute encode for type-2/3 textures. Retained across GVA unmap;
+    /// Raw compute encode for normal textures. Retained across GVA unmap;
     /// evicted on task/object lifetime end or descriptor mismatch.
     pub host_linear_textures: BTreeMap<(u32, u32), HostLinearTexture>,
     /// Perf memo for guest-CPU-produced linear textures (no host cache entry,
@@ -2479,7 +2479,7 @@ pub struct DeviceState {
     #[cfg(feature = "backend-vulkan")]
     pub gather_witness: crate::runtime::gather_witness::GatherWitness,
     /// The GVA render targets a Store has stamped, and what the two write
-    /// witnesses said at the time. The GVA half of the type-11 witness that
+    /// witnesses said at the time. The GVA half of the mapper-ref-texture witness that
     /// licenses the attachment LOAD elision — see
     /// [`crate::runtime::gva_store_witness`].
     #[cfg(feature = "backend-vulkan")]
@@ -2518,7 +2518,7 @@ pub struct DeviceState {
     /// lifetime, key space, or eviction policy.
     ///
     /// Each producer used to keep its own counter and the difference was
-    /// measured, not theorised. The guest-linear and type-5 memos shared this
+    /// measured, not theorised. The guest-linear and ref-texture memos shared this
     /// one and were sound; the GVA host cache incremented a *per-entry* field
     /// that restarted at 1 whenever the entry was re-created, and
     /// `evict_gva` re-creates it on every deferred GVA render Store arm. One
@@ -2538,16 +2538,16 @@ pub struct DeviceState {
     pub host_writes: crate::runtime::host_writes::HostWrites,
     /// Reusable native-row read buffer for the guest-linear memo path.
     pub guest_linear_scratch: Vec<u8>,
-    /// Byte-exact revalidated memo for type-5 serialized texture views
+    /// Byte-exact revalidated memo for ref-texture serialized texture views
     /// (media IOSurface planes). Same contract as
     /// [`Self::guest_linear_memo`]: every bind re-reads the native plane
     /// window; conversion + upload (via the returned content identity) are
     /// skipped on unchanged bytes. Keyed by
     /// (mapping_id, plane, width, height, view pixel format). Byte-bounded LRU
     /// ([`GUEST_LINEAR_MEMO_BYTE_CAP`]).
-    pub type5_view_memo: LruBytesMemo<(u32, u32, u32, u32, u16), GuestLinearMemo>,
-    /// Byte-exact revalidated memo for the type-11 mapping-backed sampled path
-    /// (`load_type11_mapping_rgba` — small IOSurface textures below the zero-copy
+    pub ref_texture_view_memo: LruBytesMemo<(u32, u32, u32, u32, u16), GuestLinearMemo>,
+    /// Byte-exact revalidated memo for the mapper-ref-texture mapping-backed sampled path
+    /// (`load_mapper_ref_texture_mapping_rgba` — small IOSurface textures below the zero-copy
     /// floor, e.g. dock icons under magnification). Same contract as
     /// [`Self::guest_linear_memo`]: every bind re-reads the native BGRA rect;
     /// the BGRA->RGBA convert + the two per-bind allocs + the engine's content
@@ -2556,9 +2556,9 @@ pub struct DeviceState {
     /// so this collapses the `t11_guest` CPU copies that otherwise saturate the
     /// serial drain worker (dock-hover freeze). Keyed by (mapping_id, w, h).
     /// Byte-bounded LRU ([`GUEST_LINEAR_MEMO_BYTE_CAP`]).
-    pub type11_memo: LruBytesMemo<(u32, u32, u32), GuestLinearMemo>,
-    /// Reusable native BGRA read buffer for the type-11 memo re-read.
-    pub type11_memo_scratch: Vec<u8>,
+    pub mapper_ref_texture_memo: LruBytesMemo<(u32, u32, u32), GuestLinearMemo>,
+    /// Reusable native BGRA read buffer for the mapper-ref-texture memo re-read.
+    pub mapper_ref_texture_memo_scratch: Vec<u8>,
     /// Last guest-visible generation produced by a compute storage-image
     /// writeback, keyed by the exact window it was produced for.
     ///
@@ -2810,9 +2810,9 @@ impl DeviceState {
             sampled_content_gen: 0,
             host_writes: crate::runtime::host_writes::HostWrites::new(page_shift),
             guest_linear_scratch: Vec::new(),
-            type5_view_memo: LruBytesMemo::new(GUEST_LINEAR_MEMO_BYTE_CAP),
-            type11_memo: LruBytesMemo::new(GUEST_LINEAR_MEMO_BYTE_CAP),
-            type11_memo_scratch: Vec::new(),
+            ref_texture_view_memo: LruBytesMemo::new(GUEST_LINEAR_MEMO_BYTE_CAP),
+            mapper_ref_texture_memo: LruBytesMemo::new(GUEST_LINEAR_MEMO_BYTE_CAP),
+            mapper_ref_texture_memo_scratch: Vec::new(),
             gva_host_views: Vec::new(),
             view_stale_reads: 0,
         }
@@ -3296,7 +3296,7 @@ impl DeviceState {
     /// This device carries two ways from a reference to a surface, because the
     /// guest has two: on some paths the reference *is* the mapping id, and on
     /// the rest [`Self::texture_to_mapping`] holds the per-task registration a
-    /// type-11 create recorded. A statement about the reference — a validity
+    /// mapper-ref-texture create recorded. A statement about the reference — a validity
     /// quad, an owed render frame — is a statement about every mapping it
     /// names, so the candidate set is one rule and lives here.
     ///
@@ -3437,7 +3437,7 @@ impl DeviceState {
         // page list that just stopped being this surface's.
         //
         // Retiring the guest-write token is what makes that reachable rather
-        // than theoretical. The type-4 sampled ladder's host-cache rung serves
+        // than theoretical. The backing sampled ladder's host-cache rung serves
         // its copy unless the witness reports `Wrote`, and a retired token
         // reports `NoStamp` — deliberately not evidence, because "nobody armed
         // this" is a statement about this device and not about the guest. The
@@ -3860,7 +3860,7 @@ impl DeviceState {
     ///
     /// Also advances [`MappingEntry::surface_content_epoch`], so every one of
     /// this crate's guest-page writers keeps that epoch closed for free — the
-    /// completeness property the type-11 `LoadFromTarget` gate rests on.
+    /// completeness property the mapper-ref-texture `LoadFromTarget` gate rests on.
     pub fn mark_mapping_written(&mut self, mapping_id: u32) -> u32 {
         let seq = self.next_validity_seq();
         let Some(m) = self.mappings.get_mut(&mapping_id) else {
@@ -3888,7 +3888,7 @@ impl DeviceState {
     }
 
     /// Advance a mapping's content stamps for a publish that changed its pixels
-    /// *without* writing its guest pages — the lazy type-11 Store of
+    /// *without* writing its guest pages — the lazy mapper-ref-texture Store of
     /// [`crate::runtime::writeback_debt`], which leaves the frame in the engine
     /// resident and owes the pages a copy.
     ///

--- a/crates/reims-vgpu/src/observe/ladder.rs
+++ b/crates/reims-vgpu/src/observe/ladder.rs
@@ -78,7 +78,7 @@
 /// Compose a ladder slug from a rail's role and one of the four rungs.
 ///
 /// The role is whatever the rail already used to say which of its resources
-/// failed (`"buf"`, `"tex"`, `"icb_type1"`, `"compute_stage_buf"`), and is kept
+/// failed (`"buf"`, `"tex"`, `"icb_buffer"`, `"compute_stage_buf"`), and is kept
 /// exactly as it was. Only the condition half is fixed, which is the half that
 /// had ten spellings.
 ///
@@ -236,7 +236,10 @@ mod tests {
     fn a_role_and_a_rung_compose_into_the_slug_the_rail_emits() {
         assert_eq!(ladder_slug!("buf", no_list_entry), "buf_no_list_entry");
         assert_eq!(ladder_slug!("tex", wrong_type), "tex_wrong_type");
-        assert_eq!(ladder_slug!("icb_type1", desc_read), "icb_type1_desc_read");
+        assert_eq!(
+            ladder_slug!("icb_buffer", desc_read),
+            "icb_buffer_desc_read"
+        );
         assert_eq!(
             ladder_slug!("compute_stage_buf", desc_decode),
             "compute_stage_buf_desc_decode"

--- a/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/mod.rs
@@ -1,16 +1,16 @@
 //! Product-path execution of blit fill/copy commands against guest backings.
 //!
 //! Supported now:
-//! - `fillBuffer` (0x132) on type-1 buffers
-//! - `copyFromBuffer:toBuffer:` (0x12d) on type-1 buffers
-//! - Rectangular buffer↔texture / texture↔texture copies on linear type-2/3
-//! - Same rectangular copies with **type-11 IOSurface** texture endpoints
+//! - `fillBuffer` (0x132) on buffers
+//! - `copyFromBuffer:toBuffer:` (0x12d) on buffers
+//! - Rectangular buffer↔texture / texture↔texture copies on linear normal-texture
+//! - Same rectangular copies with **mapper-ref-texture IOSurface** texture endpoints
 //!   (level 0, slice 0, depth 1) via mapping page tables; multi-plane (biplanar)
 //!   sample windows from cached `sIOSurfaceDeviceDescriptor` selected by texture
 //!   geometry (width/height/bpe), not a wire plane index
-//! - **Type-8 texture views** as copy endpoints: unswizzled views over type-2/3
-//!   or type-11 bases; multi-level / array / non-2D Metal types when geometry matches
-//!   (type-11 bases remain single-level / single-slice — see below)
+//! - **Texture-view texture views** as copy endpoints: unswizzled views over normal-texture
+//!   or mapper-ref-texture bases; multi-level / array / non-2D Metal types when geometry matches
+//!   (mapper-ref-texture bases remain single-level / single-slice — see below)
 //! - **`MTLBlitOption`**: None; DepthFromDepthStencil / StencilFromDepthStencil;
 //!   combined DS plane packing on linear GVA; unknown bits / RowLinearPVRTC fail
 //! - **`0x13e` whole-surface** texture→texture: for each level in
@@ -19,22 +19,22 @@
 //!     slices
 //!   - **depth>1 (3D volume):** Metal requires `sliceCount==1` and slices 0;
 //!     copies full `width×height×depth` of that mip (depth planes via
-//!     `bytes_per_image`); linear type-2/3 only
+//!     `bytes_per_image`); linear normal-texture only
 //!   - zero `sliceCount`/`levelCount` are Metal no-ops
 //! - **Fences** `0x13c` update / `0x13d` wait: blit-fence domain generation via
 //!   [`crate::runtime::plan::event_sync`]; waits that are not yet satisfied are
 //!   soft-pending (do not block drain), matching the unified-memory in-order path
 //!
 //! Not executed (fail visibly / soft miss):
-//! - swizzled type-8 views (contract: blit rejects remapped swizzle materialization)
+//! - swizzled texture-views (contract: blit rejects remapped swizzle materialization)
 //! - multisample view types
 //! - RowLinearPVRTC / unknown option bits
 //! - overlapping same-buffer B2B windows
-//! - type-11 multi-mip / non-zero level or slice — **not a missing feature**: Metal
+//! - mapper-ref-texture multi-mip / non-zero level or slice — **not a missing feature**: Metal
 //!   forbids mipmapped IOSurface textures (`newTextureWithDescriptor:iosurface:`
 //!   rejects `mipmapLevelCount > 1`). Product path fail-closes; do not invent a
 //!   pyramid layout in the mapping.
-//! - 3D whole-surface with `sliceCount!=1`, non-zero slices, or type-11 endpoint
+//! - 3D whole-surface with `sliceCount!=1`, non-zero slices, or mapper-ref-texture endpoint
 
 // The backend the process executes on, reached only through the trait: this
 // module names no rail.
@@ -47,7 +47,7 @@ use crate::runtime::decode::resource::{
     decode_buffer_descriptor, decode_iosurface_texture_descriptor, decode_texture_descriptor,
     decode_texture_view_descriptor, texture_view_type_is_3d, texture_view_type_supported,
     texture_view_type_uses_slices, Descriptor as ResourceDescriptor, OBJECT_TYPE_BUFFER,
-    OBJECT_TYPE_IOSURFACE, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT,
+    OBJECT_TYPE_MAPPER_REF_TEXTURE, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
     OBJECT_TYPE_TEXTURE_VIEW, TEXTURE_VIEW_MTL_TYPE_2D,
 };
 use crate::runtime::draw::{self, host_alloc_len};
@@ -70,7 +70,7 @@ pub enum BlitStatus {
     Ok,
     /// Missing object, wrong kind, or unreadable descriptor.
     MissingResource,
-    /// Opcode / options / view / slice / 3D / type-11 not on this path.
+    /// Opcode / options / view / slice / 3D / mapper-ref-texture not on this path.
     Unsupported,
     /// Offset/length/extent outside allocation or level bounds.
     Bounds,
@@ -198,9 +198,9 @@ fn reset_tex_wrong_type_dedup_for_test() {
 static T5_DECODE_FAIL_SEEN: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<u32>>> =
     std::sync::OnceLock::new();
 
-/// One always-on diagnostic per surface id when a type-5 RefTexture's view
+/// One always-on diagnostic per surface id when a ref-texture RefTexture's view
 /// record fails to decode: dumps `desc_len` + head hex so the exact blit-path
-/// type-5 layout can be read offline (the decoder wants tag 0x42 at +0x14, 2D
+/// ref-texture layout can be read offline (the decoder wants tag 0x42 at +0x14, 2D
 /// nonzero geom, depth==1). Deduped so a per-draw repeat cannot flood.
 fn note_t5_decode_fail(sid: u32, bytes: &[u8]) {
     let set = T5_DECODE_FAIL_SEEN.get_or_init(|| std::sync::Mutex::new(Default::default()));
@@ -329,7 +329,7 @@ pub(crate) struct LinearTextureLevel {
     pixel_format: u16,
 }
 
-/// Type-11 IOSurface texture (single level, 2D).
+/// Mapper-ref-texture IOSurface texture (single level, 2D).
 ///
 /// Metal rejects mipmapped IOSurface textures (`mipmapLevelCount > 1` fails
 /// descriptor validation on `newTextureWithDescriptor:iosurface:plane:`). The
@@ -339,7 +339,7 @@ pub(crate) struct LinearTextureLevel {
 /// Multi-plane (biplanar 420): sample window comes from the cached guest device
 /// descriptor via geometry match (texture width/height/bpe); `surface_offset` is
 /// the plane base in the shared mapping.
-pub(crate) struct Type11Texture {
+pub(crate) struct MapperRefTexture {
     mapping_id: u32,
     width: u32,
     height: u32,
@@ -347,8 +347,8 @@ pub(crate) struct Type11Texture {
     surface_offset: u64,
     /// IOSurface-aligned surface row stride (bytes).
     ///
-    /// `u32` to match both ends it sits between: `type11_sample_window` and
-    /// `type5_sample_window` each return it as one, and its only readers hand
+    /// `u32` to match both ends it sits between: `mapper_ref_texture_sample_window` and
+    /// `ref_texture_sample_window` each return it as one, and its only readers hand
     /// it to [`mapping_write::SurfaceWindow::bpr`], which is one. It was `u64`,
     /// so both construction sites widened and both readers narrowed straight
     /// back — a round trip that reads exactly like an unchecked truncation of a
@@ -362,42 +362,42 @@ pub(crate) struct Type11Texture {
 
 enum TextureBacking {
     Linear(LinearTextureLevel),
-    Type11(Type11Texture),
+    MapperRefTexture(MapperRefTexture),
 }
 
 impl TextureBacking {
     fn width(&self) -> u32 {
         match self {
             TextureBacking::Linear(t) => t.width,
-            TextureBacking::Type11(t) => t.width,
+            TextureBacking::MapperRefTexture(t) => t.width,
         }
     }
     fn height(&self) -> u32 {
         match self {
             TextureBacking::Linear(t) => t.height,
-            TextureBacking::Type11(t) => t.height,
+            TextureBacking::MapperRefTexture(t) => t.height,
         }
     }
     fn depth(&self) -> u32 {
         match self {
             TextureBacking::Linear(t) => t.depth,
-            TextureBacking::Type11(_) => 1,
+            TextureBacking::MapperRefTexture(_) => 1,
         }
     }
     fn bpp(&self) -> u32 {
         match self {
             TextureBacking::Linear(t) => t.bpp,
-            TextureBacking::Type11(t) => t.bpp,
+            TextureBacking::MapperRefTexture(t) => t.bpp,
         }
     }
     /// The storage grid one [`Self::bpp`] unit covers.
     fn block(&self) -> pixel_format::BlockGeometry {
         match self {
             TextureBacking::Linear(t) => t.block,
-            // A type-11 IOSurface is never block-compressed: its resolve takes
+            // A mapper-ref-texture IOSurface is never block-compressed: its resolve takes
             // `bytes_per_pixel`, which has no answer for a compressed format, so
             // such a surface is refused as `t11_fmt_bpp` long before here.
-            TextureBacking::Type11(t) => pixel_format::BlockGeometry {
+            TextureBacking::MapperRefTexture(t) => pixel_format::BlockGeometry {
                 width: 1,
                 height: 1,
                 bytes: t.bpp,
@@ -407,11 +407,11 @@ impl TextureBacking {
     fn pixel_format(&self) -> u16 {
         match self {
             TextureBacking::Linear(t) => t.pixel_format,
-            TextureBacking::Type11(t) => t.pixel_format,
+            TextureBacking::MapperRefTexture(t) => t.pixel_format,
         }
     }
-    fn is_type11(&self) -> bool {
-        matches!(self, TextureBacking::Type11(_))
+    fn is_mapper_ref_texture(&self) -> bool {
+        matches!(self, TextureBacking::MapperRefTexture(_))
     }
 }
 
@@ -558,7 +558,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         ));
     };
 
-    // Type-8 view → base texture (unswizzled; multi-level / array / non-2D allowed).
+    // Texture-view view → base texture (unswizzled; multi-level / array / non-2D allowed).
     if entry.object_type == OBJECT_TYPE_TEXTURE_VIEW {
         let Some(bytes) = objects::read_descriptor(state, host, task_id, &entry) else {
             return Err(br(
@@ -672,9 +672,9 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
                     return Err(br(BlitStatus::Unsupported, "view_1d_height"));
                 }
             }
-            TextureBacking::Type11(_) => {
+            TextureBacking::MapperRefTexture(_) => {
                 // Metal forbids mipmapped / multi-slice IOSurface textures; see
-                // Type11Texture. Fail closed rather than inventing layout.
+                // MapperRefTexture. Fail closed rather than inventing layout.
                 if abs_level != 0 || abs_slice != 0 {
                     return Err(br(BlitStatus::Unsupported, "view_t11_level_slice"));
                 }
@@ -694,7 +694,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
                     t.bpp = pixel_format::bytes_per_pixel(eff)
                         .ok_or_else(|| br(BlitStatus::Unsupported, "view_fmt_bpp"))?;
                 }
-                TextureBacking::Type11(t) => {
+                TextureBacking::MapperRefTexture(t) => {
                     t.pixel_format = eff;
                     t.bpp = pixel_format::bytes_per_pixel(eff)
                         .ok_or_else(|| br(BlitStatus::Unsupported, "view_fmt_bpp"))?;
@@ -704,10 +704,10 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         return Ok(backing);
     }
 
-    // Type-11 IOSurface: single level, 2D, mapping page table.
+    // Mapper-ref-texture IOSurface: single level, 2D, mapping page table.
     // Non-zero level/slice is fail-closed (Metal disallows mipmapped IOSurfaces).
     // Texture object dims/format select the plane when the mapping is multi-plane.
-    if entry.object_type == OBJECT_TYPE_IOSURFACE {
+    if entry.object_type == OBJECT_TYPE_MAPPER_REF_TEXTURE {
         if level != 0 || slice != 0 {
             return Err(br(BlitStatus::Unsupported, "t11_level_slice"));
         }
@@ -734,7 +734,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
             return Err(br(BlitStatus::MissingResource, "t11_zero_geom"));
         }
         // Latch texture→mapping and refresh pages / device desc.
-        let _ = objects::resolve_type11_ref(state, host, task_id, texture_ref);
+        let _ = objects::resolve_mapper_ref_texture(state, host, task_id, texture_ref);
         let _ = mapper::ensure_resolved_for_scanout(state, host, mapping_id);
         let Some(m) = state.mappings.get(&mapping_id) else {
             return Err(br(BlitStatus::MissingResource, "t11_no_mapping"));
@@ -753,12 +753,12 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
             return Err(br(BlitStatus::Unsupported, "t11_fmt_bpp"));
         };
         let Some((surface_offset, surface_bpr, span_end)) =
-            mapping_write::type11_sample_window(m, tex_w, tex_h, format)
+            mapping_write::mapper_ref_texture_sample_window(m, tex_w, tex_h, format)
         else {
             return Err(br(BlitStatus::Bounds, "t11_sample_window"));
         };
         crate::backend::selected().note_blit_t11_resident(state, mapping_id);
-        return Ok(TextureBacking::Type11(Type11Texture {
+        return Ok(TextureBacking::MapperRefTexture(MapperRefTexture {
             mapping_id,
             width: tex_w,
             height: tex_h,
@@ -770,7 +770,7 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         }));
     }
 
-    // Type-5 RefTexture: a serialized Metal texture VIEW over an IOSurface
+    // Ref-texture RefTexture: a serialized Metal texture VIEW over an IOSurface
     // (surfaceID at +0). The compute stage path already resolves these; the
     // blit path previously dropped every one as `tex_wrong_type` (~99/six-app
     // launch, all object_type=5), so a blit COPY from a video/biplanar plane
@@ -779,10 +779,10 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
     //
     // Resolve it with the view's own geometry, format **and plane index**. The
     // plane is on the wire here (record `+0x20`) and must be used: it is the
-    // whole difference between this and type-11, whose window resolves the plane
+    // whole difference between this and mapper-ref-texture, whose window resolves the plane
     // by matching geometry and bytes-per-element and so cannot tell two planes
     // that share both apart. A biplanar COPY names exactly such a pair, so this
-    // is the path where dropping the index lands. `type5_sample_window` states
+    // is the path where dropping the index lands. `ref_texture_sample_window` states
     // the case; a plane it cannot resolve declines here rather than binding
     // whichever plane shares the geometry.
     if entry.object_type == objects::OBJECT_TYPE_REF_TEXTURE {
@@ -795,21 +795,21 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
                 crate::observe::ladder_slug!("t5", desc_read),
             ));
         };
-        let Ok(t5) = reims_vgpu_wire::device_desc::type5_header(&bytes) else {
+        let Ok(t5) = reims_vgpu_wire::device_desc::ref_texture_header(&bytes) else {
             return Err(br(BlitStatus::MissingResource, "t5_desc_short"));
         };
         let sid = t5.surface_id.get();
         if sid == 0 {
             return Err(br(BlitStatus::MissingResource, "t5_no_sid"));
         }
-        let Some(view) = objects::decode_type5_texture_view(&bytes) else {
+        let Some(view) = objects::decode_ref_texture_view(&bytes) else {
             // A short/zero-geom record fails closed — no fallback to base geom.
             // Capture why (len/tag/geom) deduped per sid so the exact blit-path
-            // type-5 layout can be decoded without flooding.
+            // ref-texture layout can be decoded without flooding.
             note_t5_decode_fail(sid, &bytes);
             return Err(br(BlitStatus::Unsupported, "t5_view_decode"));
         };
-        // Surface id IS the type-4 mapping mid (never the task object-list ref —
+        // Surface id IS the backing mapping mid (never the task object-list ref —
         // those id spaces collide). Resolve the backing, then the mapping.
         let _ = objects::ensure_surface_for_present(state, host, sid);
         let _ = mapper::ensure_resolved_for_scanout(state, host, sid);
@@ -823,13 +823,15 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         let Some(bpp) = pixel_format::bytes_per_pixel(format) else {
             return Err(br(BlitStatus::Unsupported, "t5_fmt_bpp"));
         };
-        let Some((surface_offset, surface_bpr, span_end)) = mapping_write::type5_sample_window(
-            m,
-            view.plane_index,
-            view.width,
-            view.height,
-            format,
-        ) else {
+        let Some((surface_offset, surface_bpr, span_end)) =
+            mapping_write::ref_texture_sample_window(
+                m,
+                view.plane_index,
+                view.width,
+                view.height,
+                format,
+            )
+        else {
             return Err(br(BlitStatus::Bounds, "t5_sample_window"));
         };
         // Whether this arm runs at all. Without it a change to the window this
@@ -840,13 +842,13 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         // Read on a driven x86/Vulkan boot (Safari window drag + two
         // web-content-probe runs): **0** — this arm does not execute on that
         // workload at all, while `blit_dest_bound` reads 26, so the blit path
-        // itself does run and it is the type-5 source that is absent. The
+        // itself does run and it is the ref-texture source that is absent. The
         // plane-index resolution above is therefore contract fidelity, not a
         // repair of anything this workload does, and a screen that looks the
         // same after changing it says nothing either way.
         crate::runtime::drain::note_store_route("blit_t5_plane_device");
         crate::backend::selected().note_blit_t11_resident(state, sid);
-        return Ok(TextureBacking::Type11(Type11Texture {
+        return Ok(TextureBacking::MapperRefTexture(MapperRefTexture {
             mapping_id: sid,
             width: view.width,
             height: view.height,
@@ -858,7 +860,8 @@ fn resolve_texture_backing_depth<M: HostMemory + HostOps>(
         }));
     }
 
-    if entry.object_type != OBJECT_TYPE_TEXTURE && entry.object_type != OBJECT_TYPE_TEXTURE_VARIANT
+    if entry.object_type != OBJECT_TYPE_TEXTURE
+        && entry.object_type != OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
     {
         let _ = note_tex_wrong_type(task_id, texture_ref, entry.object_type, level, slice);
         return Err(br(
@@ -1044,7 +1047,7 @@ fn read_texture_row<M: HostMemory + HostOps>(
             }
             Ok(())
         }
-        TextureBacking::Type11(t) => {
+        TextureBacking::MapperRefTexture(t) => {
             if oz != 0 {
                 return Err(br(BlitStatus::Unsupported, "rd_row_t11_z"));
             }
@@ -1085,7 +1088,7 @@ fn read_texture_row<M: HostMemory + HostOps>(
 /// destination region resolved to before its row loop started
 /// ([`texture_region_window`]).
 ///
-/// `allowed` is not consulted on the type-11 arm: that write goes through the
+/// `allowed` is not consulted on the mapper-ref-texture arm: that write goes through the
 /// mapping rail, whose authorisation is the page list the guest declared for
 /// the mapping itself. That is a different and equally explicit model, not an
 /// unbounded one.
@@ -1140,7 +1143,7 @@ fn write_texture_row<M: HostMemory + HostOps>(
             }
             Ok(())
         }
-        TextureBacking::Type11(t) => {
+        TextureBacking::MapperRefTexture(t) => {
             if oz != 0 {
                 return Err(br(BlitStatus::Unsupported, "wr_row_t11_z"));
             }
@@ -1230,7 +1233,7 @@ fn read_texture_rect<M: HostMemory + HostOps>(
             );
             Ok(())
         }
-        TextureBacking::Type11(t) => {
+        TextureBacking::MapperRefTexture(t) => {
             let (pixels, height, origin_x, origin_y) =
                 t11_rect_extent(t, origin, row_bytes, row_count)?;
             if !mapping_write::read_rect_raw_at(
@@ -1257,7 +1260,7 @@ fn read_texture_rect<M: HostMemory + HostOps>(
 /// A linear level's rectangle as the GVA rail's own shape: where it starts and
 /// how its rows are laid out.
 ///
-/// This is the linear endpoint's missing rect description. The type-11 endpoint
+/// This is the linear endpoint's missing rect description. The mapper-ref-texture endpoint
 /// has had one since it landed — [`mapping_write::write_rect_raw_at`] and
 /// friends — while the linear endpoint had only [`write_texture_row`] and
 /// [`read_texture_row`], so [`write_texture_rect`] and [`read_texture_rect`]
@@ -1312,7 +1315,7 @@ fn linear_rect(
 /// [`write_texture_row`]; see [`read_texture_rect`] for why the rect is the
 /// unit.
 ///
-/// A rect that covers a type-11 plane entirely goes through
+/// A rect that covers a mapper-ref-texture plane entirely goes through
 /// [`mapping_write::write_full_rect_raw_at`], whose fragmented arm imports each
 /// maximal packed GPA run once instead of once per row. The two calls address
 /// identical guest bytes; only the fragmented staging differs.
@@ -1351,7 +1354,7 @@ fn write_texture_rect<M: HostMemory + HostOps>(
             );
             Ok(())
         }
-        TextureBacking::Type11(t) => {
+        TextureBacking::MapperRefTexture(t) => {
             let (pixels, height, origin_x, origin_y) =
                 t11_rect_extent(t, origin, row_bytes, row_count)?;
             let src = &buf[..need as usize];
@@ -1393,11 +1396,11 @@ fn write_texture_rect<M: HostMemory + HostOps>(
     }
 }
 
-/// The mapping-rail sample window a type-11 texture backing names.
+/// The mapping-rail sample window a mapper-ref-texture backing names.
 ///
 /// Spelled once so the four rect/row call sites cannot drift on which of the
 /// four fields a copy presents.
-fn t11_window(t: &Type11Texture) -> mapping_write::SurfaceWindow {
+fn t11_window(t: &MapperRefTexture) -> mapping_write::SurfaceWindow {
     mapping_write::SurfaceWindow {
         base_off: t.surface_offset,
         bpr: t.row_stride,
@@ -1409,7 +1412,7 @@ fn t11_window(t: &Type11Texture) -> mapping_write::SurfaceWindow {
 /// Narrow a rect's texel geometry to the `u32` the mapping rail's [`mapping_write::Rect`]
 /// is expressed in, refusing by name rather than truncating.
 fn t11_rect_extent(
-    t: &Type11Texture,
+    t: &MapperRefTexture,
     origin: Point,
     row_bytes: u64,
     row_count: u64,
@@ -1434,12 +1437,12 @@ fn t11_rect_extent(
 /// Census: does the surface this blit is about to copy through its **guest
 /// pages** have live GPU-resident content instead?
 ///
-/// The sampled rail and the blit rail consume the same wire form — a type-11
-/// IOSurface, named directly or through a type-5 view — and they resolve it
+/// The sampled rail and the blit rail consume the same wire form — a mapper-ref-texture
+/// IOSurface, named directly or through a ref-texture view — and they resolve it
 /// completely differently. `draw::vulkan`'s sampled resolver runs a four-rung
 /// ladder whose top rung is `t11rung_resident`, the engine image, and a driven
 /// session puts 64-93 % of its binds there. This resolver has no ladder at all:
-/// it returns a [`Type11Texture`] over the mapping's guest pages every time, and
+/// it returns a [`MapperRefTexture`] over the mapping's guest pages every time, and
 /// the copy then reads and writes those pages on the CPU.
 ///
 /// That is only sound while the guest pages hold the surface's newest content.
@@ -1478,12 +1481,14 @@ fn note_t2t_shape(
     copy_bpp: u32,
 ) {
     use crate::runtime::drain::{note_store_route, note_store_route_n};
-    note_store_route(match (src.is_type11(), dst.is_type11()) {
-        (false, false) => "blit_t2t_linear_linear",
-        (false, true) => "blit_t2t_linear_t11",
-        (true, false) => "blit_t2t_t11_linear",
-        (true, true) => "blit_t2t_t11_t11",
-    });
+    note_store_route(
+        match (src.is_mapper_ref_texture(), dst.is_mapper_ref_texture()) {
+            (false, false) => "blit_t2t_linear_linear",
+            (false, true) => "blit_t2t_linear_t11",
+            (true, false) => "blit_t2t_t11_linear",
+            (true, true) => "blit_t2t_t11_t11",
+        },
+    );
     let bytes = copy_w
         .saturating_mul(copy_h)
         .saturating_mul(copy_d)
@@ -1507,12 +1512,11 @@ fn note_t2t_shape(
 /// never had a debt to pay and a rail that pays thousands look identical from
 /// outside, and the screen cannot tell them apart either.
 ///
-/// `gva` is the interesting one. It counts blit endpoints whose real content was
-/// sitting in an engine resident behind an armed [`crate::runtime::writeback_debt::GvaWritebackDebt`],
-/// i.e. copies that read guest pages the render never reached. `surface` is the
-/// type-11/type-4 spelling, which `mapping_write`'s own settle already covered
-/// from the other side, so a large `surface` next to a zero `gva` says this
-/// change bought nothing new.
+/// `gva` is the interesting one. It counts blit endpoints whose real content was sitting in an
+/// engine resident behind an armed [`crate::runtime::writeback_debt::GvaWritebackDebt`], i.e.
+/// copies that read guest pages the render never reached. `surface` is the
+/// mapper-ref-texture/backing spelling, which `mapping_write`'s own settle already covered from the
+/// other side, so a large `surface` next to a zero `gva` says this change bought nothing new.
 fn note_blit_endpoint_debt(state: &DeviceState, task_id: u32, texture_ref: u32) {
     if state.pending_writebacks.is_empty() {
         return;
@@ -1564,7 +1568,7 @@ pub mod vulkan;
 /// first row to last, so a level, slice or plane stride this bound does not
 /// model cannot place a row outside the set it authorises.
 ///
-/// `Ok(None)` for a type-11 texture: that write goes through the mapping rail,
+/// `Ok(None)` for a mapper-ref-texture: that write goes through the mapping rail,
 /// authorised by the page list the guest declared for the mapping. Walking a
 /// GVA span for it would bound the wrong address space.
 ///
@@ -2259,7 +2263,7 @@ fn copy_buffer_texture_rows_aspect<M: HostMemory + HostOps>(
     // kind. Same three readings, so the two halves are comparable line for line.
     {
         use crate::runtime::drain::{note_store_route, note_store_route_n};
-        note_store_route(match (to_texture, tex.is_type11()) {
+        note_store_route(match (to_texture, tex.is_mapper_ref_texture()) {
             (true, false) => "blit_b2t_linear",
             (true, true) => "blit_b2t_t11",
             (false, false) => "blit_t2b_linear",
@@ -2311,8 +2315,8 @@ fn copy_buffer_texture_rows_aspect<M: HostMemory + HostOps>(
         dest_window(state, host, task_id, buf_base_gva, span)
     };
     // The half `blit_rows_us` cannot see. That counter sits in `copy_row_region`,
-    // which only the linear-to-linear fast path reaches; every type-11 and
-    // type-5 endpoint stages through this loop instead, and each of its rows
+    // which only the linear-to-linear fast path reaches; every mapper-ref-texture and
+    // ref-texture endpoint stages through this loop instead, and each of its rows
     // re-vouches the mapping's guest page table. `mapw_pages_vouched` reads over
     // a million on a driven Maps leg and nothing timed the loop that spends them.
     let bt_rows_started = std::time::Instant::now();
@@ -2507,8 +2511,8 @@ fn exec_copy_buffer_to_texture<M: HostMemory + HostOps>(
         Err(st) => return st,
     };
     let repack = pixel_format::blit_aspect_needs_repack(dst.pixel_format(), aspect);
-    // Type-11 is 2D only.
-    if dst.is_type11() && (cmd.destination_origin.z != 0 || cmd.source_size.depth > 1) {
+    // Mapper-ref-texture is 2D only.
+    if dst.is_mapper_ref_texture() && (cmd.destination_origin.z != 0 || cmd.source_size.depth > 1) {
         if cmd.source_size.depth == 0 {
             return BlitStatus::ZeroExtent;
         }
@@ -2652,7 +2656,7 @@ fn exec_copy_buffer_to_texture<M: HostMemory + HostOps>(
             Err(st) => st,
         };
     }
-    // Type-11 destination: row-stage from buffer GVA.
+    // Mapper-ref-texture destination: row-stage from buffer GVA.
     let src_span = match cmd
         .source_offset
         .checked_add((copy_d - 1).saturating_mul(src_bpi))
@@ -2665,7 +2669,7 @@ fn exec_copy_buffer_to_texture<M: HostMemory + HostOps>(
     if src_span > src.size {
         return br(BlitStatus::Bounds, "b2t_t11_src_span_oob");
     }
-    // `None` for the type-11 destination this arm is for, which the mapping rail
+    // `None` for the mapper-ref-texture destination this arm is for, which the mapping rail
     // authorises instead; a linear destination reaching here is still bounded.
     let allowed = match texture_region_window(
         state,
@@ -2766,7 +2770,7 @@ fn exec_copy_texture_to_buffer<M: HostMemory + HostOps>(
         Ok(b) => b,
         Err(st) => return st,
     };
-    if src.is_type11() && (cmd.source_origin.z != 0 || cmd.source_size.depth > 1) {
+    if src.is_mapper_ref_texture() && (cmd.source_origin.z != 0 || cmd.source_size.depth > 1) {
         if cmd.source_size.depth == 0 {
             return BlitStatus::ZeroExtent;
         }
@@ -2923,7 +2927,7 @@ fn exec_copy_texture_to_buffer<M: HostMemory + HostOps>(
     );
     // `blit_rows_us` lives in `copy_row_region`, which only the linear-to-linear
     // fast path reaches. A texture-to-buffer copy stages every row through
-    // `read_texture_row` instead, and for a type-11 or type-5 source that
+    // `read_texture_row` instead, and for a mapper-ref-texture or ref-texture source that
     // re-vouches the mapping's guest page table per row.
     let stage_rows_started = std::time::Instant::now();
     let mut row = vec![0u8; row_bytes as usize];
@@ -3029,7 +3033,7 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
     let copy_bpp = src_bpp;
     let repack_src = pixel_format::blit_aspect_needs_repack(src.pixel_format(), aspect);
     let repack_dst = pixel_format::blit_aspect_needs_repack(dst.pixel_format(), aspect);
-    let any_t11 = src.is_type11() || dst.is_type11();
+    let any_t11 = src.is_mapper_ref_texture() || dst.is_mapper_ref_texture();
     if any_t11 && (cmd.source_origin.z != 0 || cmd.destination_origin.z != 0) {
         return br(BlitStatus::Unsupported, "t2t_t11_z");
     }
@@ -3510,7 +3514,7 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
             Err(st) => st,
         };
     }
-    // Mixed or type-11↔type-11: stage rows.
+    // Mixed or mapper-ref-texture↔mapper-ref-texture: stage rows.
     let allowed = match texture_region_window(
         state,
         host,
@@ -3530,7 +3534,7 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
         Err(st) => return st,
     };
     // The last untimed loop on the rail: a texture-to-texture copy with a
-    // type-11 or type-5 end on either side stages through here rather than
+    // mapper-ref-texture or ref-texture end on either side stages through here rather than
     // through `copy_row_region`, so `blit_rows_us` reports nothing for it.
     //
     // A plane at a time, not a row at a time: this is the same staging shape the
@@ -3540,13 +3544,13 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
     // Whether a GPU-side copy serves this pair, and if not, which term stops it.
     // `engine::copy_target_to_guest_pages` takes no source rectangle: it copies
     // level 0 of the resident whole, at origin zero, into a destination whose
-    // geometry is the resident's own. So a type-11 source going to a linear
+    // geometry is the resident's own. So a mapper-ref-texture source going to a linear
     // destination is reachable only when both ends are the whole plane at the
     // origin, and the three counters partition the population so a reading says
     // how much of it that is. See [`try_copy_t11_plane_to_linear_on_gpu`] for
     // what the arm below is instead of, which is the settle the staging loop
     // pays to make the source's guest bytes readable.
-    if src.is_type11() && !dst.is_type11() {
+    if src.is_mapper_ref_texture() && !dst.is_mapper_ref_texture() {
         let whole_src =
             sox == 0 && soy == 0 && copy_w == src.width() as u64 && copy_h == src.height() as u64;
         let whole_dst =
@@ -3557,7 +3561,7 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
             (false, _) => "blit_t2t_t11_src_partial",
         });
         if whole_src && whole_dst {
-            if let (TextureBacking::Type11(s), TextureBacking::Linear(d)) = (&src, &dst) {
+            if let (TextureBacking::MapperRefTexture(s), TextureBacking::Linear(d)) = (&src, &dst) {
                 if let Some(status) = crate::backend::selected()
                     .try_copy_t11_plane_to_linear_on_gpu(
                         state,
@@ -3625,7 +3629,7 @@ fn exec_copy_texture_to_texture<M: HostMemory + HostOps>(
 ///   array slices (`origin (0,0,0)`, size `w×h×1`).
 /// - **depth > 1 (3D volume):** Metal requires `sliceCount == 1` and source/
 ///   destination slices 0; copies full `width×height×depth` of that mip with
-///   depth planes strided by `bytes_per_image`. Linear type-2/3 only.
+///   depth planes strided by `bytes_per_image`. Linear normal-texture only.
 ///
 /// One resolved blit endpoint, reduced to what the GPU whole-plane arm reads.
 ///
@@ -3691,11 +3695,11 @@ enum GpuPlaneRefusal {
     SrcNotResident,
     /// The destination is a linear guest allocation, which has no mapping for a
     /// GPU-side copy to name.
-    DstNotType11,
+    DstNotMapperRefTexture,
     /// The destination mapping declines a resident-to-guest-pages copy at this
     /// extent, so there is no window to write.
     DstWindowUnresolved,
-    /// The two derivations of the destination plane disagree. A type-5 view's
+    /// The two derivations of the destination plane disagree. A ref-texture view's
     /// wire plane index lands here: it can name a plane the mapping's own
     /// geometry scan does not resolve to, and the GPU rail takes no index.
     PlaneOffset,
@@ -3714,7 +3718,7 @@ impl GpuPlaneRefusal {
             Self::MultiLevel => "sl_gpu_multi_level",
             Self::SelfCopy => "sl_gpu_self_copy",
             Self::SrcNotResident => "sl_gpu_src_not_resident",
-            Self::DstNotType11 => "sl_gpu_dst_not_t11",
+            Self::DstNotMapperRefTexture => "sl_gpu_dst_not_t11",
             Self::DstWindowUnresolved => "sl_gpu_dst_window",
             Self::PlaneOffset => "sl_gpu_plane_offset",
             Self::GeometryDiffers => "sl_gpu_geometry_differs",
@@ -3761,7 +3765,7 @@ fn gpu_whole_plane_destination(
     src: GpuResidentSource,
 ) -> Result<(), GpuPlaneRefusal> {
     let Some(dst) = dst else {
-        return Err(GpuPlaneRefusal::DstNotType11);
+        return Err(GpuPlaneRefusal::DstNotMapperRefTexture);
     };
     let Some(window) = window else {
         return Err(GpuPlaneRefusal::DstWindowUnresolved);
@@ -3916,8 +3920,8 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             if cmd.slice_count != 1 || cmd.source_slice != 0 || cmd.destination_slice != 0 {
                 return br(BlitStatus::Unsupported, "sl_volume_slice_constraint");
             }
-            // Type-11 is 2D (depth 1); volume endpoints are linear only.
-            if src0.is_type11() || dst0.is_type11() {
+            // Mapper-ref-texture is 2D (depth 1); volume endpoints are linear only.
+            if src0.is_mapper_ref_texture() || dst0.is_mapper_ref_texture() {
                 return br(BlitStatus::Unsupported, "sl_volume_t11");
             }
         } else if cmd.slice_count > 1 {
@@ -4028,11 +4032,12 @@ fn exec_copy_texture_to_texture_slice_level<M: HostMemory + HostOps>(
             continue;
         }
 
-        // Type-11 / mixed: depth-1 only (type-11 is 2D); per-slice whole-surface.
+        // Mapper-ref-texture / mixed: depth-1 only (mapper-ref-texture is 2D); per-slice
+        // whole-surface.
         if is_volume {
             return br(BlitStatus::Unsupported, "sl_volume_mixed");
         }
-        // The slice/level form's type-11 arm. It used to stage one row at a
+        // The slice/level form's mapper-ref-texture arm. It used to stage one row at a
         // time, and a driven Maps leg charged that loop 30.15 s of a 30.28 s
         // blit rail to move 14.6 MB, against 0.12 s for the resolves beside it
         // and 0.22 s for every strided guest-RAM copy in the device. The bytes
@@ -4156,7 +4161,7 @@ pub(crate) fn blit_status_from_fence(status: FenceStatus) -> BlitStatus {
 /// that other modules own or that are protocol no-ops (caller should not count
 /// those as copy/fill failures). Fences use [`execute_blit_fence`].
 ///
-/// Nothing follows a successful copy. A blit into a type-11 destination writes
+/// Nothing follows a successful copy. A blit into a mapper-ref-texture destination writes
 /// the guest pages directly and no GPU object caches those bytes, so the
 /// content is coherent by construction and there is nothing to invalidate.
 /// Each arm resolved its own destination in order to write it, so a second

--- a/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/tests.rs
@@ -89,7 +89,7 @@ fn copy_cmd(copy_kind: CopyKind, source: u32, destination: u32) -> Command {
 }
 
 /// Back `mapping_id` with one guest data page at `pfn` and mark it mapped.
-/// This is the surface state every type-11 / type-5 install needs before it
+/// This is the surface state every mapper-ref-texture / ref-texture install needs before it
 /// can attach geometry or a descriptor.
 fn map_one_page_surface(host: &mut FakeHost, state: &mut DeviceState, mapping_id: u32, pfn: u32) {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
@@ -118,7 +118,7 @@ fn write_list_entry(
     write_task_gva_arm64e(host, &state.tasks[1], off, &entry);
 }
 
-/// Install type-1 buffer: object-list at GVA 0, descriptor at GVA 0x100 + ref*0x20.
+/// Install buffer: object-list at GVA 0, descriptor at GVA 0x100 + ref*0x20.
 fn install_buffer(
     host: &mut FakeHost,
     state: &mut DeviceState,
@@ -513,7 +513,7 @@ fn copy_b2b_overlap_rejected() {
 }
 
 #[test]
-fn copy_buffer_to_type11_roundtrip() {
+fn copy_buffer_to_mapper_ref_texture_roundtrip() {
     let (mut host, mut state) = blit_device();
     // Buffer with 8 BGRA pixels (one row of 2 pixels for a 2x1 copy).
     install_buffer(&mut host, &mut state, 1, 1, 256);
@@ -521,9 +521,9 @@ fn copy_buffer_to_type11_roundtrip() {
     let src_gva = 1u64 << RESOURCE_PAGE_SHIFT;
     write_task_gva_arm64e(&mut host, &state.tasks[1], src_gva, &pat);
 
-    // Type-11 object ref 3 → mapping 9, 2x2 BGRA.
+    // Mapper-ref-texture object ref 3 → mapping 9, 2x2 BGRA.
     let mapping_id = 9u32;
-    install_type11(&mut host, &mut state, 3, mapping_id, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 3, mapping_id, 0x20);
 
     let mut cmd = copy_cmd(CopyKind::BufferToTexture, 1, 3);
     cmd.source_offset = 0;
@@ -558,12 +558,12 @@ fn copy_buffer_to_type11_roundtrip() {
     assert!(state.mappings[&mapping_id].content_generation > gen_before);
 }
 
-/// type-11→type-11 copy lands source bytes in dest pages (unified content).
+/// mapper-ref-texture→mapper-ref-texture copy lands source bytes in dest pages (unified content).
 #[test]
-fn copy_type11_to_type11_writes_dst_pages() {
+fn copy_mapper_ref_texture_to_mapper_ref_texture_writes_dst_pages() {
     let (mut host, mut state) = blit_device();
-    install_type11(&mut host, &mut state, 3, 3, 0x20);
-    install_type11(&mut host, &mut state, 4, 4, 0x21);
+    install_mapper_ref_texture(&mut host, &mut state, 3, 3, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 4, 4, 0x21);
     // Seed source mid=3 pages with a known pattern.
     let src_pat = [9u8, 8, 7, 6, 5, 4, 3, 2, 1, 0, 11, 12, 13, 14, 15, 16];
     assert!(mapping_write::write_rect_raw(
@@ -617,8 +617,8 @@ fn copy_type11_to_type11_writes_dst_pages() {
 #[test]
 fn an_extent_past_the_edge_is_refused_like_an_origin_past_the_edge() {
     let (mut host, mut state) = blit_device();
-    install_type11(&mut host, &mut state, 3, 3, 0x20); // 2×2 BGRA, mid 3
-    install_type11(&mut host, &mut state, 4, 4, 0x21); // 2×2 BGRA, mid 4
+    install_mapper_ref_texture(&mut host, &mut state, 3, 3, 0x20); // 2×2 BGRA, mid 3
+    install_mapper_ref_texture(&mut host, &mut state, 4, 4, 0x21); // 2×2 BGRA, mid 4
     install_buffer(&mut host, &mut state, 5, 5, 4096);
 
     // Origin in range, extent past the edge: 3 wide out of a 2-wide texture.
@@ -673,8 +673,8 @@ fn an_extent_past_the_edge_is_refused_like_an_origin_past_the_edge() {
 #[test]
 fn copy_executor_reason_slugs_name_distinct_sites() {
     let (mut host, mut state) = blit_device();
-    install_type11(&mut host, &mut state, 3, 3, 0x20); // 2×2 BGRA, mid 3
-    install_type11(&mut host, &mut state, 4, 4, 0x21); // 2×2 BGRA, mid 4
+    install_mapper_ref_texture(&mut host, &mut state, 3, 3, 0x20); // 2×2 BGRA, mid 3
+    install_mapper_ref_texture(&mut host, &mut state, 4, 4, 0x21); // 2×2 BGRA, mid 4
     install_buffer(&mut host, &mut state, 5, 5, 4096);
 
     // texture→texture: destination origin past a 2×2 target → Bounds.
@@ -691,8 +691,8 @@ fn copy_executor_reason_slugs_name_distinct_sites() {
     );
     assert_eq!(blit_fail_reason(), "t2t_origin_oob");
 
-    // texture→texture: a type-11 endpoint with a non-zero z origin (type-11 is
-    // 2D) → Unsupported, a DIFFERENT reason under the same executor.
+    // texture→texture: a mapper-ref-texture endpoint with a non-zero z origin (mapper-ref-texture
+    // is 2D) → Unsupported, a DIFFERENT reason under the same executor.
     let mut cmd = copy_cmd(CopyKind::TextureToTexture, 3, 4);
     cmd.source_origin.z = 1;
     cmd.source_size = Size {
@@ -734,8 +734,8 @@ fn copy_executor_reason_slugs_name_distinct_sites() {
     );
     assert_eq!(blit_fail_reason(), "b2t_origin_oob");
 
-    // A full-target valid type-11→type-11 copy succeeds and resets the channel,
-    // so no stale slug leaks into the next command's dispatch line.
+    // A full-target valid mapper-ref-texture→mapper-ref-texture copy succeeds and resets the
+    // channel, so no stale slug leaks into the next command's dispatch line.
     let mut cmd = copy_cmd(CopyKind::TextureToTexture, 3, 4);
     cmd.source_size = Size {
         width: 2,
@@ -746,8 +746,8 @@ fn copy_executor_reason_slugs_name_distinct_sites() {
     assert_eq!(blit_fail_reason(), "");
 }
 
-/// Install type-11 object-list entry + mapping pages (2×2 BGRA).
-fn install_type11(
+/// Install mapper-ref-texture object-list entry + mapping pages (2×2 BGRA).
+fn install_mapper_ref_texture(
     host: &mut FakeHost,
     state: &mut DeviceState,
     obj_ref: u32,
@@ -756,7 +756,7 @@ fn install_type11(
 ) {
     map_one_page_surface(host, state, mapping_id, pfn);
     assert!(state.set_mapping_geom(mapping_id, 2, 2, MTL_FORMAT_BGRA8_UNORM));
-    install_type11_plane(
+    install_mapper_ref_texture_plane(
         host,
         state,
         obj_ref,
@@ -800,7 +800,7 @@ fn install_biplanar_mapping(
     // Surface-level geom is not the plane; leave has_geom false until texture latch.
 }
 
-fn install_type11_plane(
+fn install_mapper_ref_texture_plane(
     host: &mut FakeHost,
     state: &mut DeviceState,
     obj_ref: u32,
@@ -809,7 +809,7 @@ fn install_type11_plane(
     width: u32,
     height: u32,
 ) {
-    use crate::runtime::decode::resource::OBJECT_TYPE_IOSURFACE;
+    use crate::runtime::decode::resource::OBJECT_TYPE_MAPPER_REF_TEXTURE;
     // iosurface desc layout: surfaceID @0, format @0x16, width @0x18, height @0x1c.
     const DESC_LEN: usize = 0x20;
     assert!(state.set_object_list(1, 0, 16));
@@ -824,18 +824,18 @@ fn install_type11_plane(
         host,
         state,
         obj_ref,
-        OBJECT_TYPE_IOSURFACE as u32,
+        OBJECT_TYPE_MAPPER_REF_TEXTURE as u32,
         DESC_LEN as u32,
         desc_gva,
     );
 }
 
-/// Install a type-5 RefTexture (object_type=5) that names an IOSurface
+/// Install a ref-texture RefTexture (object_type=5) that names an IOSurface
 /// mapping via `surfaceID@+0` and a serialized 0x62 color-view record
 /// (fmt@+0x16, w@+0x18, h@+0x1c, depth@+0x20, plane@+0x34 — the live blit-
-/// source layout from `decode_type5_texture_view_live_0x62_color_window_view`).
+/// source layout from `decode_ref_texture_view_live_0x62_color_window_view`).
 /// Also installs a single-page mapping at `mapping_id` so the resolve lands.
-fn install_type5(
+fn install_ref_texture(
     host: &mut FakeHost,
     state: &mut DeviceState,
     obj_ref: u32,
@@ -848,9 +848,9 @@ fn install_type5(
     // Mapping (surfaceID == mapping_id): mapped, one data page, latched geom.
     map_one_page_surface(host, state, mapping_id, pfn);
     assert!(state.set_mapping_geom(mapping_id, width, height, format));
-    // Type-5 descriptor: 56-byte blob, 0x62 color-view record.
+    // Ref-texture descriptor: 56-byte blob, 0x62 color-view record.
     assert!(state.set_object_list(1, 0, 16));
-    let built = reims_vgpu_wire::device_desc::Type5Builder::new(
+    let built = reims_vgpu_wire::device_desc::RefTextureBuilder::new(
         mapping_id,
         0,
         obj_ref,
@@ -870,14 +870,14 @@ fn install_type5(
         desc_len as u32,
         desc_gva,
     );
-    let e = objects::lookup_list_entry(state, host, 1, obj_ref).expect("type5 entry");
+    let e = objects::lookup_list_entry(state, host, 1, obj_ref).expect("ref_texture entry");
     assert_eq!(e.object_type, objects::OBJECT_TYPE_REF_TEXTURE);
 }
 
 /// A blit source must read the plane the wire named, and the only shape that
 /// can prove it is two planes that share geometry and bytes-per-element.
 ///
-/// This branch resolved type-5 views through `type11_sample_window`, which
+/// This branch resolved ref-texture views through `mapper_ref_texture_sample_window`, which
 /// takes no plane index and picks a plane by matching width, height and bpe.
 /// On the v0a8 shape the live apple.com hero produces — Y and alpha both R8
 /// at the luma geometry — that scan matches *two* records, takes neither, and
@@ -889,7 +889,7 @@ fn install_type5(
 /// identical in geometry to plane 0 and differs only in offset, so an
 /// assertion on the offset is exactly the assertion that the index was used.
 #[test]
-fn a_type5_blit_source_reads_the_plane_the_wire_named() {
+fn a_ref_texture_blit_source_reads_the_plane_the_wire_named() {
     use crate::contract::endian::st64;
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_ALLOC_SIZE, DEVICE_DESC_LEN, DEVICE_DESC_PLANES, DEVICE_DESC_PLANE_COUNT,
@@ -906,7 +906,7 @@ fn a_type5_blit_source_reads_the_plane_the_wire_named() {
     let (w, h) = (8u32, 4u32);
     // Plane 2 is the alpha plane: same 8x4 R8 as plane 0, different offset.
     const ALPHA_OFFSET: u32 = 128;
-    install_type5(
+    install_ref_texture(
         &mut host,
         &mut state,
         obj_ref,
@@ -916,7 +916,7 @@ fn a_type5_blit_source_reads_the_plane_the_wire_named() {
         w,
         h,
     );
-    set_type5_record_plane(&mut host, &state, obj_ref, 2);
+    set_ref_texture_record_plane(&mut host, &state, obj_ref, 2);
 
     let mut desc = vec![0u8; DEVICE_DESC_LEN];
     st32(&mut desc[DEVICE_DESC_ALLOC_SIZE..], 0x1000);
@@ -948,7 +948,7 @@ fn a_type5_blit_source_reads_the_plane_the_wire_named() {
     // it resolves nothing at all, which is what this test exists to exclude.
     let ambiguous = {
         let m = state.mappings.get(&mapping_id).unwrap();
-        mapping_write::type11_sample_window(m, w, h, MTL_FORMAT_R8_UNORM)
+        mapping_write::mapper_ref_texture_sample_window(m, w, h, MTL_FORMAT_R8_UNORM)
     };
     assert!(
         ambiguous.is_none(),
@@ -958,59 +958,64 @@ fn a_type5_blit_source_reads_the_plane_the_wire_named() {
     // planes 0 and 2 specifically and not a descriptor that resolves nothing.
     let uv = {
         let m = state.mappings.get(&mapping_id).unwrap();
-        mapping_write::type5_sample_window(m, 1, 4, 2, MTL_FORMAT_RG8_UNORM)
+        mapping_write::ref_texture_sample_window(m, 1, 4, 2, MTL_FORMAT_RG8_UNORM)
     };
     assert_eq!(uv.map(|(off, _, _)| off), Some(64));
 
     let backing = resolve_texture_backing(&mut state, &mut host, 1, obj_ref, 0, 0)
-        .expect("type-5 blit source must resolve");
+        .expect("ref-texture blit source must resolve");
     match backing {
-        TextureBacking::Type11(t) => assert_eq!(
+        TextureBacking::MapperRefTexture(t) => assert_eq!(
             t.surface_offset, ALPHA_OFFSET as u64,
             "the wire named plane 2, and only the wire index can reach it"
         ),
-        TextureBacking::Linear(_) => panic!("expected Type11 backing, got Linear"),
+        TextureBacking::Linear(_) => panic!("expected MapperRefTexture backing, got Linear"),
     }
 }
 
-/// Overwrite the plane index in an installed type-5 record.
+/// Overwrite the plane index in an installed ref-texture record.
 ///
-/// `install_type5` leaves it 0 (the field sits past the fields it writes and
+/// `install_ref_texture` leaves it 0 (the field sits past the fields it writes and
 /// the blob is zeroed), which is the one value that cannot distinguish a
 /// used index from a dropped one.
-fn set_type5_record_plane(host: &mut FakeHost, state: &DeviceState, obj_ref: u32, plane: u32) {
+fn set_ref_texture_record_plane(
+    host: &mut FakeHost,
+    state: &DeviceState,
+    obj_ref: u32,
+    plane: u32,
+) {
     let off = objects::TYPE5_ARG_RECORD + objects::TYPE5_RECORD_PLANE;
     let desc_gva = 0x180u64 + (obj_ref as u64) * 0x40;
     let mut word = [0u8; 4];
     st32(&mut word, plane);
     write_task_gva_arm64e(host, &state.tasks[1], desc_gva + off as u64, &word);
-    let entry = objects::lookup_list_entry(state, host, 1, obj_ref).expect("type5 entry");
-    let desc = objects::read_descriptor(state, host, 1, &entry).expect("type5 desc");
+    let entry = objects::lookup_list_entry(state, host, 1, obj_ref).expect("ref_texture entry");
+    let desc = objects::read_descriptor(state, host, 1, &entry).expect("ref_texture desc");
     assert_eq!(
-        objects::decode_type5_texture_view(&desc)
+        objects::decode_ref_texture_view(&desc)
             .expect("view")
             .plane_index,
         plane
     );
 }
 
-/// Regression guard for the type-5 RefTexture blit-source branch
-/// (`resolve_texture_backing_depth` ~588): a type-5 object whose 0x62 record
-/// names a BGRA8 view must resolve to a `Type11` backing carrying the VIEW
+/// Regression guard for the ref-texture RefTexture blit-source branch
+/// (`resolve_texture_backing_depth` ~588): a ref-texture object whose 0x62 record
+/// names a BGRA8 view must resolve to a `MapperRefTexture` backing carrying the VIEW
 /// geometry/format (not the base mapping's), so a blit copy from a media /
-/// window backing lands. Mirrors the type-11 install fixtures.
+/// window backing lands. Mirrors the mapper-ref-texture install fixtures.
 #[test]
-fn type5_ref_texture_resolves_as_type11_blit_backing() {
+fn ref_texture_resolves_as_mapper_ref_texture_blit_backing() {
     use crate::contract::pixel_format::bytes_per_pixel;
     let (mut host, mut state) = blit_device();
     let mapping_id = 34u32;
     let obj_ref = 12u32;
     let (w, h, fmt) = (2u32, 2u32, MTL_FORMAT_BGRA8_UNORM);
-    install_type5(&mut host, &mut state, obj_ref, mapping_id, 0x30, fmt, w, h);
+    install_ref_texture(&mut host, &mut state, obj_ref, mapping_id, 0x30, fmt, w, h);
     let backing = resolve_texture_backing(&mut state, &mut host, 1, obj_ref, 0, 0)
-        .expect("type-5 blit source must resolve");
+        .expect("ref-texture blit source must resolve");
     match backing {
-        TextureBacking::Type11(t) => {
+        TextureBacking::MapperRefTexture(t) => {
             assert_eq!(t.mapping_id, mapping_id, "backs the named surface");
             assert_eq!((t.width, t.height), (w, h), "view geometry, not base");
             assert_eq!(t.pixel_format, fmt);
@@ -1018,17 +1023,17 @@ fn type5_ref_texture_resolves_as_type11_blit_backing() {
             assert!(u64::from(t.row_stride) >= u64::from(w) * u64::from(t.bpp));
             assert!(t.span_end >= u64::from(t.row_stride) * u64::from(h));
         }
-        TextureBacking::Linear(_) => panic!("expected Type11 backing, got Linear"),
+        TextureBacking::Linear(_) => panic!("expected MapperRefTexture backing, got Linear"),
     }
 }
 
-/// A type-5 record whose tag is neither 0x42 nor 0x62 is unknown wire → the
+/// A ref-texture record whose tag is neither 0x42 nor 0x62 is unknown wire → the
 /// blit branch must fail closed (`t5_view_decode`), never invent geometry.
 #[test]
-fn type5_unknown_record_tag_fails_closed() {
+fn ref_texture_unknown_record_tag_fails_closed() {
     let (mut host, mut state) = blit_device();
     let (mapping_id, obj_ref) = (34u32, 12u32);
-    install_type5(
+    install_ref_texture(
         &mut host,
         &mut state,
         obj_ref,
@@ -1049,18 +1054,18 @@ fn type5_unknown_record_tag_fails_closed() {
     );
     match resolve_texture_backing(&mut state, &mut host, 1, obj_ref, 0, 0) {
         Err(st) => assert_eq!(st, BlitStatus::Unsupported),
-        Ok(_) => panic!("unknown type-5 record tag must fail closed"),
+        Ok(_) => panic!("unknown ref-texture record tag must fail closed"),
     }
 }
 
 #[test]
-fn biplanar_type11_y_and_uv_planes_distinct() {
+fn biplanar_mapper_ref_texture_y_and_uv_planes_distinct() {
     use crate::contract::pixel_format::{MTL_FORMAT_R8_UNORM, MTL_FORMAT_RG8_UNORM};
     let (mut host, mut state) = blit_device();
     let mapping_id = 7u32;
     install_biplanar_mapping(&mut host, &mut state, mapping_id, 0x30);
     // Y plane texture ref 10, UV plane texture ref 11 — same mapping_id.
-    install_type11_plane(
+    install_mapper_ref_texture_plane(
         &mut host,
         &mut state,
         10,
@@ -1069,7 +1074,7 @@ fn biplanar_type11_y_and_uv_planes_distinct() {
         4,
         2,
     );
-    install_type11_plane(
+    install_mapper_ref_texture_plane(
         &mut host,
         &mut state,
         11,
@@ -1214,7 +1219,7 @@ fn biplanar_type11_y_and_uv_planes_distinct() {
     assert_eq!(row0, y_pat[0..4]);
 }
 
-fn install_type8_view(
+fn install_texture_view(
     host: &mut FakeHost,
     state: &mut DeviceState,
     view_ref: u32,
@@ -1265,17 +1270,17 @@ fn install_type8_view(
 }
 
 #[test]
-fn copy_buffer_to_type8_view_of_type11() {
+fn copy_buffer_to_texture_view_view_of_mapper_ref_texture() {
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 256);
     let mapping_id = 9u32;
-    install_type11(&mut host, &mut state, 3, mapping_id, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 3, mapping_id, 0x20);
     // View ref 8 → base 3, level 0, BGRA identity.
-    install_type8_view(&mut host, &mut state, 8, 3, MTL_FORMAT_BGRA8_UNORM, 0, None);
+    install_texture_view(&mut host, &mut state, 8, 3, MTL_FORMAT_BGRA8_UNORM, 0, None);
     let pat = [0xaau8, 0xbb, 0xcc, 0xdd, 0x11, 0x22, 0x33, 0x44];
     let src_gva = 1u64 << RESOURCE_PAGE_SHIFT;
     write_task_gva_arm64e(&mut host, &state.tasks[1], src_gva, &pat);
-    let mut cmd = copy_cmd(CopyKind::BufferToTexture, 1, 8); // type-8 view
+    let mut cmd = copy_cmd(CopyKind::BufferToTexture, 1, 8); // texture-view
     cmd.source_offset = 0;
     cmd.source_bytes_per_row = 8;
     cmd.source_size = Size {
@@ -1303,12 +1308,12 @@ fn copy_buffer_to_type8_view_of_type11() {
 }
 
 #[test]
-fn type8_swizzled_view_rejected_for_blit() {
+fn texture_view_swizzled_view_rejected_for_blit() {
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 256);
-    install_type11(&mut host, &mut state, 3, 9, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 3, 9, 0x20);
     // Non-identity swizzle BGRA order selectors.
-    install_type8_view(
+    install_texture_view(
         &mut host,
         &mut state,
         8,
@@ -1331,12 +1336,12 @@ fn type8_swizzled_view_rejected_for_blit() {
 }
 
 #[test]
-fn type8_level_base_on_type11_rejected() {
+fn texture_view_level_base_on_mapper_ref_texture_rejected() {
     // Metal forbids mipmapped IOSurfaces; view level_base=1 fail-closes.
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 256);
-    install_type11(&mut host, &mut state, 3, 9, 0x20);
-    install_type8_view(
+    install_mapper_ref_texture(&mut host, &mut state, 3, 9, 0x20);
+    install_texture_view(
         &mut host,
         &mut state,
         8,
@@ -1712,7 +1717,7 @@ fn derived_slice_stride_2d() {
     );
 }
 
-/// Multi-mip linear texture + multi-level type-8 view selecting L1.
+/// Multi-mip linear texture + multi-level texture-view selecting L1.
 #[test]
 fn copy_buffer_to_multilevel_view_l1() {
     use crate::runtime::decode::resource::{
@@ -1726,7 +1731,7 @@ fn copy_buffer_to_multilevel_view_l1() {
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 512);
 
-    // Type-2 texture handle=2, 2 mips: L0 4x2, L1 2x1, RGBA8 (bpp=4).
+    // Texture texture handle=2, 2 mips: L0 4x2, L1 2x1, RGBA8 (bpp=4).
     let handle = 2u32;
     let levels = 2u32;
     let body = TEXTURE_DESC_BASE_LEN + TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
@@ -1758,7 +1763,7 @@ fn copy_buffer_to_multilevel_view_l1() {
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
     // View: level_base=0, level_count=2 over texture ref 4.
-    install_type8_view(&mut host, &mut state, 8, 4, MTL_FORMAT_RGBA8_UNORM, 0, None);
+    install_texture_view(&mut host, &mut state, 8, 4, MTL_FORMAT_RGBA8_UNORM, 0, None);
     // Patch level_count to 2 on the installed view.
     {
         use crate::runtime::decode::resource::{
@@ -1809,9 +1814,9 @@ fn copy_buffer_to_multilevel_view_l1() {
 fn multilevel_view_relative_level_oob() {
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 64);
-    install_type11(&mut host, &mut state, 3, 9, 0x20);
-    // View over type-11 with level_count=1, level_base=0; command level 1 is OOB.
-    install_type8_view(&mut host, &mut state, 8, 3, MTL_FORMAT_BGRA8_UNORM, 0, None);
+    install_mapper_ref_texture(&mut host, &mut state, 3, 9, 0x20);
+    // View over mapper-ref-texture with level_count=1, level_base=0; command level 1 is OOB.
+    install_texture_view(&mut host, &mut state, 8, 3, MTL_FORMAT_BGRA8_UNORM, 0, None);
     let mut cmd = copy_cmd(CopyKind::BufferToTexture, 1, 8);
     cmd.destination_level = 1; // relative 1 >= count 1
     cmd.source_size = Size {
@@ -1890,7 +1895,7 @@ fn slice_level_zero_counts_are_noop() {
     );
 }
 
-/// Install a simple type-2 RGBA8 texture (single level, handle → GVA).
+/// Install a simple texture RGBA8 texture (single level, handle → GVA).
 fn install_linear_rgba(
     host: &mut FakeHost,
     state: &mut DeviceState,
@@ -2035,7 +2040,9 @@ fn a_last_array_slice_is_not_charged_for_its_trailing_row_padding() {
             assert!(t.texel_offset(3, 1, 0).unwrap() + 4 <= EXACT);
             t.slice_stride
         }
-        TextureBacking::Type11(_) => panic!("linear texture resolved as type-11"),
+        TextureBacking::MapperRefTexture(_) => {
+            panic!("linear texture resolved as mapper-ref-texture")
+        }
     };
 
     // The bound this replaced charged a second whole stride and refused this
@@ -2090,7 +2097,7 @@ fn whole_surface_0x13e_single_level_copy() {
     assert_eq!(&back[16..32], &pat[16..32]);
 }
 
-/// A type-11 whole-surface `0x13e` moves every row, in order.
+/// A mapper-ref-texture whole-surface `0x13e` moves every row, in order.
 ///
 /// This arm stages the slice whole rather than a row at a time, because a
 /// per-row call into the mapping rail re-pays that rail's per-*rect* costs —
@@ -2106,10 +2113,10 @@ fn whole_surface_0x13e_single_level_copy() {
 /// buffer entire — a whole-buffer compare of a uniform fill would pass on a
 /// copy that wrote row 0 twice.
 #[test]
-fn a_type11_whole_surface_copy_lands_every_row_in_order() {
+fn a_mapper_ref_texture_whole_surface_copy_lands_every_row_in_order() {
     let (mut host, mut state) = blit_device();
-    install_type11(&mut host, &mut state, 2, 20, 0x40);
-    install_type11(&mut host, &mut state, 3, 21, 0x50);
+    install_mapper_ref_texture(&mut host, &mut state, 2, 20, 0x40);
+    install_mapper_ref_texture(&mut host, &mut state, 3, 21, 0x50);
 
     // 2×2 BGRA: two rows of 8 bytes, each row its own byte value.
     let src_pixels: [u8; 16] = [
@@ -2136,7 +2143,7 @@ fn a_type11_whole_surface_copy_lands_every_row_in_order() {
     assert_eq!(
         execute_blit(&mut state, &mut host, 1, &cmd),
         BlitStatus::Ok,
-        "a type-11 to type-11 whole-surface copy must execute"
+        "a mapper-ref-texture to mapper-ref-texture whole-surface copy must execute"
     );
 
     let mut back = [0u8; 16];
@@ -2389,7 +2396,7 @@ fn whole_surface_0x13e_two_levels() {
     let _ = RESOURCE_PAGE_SHIFT;
 }
 
-/// Install type-2 RGBA8 volume (single level, depth>1) at `handle<<14`.
+/// Install texture RGBA8 volume (single level, depth>1) at `handle<<14`.
 fn install_linear_rgba_volume(
     host: &mut FakeHost,
     state: &mut DeviceState,
@@ -2487,7 +2494,9 @@ fn whole_surface_0x13e_volume_rejects_nonzero_slice() {
     install_linear_rgba_volume(&mut host, &mut state, 2, 2, 2, 2, 2, 8);
     install_linear_rgba_volume(&mut host, &mut state, 3, 3, 2, 2, 2, 8);
     let mut cmd = copy_cmd(CopyKind::TextureToTextureSliceLevel, 2, 3); // Non-zero slice on 3D whole-surface is fail-closed (Metal forbids).
-                                                                        // Status may be Bounds (slice packing) or Unsupported (3D rule).
+                                                                        // Status may be Bounds
+                                                                        // (slice packing) or
+                                                                        // Unsupported (3D rule).
     cmd.source_slice = 1;
     cmd.slice_count = 1;
     cmd.level_count = 1;
@@ -2741,7 +2750,7 @@ fn copy_region_io_enrichment_dedups_per_page_and_direction() {
     ));
 }
 
-/// The copy path and the draw/sample path follow a type-8 view chain exactly
+/// The copy path and the draw/sample path follow a texture-view chain exactly
 /// as deep as each other.
 ///
 /// Two arms consume this one wire form: `resolve_texture_backing_depth` here,
@@ -2757,7 +2766,7 @@ fn copy_region_io_enrichment_dedups_per_page_and_direction() {
 /// only pinned this arm at eight would pass again the moment the other one
 /// moved, which is the failure that produced the divergence in the first place.
 ///
-/// The chain runs `MAX_TEXTURE_VIEW_CHAIN` views down to a type-11 base, each
+/// The chain runs `MAX_TEXTURE_VIEW_CHAIN` views down to a mapper-ref-texture base, each
 /// view a plain identity hop, so the only thing that can refuse it is depth.
 #[test]
 fn a_copy_follows_a_view_chain_as_deep_as_a_sample_does() {
@@ -2766,10 +2775,10 @@ fn a_copy_follows_a_view_chain_as_deep_as_a_sample_does() {
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 256);
     let mapping_id = 9u32;
-    install_type11(&mut host, &mut state, 3, mapping_id, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 3, mapping_id, 0x20);
 
     // Views live at refs `outermost` down to `base_view`, each viewing the next
-    // lower ref; the lowest views the type-11 at ref 3. The object list holds
+    // lower ref; the lowest views the mapper-ref-texture at ref 3. The object list holds
     // 16 entries, so the deepest legal chain has to fit under that.
     let base_view = 4u32;
     let outermost = base_view + MAX_TEXTURE_VIEW_CHAIN as u32 - 1;
@@ -2780,7 +2789,7 @@ fn a_copy_follows_a_view_chain_as_deep_as_a_sample_does() {
         } else {
             view_ref - 1
         };
-        install_type8_view(
+        install_texture_view(
             &mut host,
             &mut state,
             view_ref,
@@ -2796,7 +2805,7 @@ fn a_copy_follows_a_view_chain_as_deep_as_a_sample_does() {
         .expect("the sample arm follows the contract's deepest chain");
     assert_eq!(
         resolved.base_texture_ref, 3,
-        "the sample arm must land on the type-11 base, not stop inside the chain"
+        "the sample arm must land on the mapper-ref-texture base, not stop inside the chain"
     );
 
     // The copy arm must reach the same base, and land real pixels through it.
@@ -2853,7 +2862,7 @@ fn a_copy_refuses_a_view_chain_the_sample_arm_also_refuses() {
 
     let (mut host, mut state) = blit_device();
     install_buffer(&mut host, &mut state, 1, 1, 256);
-    install_type11(&mut host, &mut state, 3, 9, 0x20);
+    install_mapper_ref_texture(&mut host, &mut state, 3, 9, 0x20);
 
     let base_view = 4u32;
     let outermost = base_view + MAX_TEXTURE_VIEW_CHAIN as u32; // one view too many
@@ -2864,7 +2873,7 @@ fn a_copy_refuses_a_view_chain_the_sample_arm_also_refuses() {
         } else {
             view_ref - 1
         };
-        install_type8_view(
+        install_texture_view(
             &mut host,
             &mut state,
             view_ref,
@@ -2939,7 +2948,7 @@ fn the_gpu_whole_plane_arm_refuses_before_it_resolves_anything() {
 /// The GPU whole-plane arm's destination half, and specifically the plane check.
 ///
 /// `write_bgra8_from_resident_gpu` resolves the plane itself, from the mapping's
-/// declaration, and takes no plane index. A type-5 view carries one on the wire
+/// declaration, and takes no plane index. A ref-texture view carries one on the wire
 /// and can therefore name a plane at a `surface_offset` that scan does not reach.
 /// Landing a frame there is silent at every layer — the pixels appear in the next
 /// plane of the same IOSurface — so the disagreement has to refuse before the
@@ -2972,7 +2981,7 @@ fn the_gpu_whole_plane_arm_refuses_a_plane_the_rail_would_not_write() {
     );
     assert_eq!(
         gpu_whole_plane_destination(None, Some(window), src),
-        Err(DstNotType11),
+        Err(DstNotMapperRefTexture),
         "a linear allocation has no mapping for the rail to name"
     );
     assert_eq!(
@@ -2981,7 +2990,7 @@ fn the_gpu_whole_plane_arm_refuses_a_plane_the_rail_would_not_write() {
         "a mapping that declines the extent has no window to write"
     );
 
-    // The type-5 plane hazard: the guest's descriptor names the second plane of a
+    // The ref-texture plane hazard: the guest's descriptor names the second plane of a
     // biplanar surface, the mapping's own geometry scan resolves the first.
     let second_plane = GpuPlane {
         surface_offset: 0x8000,

--- a/crates/reims-vgpu/src/runtime/blit_exec/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/blit_exec/vulkan.rs
@@ -4,8 +4,8 @@
 //! endpoints and moves guest bytes, and every function it calls is
 //! backend-neutral. What this module adds is the two cases where the content is
 //! already on the GPU and copying it through guest memory would cross a frame
-//! twice — a whole-plane type-11 to type-11 copy out of a resident, and a
-//! whole-plane type-11 to guest-linear one.
+//! twice — a whole-plane mapper-ref-texture to mapper-ref-texture copy out of a resident, and a
+//! whole-plane mapper-ref-texture to guest-linear one.
 //!
 //! Both are **fall-throughs, never losses**: each returns `Option<BlitStatus>`,
 //! and `None` means the host loop runs unchanged and lands the same pixels. The
@@ -88,8 +88,8 @@ pub(crate) fn try_copy_whole_plane_on_gpu<M: HostMemory + HostOps>(
             return None;
         }
     };
-    let TextureBacking::Type11(t) = &dst else {
-        note_store_route(GpuPlaneRefusal::DstNotType11.route());
+    let TextureBacking::MapperRefTexture(t) = &dst else {
+        note_store_route(GpuPlaneRefusal::DstNotMapperRefTexture.route());
         return None;
     };
     let plane = GpuPlane {
@@ -170,7 +170,7 @@ pub(crate) fn try_copy_whole_plane_on_gpu<M: HostMemory + HostOps>(
     }
 }
 
-/// Why one whole-plane type-11 to guest-linear copy is not the GPU arm's, for
+/// Why one whole-plane mapper-ref-texture to guest-linear copy is not the GPU arm's, for
 /// the terms that can be decided from the two endpoints alone.
 ///
 /// Every variant is a **fall-through and not a loss**: the staging loop runs
@@ -214,7 +214,7 @@ impl T2tGvaRefusal {
     }
 }
 
-/// The destination plane a whole-plane type-11 to guest-linear copy would write,
+/// The destination plane a whole-plane mapper-ref-texture to guest-linear copy would write,
 /// and its span, or the typed reason there is none.
 ///
 /// Everything [`try_copy_t11_plane_to_linear_on_gpu`] can decide before it asks
@@ -223,7 +223,7 @@ impl T2tGvaRefusal {
 /// declared geometry and `None` when it has none.
 fn gpu_t2t_gva_plane(
     surface: Option<(u32, u32)>,
-    src: &Type11Texture,
+    src: &MapperRefTexture,
     dst: &LinearTextureLevel,
     destination_ref: u32,
 ) -> Result<
@@ -307,7 +307,7 @@ pub(crate) fn try_copy_t11_plane_to_linear_on_gpu<M: HostMemory + HostOps>(
     host: &mut M,
     task_id: u32,
     destination_ref: u32,
-    src: &Type11Texture,
+    src: &MapperRefTexture,
     dst: &LinearTextureLevel,
 ) -> Option<BlitStatus> {
     use crate::runtime::drain::note_store_route;
@@ -379,7 +379,7 @@ pub(crate) fn try_copy_t11_plane_to_linear_on_gpu<M: HostMemory + HostOps>(
     }
 }
 
-/// Whether this rail already holds a type-11 surface's content, as a counter.
+/// Whether this rail already holds a mapper-ref-texture surface's content, as a counter.
 ///
 /// A census and nothing else: it changes no decision, and every caller runs the
 /// same host copy afterwards either way. The Metal rail has no resident registry
@@ -431,7 +431,7 @@ pub(crate) fn note_blit_t11_resident(state: &DeviceState, mapping_id: u32) {
 mod tests {
     use super::*;
 
-    /// The GPU arm for a whole-plane type-11 source going to a guest-linear
+    /// The GPU arm for a whole-plane mapper-ref-texture source going to a guest-linear
     /// destination, decided from the two endpoints alone.
     ///
     /// The staging loop this stands in front of reads the source's *guest bytes*,
@@ -442,13 +442,13 @@ mod tests {
     /// about whether the resident and the destination plane are the two ends of one
     /// byte copy, and never about whether the guest's pages are readable.
     #[test]
-    fn a_whole_surface_type11_source_reaches_the_destinations_own_guest_plane() {
+    fn a_whole_surface_mapper_ref_texture_source_reaches_the_destinations_own_guest_plane() {
         use super::T2tGvaRefusal::*;
 
         const W: u32 = 64;
         const H: u32 = 32;
         const BPR: u64 = 256;
-        let src = Type11Texture {
+        let src = MapperRefTexture {
             mapping_id: 7,
             width: W,
             height: H,
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(
             gpu_t2t_gva_plane(
                 Some((W, H)),
-                &Type11Texture {
+                &MapperRefTexture {
                     surface_offset: 0x8000,
                     ..src
                 },

--- a/crates/reims-vgpu/src/runtime/census/mod.rs
+++ b/crates/reims-vgpu/src/runtime/census/mod.rs
@@ -30,7 +30,7 @@
 //! |---|---|
 //! | [`present_proxy`] | `secondary_mrt_drop` — a multi-RT draw degraded to single-RT — plus `stale_online_pending` and [`present_proxy::host_window_publish`], the sole record that a captured frame never reached the host window |
 //! | [`srgb_census`] | which rails drop the sRGB transfer function |
-//! | [`view_swizzle_census`] | type-8 view swizzles dropped, or served by rewriting texels on the CPU |
+//! | [`view_swizzle_census`] | texture-view swizzles dropped, or served by rewriting texels on the CPU |
 //!
 //! # Adding one
 //!
@@ -55,14 +55,14 @@
 //! change is a guest that starts populating the tail, and that is now a typed
 //! decline raised at the record, not a counter nobody reads.
 //!
-//! `t11_decline` was the second: an eight-way reason enum over the type-11
+//! `t11_decline` was the second: an eight-way reason enum over the mapper-ref-texture
 //! sampled rail's zero-copy declines. Across every recorded boot, 1 051 sampled
 //! declines named `below_floor` and nothing else — the other seven variants
 //! never fired once, including the three that sat *after* the floor test and so
 //! were never shadowed by it. That answer set `SAMPLED_GATHER_MIN_BYTES`, whose
 //! scope and basis are recorded on the constant. The threshold now governs only
 //! the copied gather fallback; a directly-backed resource has no size
-//! crossover. The rail returns `Option` like its type-2/3 sibling: falling back
+//! crossover. The rail returns `Option` like its normal-texture sibling: falling back
 //! to the CPU byte loader is expected control flow that yields the same pixels,
 //! so it stays quiet.
 //!

--- a/crates/reims-vgpu/src/runtime/census/srgb_census.rs
+++ b/crates/reims-vgpu/src/runtime/census/srgb_census.rs
@@ -16,7 +16,7 @@
 //! census, because a session already did and was wrong.
 //!
 //! This census reports the sites listed in [`site`] and nothing else. It once
-//! carried three more — the linear, type-11 and type-5 **zero-copy** sampled
+//! carried three more — the linear, mapper-ref-texture and ref-texture **zero-copy** sampled
 //! rails — which were removed when those rails were changed to bind the
 //! `_SRGB` view and honour the qualifier. They had no emitter for some time
 //! before that, so the census was answering for a population it no longer

--- a/crates/reims-vgpu/src/runtime/census/view_swizzle_census.rs
+++ b/crates/reims-vgpu/src/runtime/census/view_swizzle_census.rs
@@ -1,8 +1,8 @@
-//! Always-on declines for the type-8 view-swizzle bug class.
+//! Always-on declines for the texture-view-swizzle bug class.
 //!
 //! # The class
 //!
-//! A guest texture view (type-8, opcode `0x1b`) can remap which channel each
+//! A guest texture view (texture-view, opcode `0x1b`) can remap which channel each
 //! output component reads. Vulkan performs exactly that for free through the
 //! image view's `VkComponentMapping`. Doing it any other way is a defect with
 //! two shapes, and these declines tell them apart:

--- a/crates/reims-vgpu/src/runtime/chain_phase.rs
+++ b/crates/reims-vgpu/src/runtime/chain_phase.rs
@@ -162,7 +162,7 @@ pub enum Phase {
     /// span it used to hold is now charged to [`Self::Prep`].
     PrepPages = 13,
     /// The four target-identity rails: resident render chain, GVA deferred
-    /// store, type-11 surface resident, and the Load-from-target identity.
+    /// store, mapper-ref-texture surface resident, and the Load-from-target identity.
     ///
     /// # Why the assemble span is split at all
     ///

--- a/crates/reims-vgpu/src/runtime/compute_exec/mod.rs
+++ b/crates/reims-vgpu/src/runtime/compute_exec/mod.rs
@@ -1,10 +1,10 @@
 //! Product-path compute bind/dispatch for `SEGMENT_TYPE_COMPUTE`.
 //!
 //! Executable surface:
-//! - `0xd0` set compute pipeline (type-7 → kernel function MTLB + optional stage-input)
+//! - `0xd0` set compute pipeline (serializer-object → kernel function MTLB + optional stage-input)
 //! - `0xcb` / `0xd9` set buffers (+ optional attribute stride for dynamic stage-input layouts)
 //! - `0xcf` / `0xda` set buffer offset (+ optional attribute stride)
-//! - `0xce` set textures (type-2/3 GVA + type-11; sample vs storage via reflection)
+//! - `0xce` set textures (normal-texture GVA + mapper-ref-texture; sample vs storage via reflection)
 //! - `0xcc` / `0xcd` set samplers (+ optional LOD clamp)
 //! - `0xd1` direct stage-in region / `0xd2` indirect stage-in region (guest buffer args)
 //! - `0xd3` threadgroup memory length
@@ -22,7 +22,7 @@
 //!
 //! One-shot encode uses [`crate::backend::metal::compute::compute_core`]; nested
 //! encode uses `compute_encode_on_encoder`. Buffer and storage-image writeback
-//! is GVA / type-11 staged.
+//! is GVA / mapper-ref-texture staged.
 
 // The backend the process executes on, reached only through the trait.
 use crate::backend::Backend as _;
@@ -33,10 +33,11 @@ use crate::runtime::decode::compute::{
     BufferBinding, Command as ComputeCommand, Kind, RefBinding, SamplerBinding,
 };
 use crate::runtime::decode::resource::{
-    decode_heap_texture, decode_texture_descriptor, decode_type7_descriptor, texture_type8_opcode,
-    ComputeStageInputDescriptor, Descriptor as ResourceDescriptor, HEAP_TEXTURE_OPCODE,
-    HEAP_TEXTURE_WIDE_OPCODE, OBJECT_TYPE_BUFFER, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT,
-    OBJECT_TYPE_TEXTURE_VIEW, OBJECT_TYPE_TYPE7, TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE,
+    decode_heap_texture, decode_serializer_object_descriptor, decode_texture_descriptor,
+    texture_view_opcode, ComputeStageInputDescriptor, Descriptor as ResourceDescriptor,
+    HEAP_TEXTURE_OPCODE, HEAP_TEXTURE_WIDE_OPCODE, OBJECT_TYPE_BUFFER,
+    OBJECT_TYPE_SERIALIZER_OBJECT, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
+    OBJECT_TYPE_TEXTURE_VIEW, TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE,
     TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE_WIDE,
 };
 use crate::runtime::draw::{host_alloc_len, StoreTargetPages};
@@ -924,7 +925,7 @@ pub(crate) struct LoadedComputePipeline {
     pub stage_input: Option<ComputeStageInputDescriptor>,
 }
 
-/// What a type-7's stage-input block means for the pipeline carrying it.
+/// What a serializer-object's stage-input block means for the pipeline carrying it.
 ///
 /// Three outcomes, and the whole point of naming them is that two of them are
 /// not the same: [`Self::Absent`] is a kernel that declares no per-thread input,
@@ -972,16 +973,20 @@ pub(crate) fn load_compute_pipeline<M: HostMemory + HostOps>(
         report.reason(task_id, pipeline_ref, reason, &detail);
         None
     };
-    let (_entry, desc) =
-        match objects::resolve_descriptor(state, host, task_id, pipeline_ref, &[OBJECT_TYPE_TYPE7])
-        {
-            Ok(found) => found,
-            Err(rung) => {
-                report.rung(task_id, pipeline_ref, rung);
-                return None;
-            }
-        };
-    let Ok(decoded) = decode_type7_descriptor(&desc) else {
+    let (_entry, desc) = match objects::resolve_descriptor(
+        state,
+        host,
+        task_id,
+        pipeline_ref,
+        &[OBJECT_TYPE_SERIALIZER_OBJECT],
+    ) {
+        Ok(found) => found,
+        Err(rung) => {
+            report.rung(task_id, pipeline_ref, rung);
+            return None;
+        }
+    };
+    let Ok(decoded) = decode_serializer_object_descriptor(&desc) else {
         return miss(
             crate::observe::ladder_slug!("", desc_decode),
             format!("desc_len={}", desc.len()),
@@ -1024,7 +1029,7 @@ pub(crate) fn load_compute_pipeline<M: HostMemory + HostOps>(
     }
 }
 
-/// Read `len` bytes from a type-1 buffer at `offset` (product + session helpers).
+/// Read `len` bytes from a buffer at `offset` (product + session helpers).
 pub(crate) fn read_buffer_window<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
@@ -1243,15 +1248,15 @@ enum TextureWriteback {
         /// index `i` as page `i` of the window. See [`staged_window_pages`].
         pages: StoreTargetPages,
     },
-    Type11 {
+    MapperRefTexture {
         mapping_id: u32,
         /// The window this bind was staged against — a byte offset into the
         /// mapping, the surface's row pitch, and one past the last byte the
         /// window may touch.
         ///
         /// Resolved once, at stage time, through the plane the bind actually
-        /// names: `type5_sample_window` when the wire carried a type-5 view's
-        /// plane index, `type11_sample_window` otherwise. Both the read that
+        /// names: `ref_texture_sample_window` when the wire carried a ref-texture view's
+        /// plane index, `mapper_ref_texture_sample_window` otherwise. Both the read that
         /// seeds the image and the write that lands it use exactly these three
         /// numbers, so the two cannot name different bytes of one surface.
         surface_offset: u64,
@@ -1373,7 +1378,7 @@ pub(crate) struct StagedTexture {
     /// How many mip levels `bytes` carries, base first, packed tightly by
     /// [`crate::contract::extent::tight_pyramid_spans`].
     ///
-    /// `1` on every rail but the type-2/3 linear one, and `1` there too for a
+    /// `1` on every rail but the normal-texture linear one, and `1` there too for a
     /// storage binding or a view that already names a level: a compute write
     /// names one level and a levelled view exposes one. Where it is greater,
     /// `width`/`height` remain level 0's extent and every other level's is
@@ -1496,7 +1501,7 @@ impl ResidentServe {
 }
 
 /// Stage an opcode-9 buffer-backed texture: tight raw texels read out of the
-/// type-1 buffer the guest named, at its declared offset and row pitch.
+/// buffer the guest named, at its declared offset and row pitch.
 ///
 /// The contract is `newTextureWithBuffer:descriptor:offset:bytesPerRow:` — the
 /// texels *are* the buffer's bytes, reinterpreted through the embedded texture
@@ -1588,7 +1593,7 @@ fn stage_buffer_texture<M: HostMemory + HostOps>(
         return Err(ComputeStatus::Unsupported("compute_buftex_span"));
     };
     // A buffer-backed texture is two contract references over one allocation —
-    // the type-8 texture the guest binds and the type-1 buffer that owns the
+    // the texture-view texture the guest binds and the buffer that owns the
     // storage — and a debt may be armed under either. The draw twin pays for
     // both; so does this.
     crate::runtime::writeback_debt::pay_for_texture(state, host, task_id, texture_ref);
@@ -1807,15 +1812,16 @@ fn multisample_sampled_texture<M: HostMemory + HostOps>(
     })
 }
 
-/// Load tight raw texels for a compute texture binding (type-2/3, type-5→surface, or type-11).
+/// Load tight raw texels for a compute texture binding (normal-texture, ref-texture→surface, or
+/// mapper-ref-texture).
 ///
-/// Type-5 (`RefTextureHandle`) is the live CI wallpaper path (`compute_stage_tex … ot=5`).
-/// RE (type-5 wire + `runtime::draw` sample path): surfaceID@0 is a type-4 object id (= mapping
-/// mid). Product draw samples call [`objects::ensure_surface_for_present`] on that id and
-/// stage from the **mapping registry**, never re-resolving the surface id through the
-/// compute task's object list (that list uses a separate texture-ref namespace — live
-/// ensure=1 then MissingTexture/GuestIo class when `resolve_type11_ref(task, sid)` hit a
-/// different type-11 slot).
+/// Ref-texture (`RefTextureHandle`) is the live CI wallpaper path (`compute_stage_tex … ot=5`). RE
+/// (ref-texture wire + `runtime::draw` sample path): surfaceID@0 is a backing object id (= mapping
+/// mid). Product draw samples call [`objects::ensure_surface_for_present`] on that id and stage
+/// from the **mapping registry**, never re-resolving the surface id through the compute task's
+/// object list (that list uses a separate texture-ref namespace — live ensure=1 then
+/// MissingTexture/GuestIo class when `resolve_mapper_ref_texture(task, sid)` hit a different
+/// mapper-ref-texture slot).
 pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
@@ -1824,23 +1830,23 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
     binding: u32,
     is_storage: bool,
 ) -> Result<StagedTexture, ComputeStatus> {
-    // Type-5 RefTextureHandle → surface_id (live CI binds ot5).
+    // Ref-texture RefTextureHandle → surface_id (live CI binds ot5).
     let mut stage_ref = texture_ref;
-    let mut from_type5 = false;
-    let mut from_type4_direct = false;
-    let mut type5_record: Option<objects::Type5TextureView> = None;
+    let mut from_ref_texture = false;
+    let mut from_backing_direct = false;
+    let mut ref_texture_record: Option<objects::RefTextureView> = None;
     let mut view_level = 0;
     let mut view_pixel_format = None;
     let mut heap_texture = None;
     let mut buffer_texture: Option<crate::runtime::decode::resource::BufferTextureDescriptor> =
         None;
-    // A linear texture object (type-2/3) must resolve through its own
+    // A linear texture object (normal-texture) must resolve through its own
     // descriptor, never through the mapping registry: its numeric ref shares
-    // the id space with type-4 surface mids, so the `mappings.contains(ref)`
+    // the id space with backing record mids, so the `mappings.contains(ref)`
     // fallback below would wrongly grab a same-numbered surface (live class:
-    // `ref=N ot=2` dragged into the type-11 path and failing silently against
-    // the biplanar wallpaper mid). Same collision the type-5 path documents.
-    // Resolve the object-list entry once: `ref_is_linear` and the type5/type4
+    // `ref=N ot=2` dragged into the mapper-ref-texture path and failing silently against
+    // the biplanar wallpaper mid). Same collision the ref-texture path documents.
+    // Resolve the object-list entry once: `ref_is_linear` and the ref_texture/backing
     // classification below both read it for the same ref, and the guest object
     // list is immutable for the life of the dispatch (the device never writes
     // those pages). `ListObjectEntry` is `Copy`, so one guest-DMA read+decode
@@ -1858,7 +1864,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                     desc_read
                 )));
             };
-            let opcode = texture_type8_opcode(&desc).unwrap_or(0);
+            let opcode = texture_view_opcode(&desc).unwrap_or(0);
             // Both opcodes are the same record: the wide one is what the guest's
             // serializer emits with `TextureDescriptor2` on. The length each
             // implies is `decode_heap_texture`'s to check — this site used to
@@ -2091,20 +2097,21 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
     let stage_entry = objects::lookup_list_entry(state, host, task_id, stage_ref);
     let ref_is_linear = stage_entry
         .map(|e| {
-            e.object_type == OBJECT_TYPE_TEXTURE || e.object_type == OBJECT_TYPE_TEXTURE_VARIANT
+            e.object_type == OBJECT_TYPE_TEXTURE
+                || e.object_type == OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
         })
         .unwrap_or(false);
     if let Some(entry) = stage_entry {
         if entry.object_type == objects::OBJECT_TYPE_REF_TEXTURE {
             if let Some(desc) = objects::read_descriptor(state, host, task_id, &entry) {
-                if let Ok(t5) = reims_vgpu_wire::device_desc::type5_header(&desc) {
+                if let Ok(t5) = reims_vgpu_wire::device_desc::ref_texture_header(&desc) {
                     let sid = t5.surface_id.get();
                     if sid != 0 {
                         stage_ref = sid;
-                        from_type5 = true;
-                        type5_record = objects::decode_type5_texture_view(&desc);
+                        from_ref_texture = true;
+                        ref_texture_record = objects::decode_ref_texture_view(&desc);
                         let ok = objects::ensure_surface_for_present(state, host, sid);
-                        // Per-bind type-5 descriptor RE census (args@+8 holds the
+                        // Per-bind ref-texture descriptor RE census (args@+8 holds the
                         // serialized plane texture; product stage uses mapping geom
                         // only today). This is measurement, not a failure — it fired
                         // ~600×/boot on the always-on sink (same descriptor re-dumped
@@ -2113,7 +2120,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                         // ensure failure surfaces downstream as `MissingTexture` (the
                         // mapping lookup below misses), so no always-on line is lost.
                         crate::observe::when_verbose(|| {
-                            // The owner task the view names. `note_type5_owner_task`
+                            // The owner task the view names. `note_ref_texture_owner_task`
                             // is the always-on check on its value; this echo carries
                             // it beside the descriptor it came out of.
                             let owner_task = t5.owner_task.get();
@@ -2131,7 +2138,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                                 }
                             }
                             crate::observe::line(format!(
-                                "compute_stage_tex type5 ref={texture_ref} sid={sid} ensure={} owner_task={owner_task} desc_len={} args_n={args_n} args_hex={args_hex}",
+                                "compute_stage_tex ref_texture ref={texture_ref} sid={sid} ensure={} owner_task={owner_task} desc_len={} args_n={args_n} args_hex={args_hex}",
                                 ok as u8,
                                 desc.len(),
                             ));
@@ -2139,16 +2146,16 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                     }
                 }
             }
-        } else if entry.object_type == objects::OBJECT_TYPE_SURFACE {
-            // Direct type-4 surface bind (same id space as present mids).
-            from_type4_direct = true;
+        } else if entry.object_type == objects::OBJECT_TYPE_BACKING {
+            // Direct backing record bind (same id space as present mids).
+            from_backing_direct = true;
             let _ = objects::ensure_surface_for_present(state, host, stage_ref);
         }
     }
 
-    // Type-5 / direct type-4: surface id **is** the mapping mid. Never call
-    // resolve_type11_ref(task, sid) — task object-list indices collide with texture refs.
-    let mapping_id_opt = if from_type5 || from_type4_direct {
+    // Ref-texture / direct backing: surface id **is** the mapping mid. Never call
+    // resolve_mapper_ref_texture(task, sid) — task object-list indices collide with texture refs.
+    let mapping_id_opt = if from_ref_texture || from_backing_direct {
         if stage_ref != 0 && state.mappings.contains_key(&stage_ref) {
             Some(stage_ref)
         } else {
@@ -2156,10 +2163,10 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         }
     } else if ref_is_linear {
         // Linear texture: never fall back to the mapping registry (id-space
-        // collision with type-4 surface mids). Force the type-2/3 path.
+        // collision with backing record mids). Force the normal-texture path.
         None
     } else {
-        objects::resolve_type11_ref(state, host, task_id, stage_ref).or_else(|| {
+        objects::resolve_mapper_ref_texture(state, host, task_id, stage_ref).or_else(|| {
             if stage_ref != 0 && state.mappings.contains_key(&stage_ref) {
                 Some(stage_ref)
             } else {
@@ -2167,29 +2174,31 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             }
         })
     };
-    if mapping_id_opt.is_none() && from_type5 {
+    if mapping_id_opt.is_none() && from_ref_texture {
         crate::observe::fail(format!(
-            "compute_stage_tex type5_no_map ref={texture_ref} sid={stage_ref}"
+            "compute_stage_tex ref_texture_no_map ref={texture_ref} sid={stage_ref}"
         ));
         return Err(ComputeStatus::MissingTexture(
-            "compute_stage_tex_type5_no_map",
+            "compute_stage_tex_ref_texture_no_map",
         ));
     }
     if let Some(mapping_id) = mapping_id_opt {
         let _ = mapper::ensure_resolved_for_scanout(state, host, mapping_id);
-        // Geom/format: a type-5 record is the exact Metal texture view over
+        // Geom/format: a ref-texture record is the exact Metal texture view over
         // the IOSurface bytes. It is authoritative even for a stageable
         // single-plane mapping: the live BGRA8 desktop target is exposed as a
-        // row-byte-equivalent, quarter-width RGBA32Uint view. Type-4 direct
-        // refs use base mapping geometry. Type-11 refs may prefer the
+        // row-byte-equivalent, quarter-width RGBA32Uint view. Backing direct
+        // refs use base mapping geometry. Mapper-ref-texture refs may prefer the
         // IOSurface descriptor on this task's object list.
         if view_level != 0 {
             crate::observe::fail(format!(
-                "compute_stage_tex view_fail reason=type11_mip ref={texture_ref} base={stage_ref} level={view_level} mapping={mapping_id}"
+                "compute_stage_tex view_fail reason=mapper_ref_texture_mip ref={texture_ref} base={stage_ref} level={view_level} mapping={mapping_id}"
             ));
-            return Err(ComputeStatus::Unsupported("compute_view_type11_mip"));
+            return Err(ComputeStatus::Unsupported(
+                "compute_view_mapper_ref_texture_mip",
+            ));
         }
-        let (width, height, format) = if from_type5 || from_type4_direct {
+        let (width, height, format) = if from_ref_texture || from_backing_direct {
             let m = state
                 .mappings
                 .get(&mapping_id)
@@ -2199,14 +2208,14 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             let multiplanar = objects::mapping_is_multiplanar(m);
             let mapping_stageable =
                 m.has_geom && m.width != 0 && m.height != 0 && m.format != 0 && !multiplanar;
-            if let Some(rec) = type5_record {
-                // `type11_sample_window` below matches actual plane records by
+            if let Some(rec) = ref_texture_record {
+                // `mapper_ref_texture_sample_window` below matches actual plane records by
                 // geometry+bpe and otherwise verifies a packed row-compatible
                 // view over the same bytes. Per-bind measurement (view vs base
                 // geom), not a failure — verbose-gated to keep the always-on sink
                 // for genuine failures.
                 crate::observe::line(format!(
-                    "compute_stage_tex type5_view mapping={mapping_id} view={}x{} fmt={:#x} base={}x{} fmt={:#x} multiplanar={}",
+                    "compute_stage_tex ref_texture_view mapping={mapping_id} view={}x{} fmt={:#x} base={}x{} fmt={:#x} multiplanar={}",
                     rec.width,
                     rec.height,
                     rec.pixel_format,
@@ -2219,18 +2228,18 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             } else if !mapping_stageable {
                 if !m.has_geom || m.width == 0 || m.height == 0 {
                     crate::observe::fail(format!(
-                        "compute_stage_tex type11_fail reason=no_geom mapping={mapping_id} pages={} has_geom={}",
+                        "compute_stage_tex mapper_ref_texture_fail reason=no_geom mapping={mapping_id} pages={} has_geom={}",
                         m.page_entries.len(),
                         m.has_geom as u8
                     ));
                     return Err(ComputeStatus::MissingTexture(
-                        "compute_stage_tex_type11_no_geom",
+                        "compute_stage_tex_mapper_ref_texture_no_geom",
                     ));
                 } else if multiplanar {
                     // Multi-plane IOSurface without a plane record: fail closed,
                     // do not invent BGRA sample of the whole surface.
                     crate::observe::fail(format!(
-                        "compute_stage_tex type11_fail reason=multiplane mapping={mapping_id} {}x{} fmt={:#x} pages={} (no type-5 plane record)",
+                        "compute_stage_tex mapper_ref_texture_fail reason=multiplane mapping={mapping_id} {}x{} fmt={:#x} pages={} (no ref-texture plane record)",
                         m.width,
                         m.height,
                         m.format,
@@ -2240,7 +2249,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                 } else {
                     // Single-plane unknown format: fail closed (no BGRA invent).
                     crate::observe::fail(format!(
-                        "compute_stage_tex type11_fail reason=fmt_unknown mapping={mapping_id} {}x{} pages={}",
+                        "compute_stage_tex mapper_ref_texture_fail reason=fmt_unknown mapping={mapping_id} {}x{} pages={}",
                         m.width,
                         m.height,
                         m.page_entries.len()
@@ -2313,7 +2322,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             Some(v) => v,
             None => {
                 crate::observe::fail(format!(
-                    "compute_stage_tex type11_fail reason=fmt_bytes mapping={mapping_id} {width}x{height} fmt={format:#x}"
+                    "compute_stage_tex mapper_ref_texture_fail reason=fmt_bytes mapping={mapping_id} {width}x{height} fmt={format:#x}"
                 ));
                 return Err(ComputeStatus::Unsupported("stage_tex_fmt_bytes"));
             }
@@ -2321,7 +2330,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         let storage_selector = pixel_format::storage_selector(stage_fmt);
         if is_storage && storage_selector.is_none() {
             crate::observe::fail(format!(
-                "compute_stage_tex type11_fail reason=fmt_storage mapping={mapping_id} {width}x{height} fmt={format:#x}"
+                "compute_stage_tex mapper_ref_texture_fail reason=fmt_storage mapping={mapping_id} {width}x{height} fmt={format:#x}"
             ));
             return Err(ComputeStatus::Unsupported("stage_tex_fmt_storage"));
         }
@@ -2337,23 +2346,27 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         // once `serve` is known.
         let content_generation = m.content_generation;
         let pages_n = m.page_entries.len();
-        // Wire type-4 `length` (page-aligned getResidentSize), stashed as device_desc.alloc_size.
+        // Wire backing `length` (page-aligned getResidentSize), stashed as device_desc.alloc_size.
         // Independent of plane w/h and of MapMemory2 IOAccelMemory length — measure-only.
         let wire_len = crate::contract::iosurface_pages::decode_device_surface(&m.device_desc)
             .map(|s| s.alloc_size as u64)
             .unwrap_or(0);
-        // A type-5 record names its IOSurface plane on the wire (record `+0x20`,
+        // A ref-texture record names its IOSurface plane on the wire (record `+0x20`,
         // the `newTextureWithDescriptor:iosurface:plane:` argument), so the
-        // plane is decided, not inferred. Type-11 carries no such field and must
+        // plane is decided, not inferred. Mapper-ref-texture carries no such field and must
         // still match a plane record by geometry — which is ambiguous whenever
         // two planes share dims and bytes-per-element (v0a8 Y and alpha), and
-        // declines rather than picking one. The draw path already binds type-5
+        // declines rather than picking one. The draw path already binds ref-texture
         // views by index; this is the same resolution on the staging path.
-        let window = match type5_record {
-            Some(rec) => {
-                mapping_write::type5_sample_window(m, rec.plane_index, width, height, stage_fmt)
-            }
-            None => mapping_write::type11_sample_window(m, width, height, stage_fmt),
+        let window = match ref_texture_record {
+            Some(rec) => mapping_write::ref_texture_sample_window(
+                m,
+                rec.plane_index,
+                width,
+                height,
+                stage_fmt,
+            ),
+            None => mapping_write::mapper_ref_texture_sample_window(m, width, height, stage_fmt),
         };
         let (surface_offset, surface_bpr, span_end) = match window {
             Some(w) => w,
@@ -2373,10 +2386,10 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
                 )
                 .unwrap_or(0);
                 crate::observe::fail(format!(
-                    "compute_stage_tex type11_fail reason=window mapping={mapping_id} {width}x{height} fmt={stage_fmt:#x} pages={pages_n} wire_len={wire_len} desc={dw}x{dh} bpr={dbpr} alloc={dalloc} reach={reach}"
+                    "compute_stage_tex mapper_ref_texture_fail reason=window mapping={mapping_id} {width}x{height} fmt={stage_fmt:#x} pages={pages_n} wire_len={wire_len} desc={dw}x{dh} bpr={dbpr} alloc={dalloc} reach={reach}"
                 ));
                 return Err(ComputeStatus::MissingTexture(
-                    "compute_stage_tex_type11_window",
+                    "compute_stage_tex_mapper_ref_texture_window",
                 ));
             }
         };
@@ -2384,12 +2397,12 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             .checked_mul(bpp as u64)
             .ok_or(ComputeStatus::Unsupported("stage_tex_tight_bpr_overflow"))?
             as u32;
-        if from_type5 && type5_record.is_some() {
-            // Per-bind type-5 sample-window measurement, not a failure — verbose-gated
+        if from_ref_texture && ref_texture_record.is_some() {
+            // Per-bind ref-texture sample-window measurement, not a failure — verbose-gated
             // (was a per-bind always-on line). Genuine window failures above emit
-            // `type11_fail reason=window` always-on.
+            // `mapper_ref_texture_fail reason=window` always-on.
             crate::observe::line(format!(
-                "compute_stage_tex type5_view_window mapping={mapping_id} view={width}x{height} fmt={stage_fmt:#x} bpp={bpp} tight={tight} surface_off={surface_offset} surface_bpr={surface_bpr} span_end={span_end}"
+                "compute_stage_tex ref_texture_view_window mapping={mapping_id} view={width}x{height} fmt={stage_fmt:#x} bpp={bpp} tight={tight} surface_off={surface_offset} surface_bpr={surface_bpr} span_end={span_end}"
             ));
         }
         let need_u64 = (tight as u64)
@@ -2397,16 +2410,18 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             .ok_or(ComputeStatus::Unsupported("stage_tex_need_overflow"))?;
         let Some(need) = host_alloc_len(need_u64) else {
             crate::observe::fail(format!(
-                "compute_stage_tex type11_fail reason=host_len mapping={mapping_id} need={need_u64}"
+                "compute_stage_tex mapper_ref_texture_fail reason=host_len mapping={mapping_id} need={need_u64}"
             ));
             return Err(ComputeStatus::Unsupported("stage_tex_host_len"));
         };
         let page_bytes = (pages_n as u64).saturating_mul(1u64 << state.page_shift);
         if page_bytes < span_end {
             crate::observe::fail(format!(
-                "compute_stage_tex type11_fail reason=span mapping={mapping_id} {width}x{height} pages={pages_n} page_bytes={page_bytes} span_end={span_end} bpr={surface_bpr} wire_len={wire_len}"
+                "compute_stage_tex mapper_ref_texture_fail reason=span mapping={mapping_id} {width}x{height} pages={pages_n} page_bytes={page_bytes} span_end={span_end} bpr={surface_bpr} wire_len={wire_len}"
             ));
-            return Err(ComputeStatus::GuestIo("compute_stage_tex_type11_span"));
+            return Err(ComputeStatus::GuestIo(
+                "compute_stage_tex_mapper_ref_texture_span",
+            ));
         }
         let residency_key = crate::model::ComputeStorageResidencyKey {
             mapping_id,
@@ -2492,12 +2507,14 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
             )
         {
             crate::observe::fail(format!(
-                "compute_stage_tex type11_fail reason=read mapping={mapping_id} {width}x{height} off={surface_offset} bpr={surface_bpr} span_end={span_end} pages={pages_n}"
+                "compute_stage_tex mapper_ref_texture_fail reason=read mapping={mapping_id} {width}x{height} off={surface_offset} bpr={surface_bpr} span_end={span_end} pages={pages_n}"
             ));
-            return Err(ComputeStatus::GuestIo("compute_stage_tex_type11_read"));
+            return Err(ComputeStatus::GuestIo(
+                "compute_stage_tex_mapper_ref_texture_read",
+            ));
         }
         let writeback = if is_storage {
-            TextureWriteback::Type11 {
+            TextureWriteback::MapperRefTexture {
                 mapping_id,
                 surface_offset,
                 surface_bpr,
@@ -2509,12 +2526,12 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         } else {
             TextureWriteback::None
         };
-        if from_type5 {
-            // Per-bind type-5 stage SUCCESS census — not a failure; verbose-gated
-            // (was always-on, ~300/boot). Genuine type-5 stage failures above emit
-            // `type11_fail reason=<slug>` always-on.
+        if from_ref_texture {
+            // Per-bind ref-texture stage SUCCESS census — not a failure; verbose-gated
+            // (was always-on, ~300/boot). Genuine ref-texture stage failures above emit
+            // `mapper_ref_texture_fail reason=<slug>` always-on.
             crate::observe::line(format!(
-                "compute_stage_tex type5_ok ref={texture_ref} sid={mapping_id} {width}x{height} fmt={stage_fmt:#x} pages={pages_n}"
+                "compute_stage_tex ref_texture_ok ref={texture_ref} sid={mapping_id} {width}x{height} fmt={stage_fmt:#x} pages={pages_n}"
             ));
         }
         return Ok(StagedTexture {
@@ -2548,7 +2565,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         });
     }
 
-    // Type-2/3 linear. Fail-visible: name which gate rejected (live class:
+    // normal-texture linear. Fail-visible: name which gate rejected (live class:
     // silent ot=2 MissingTexture, journal 2026-07-14 compute census).
     // The reason travels *in* the status now, so this line and the caller's
     // both name the registered slug rather than a local shorthand only this
@@ -2565,7 +2582,7 @@ pub(crate) fn stage_texture_raw<M: HostMemory + HostOps>(
         host,
         task_id,
         stage_ref,
-        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT],
+        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS],
     ) {
         Ok(found) => found,
         Err(rung) => {
@@ -2982,7 +2999,7 @@ struct LinearLevelSource {
     row_stride: u64,
 }
 
-/// Levels 1.. of a type-2/3 texture's declared mip chain, as far as the
+/// Levels 1.. of a normal texture's declared mip chain, as far as the
 /// descriptor actually places them.
 ///
 /// The prefix, not the set: a level that will not resolve makes every level
@@ -3173,18 +3190,18 @@ fn writeback_texture<M: HostMemory + HostOps>(
                 },
             );
         }
-        TextureWriteback::Type11 {
+        TextureWriteback::MapperRefTexture {
             width,
             format,
             surface_bpr,
             ..
         } => {
-            crate::runtime::drain::note_store_route("compute_wb_type11");
+            crate::runtime::drain::note_store_route("compute_wb_mapper_ref_texture");
             let tight = pixel_format::bytes_per_pixel(*format).map(|bpp| width.saturating_mul(bpp));
             crate::runtime::drain::note_store_route(if tight == Some(*surface_bpr) {
-                "compute_wb_type11_dense"
+                "compute_wb_mapper_ref_texture_dense"
             } else {
-                "compute_wb_type11_padded"
+                "compute_wb_mapper_ref_texture_padded"
             });
         }
     }
@@ -3297,7 +3314,7 @@ fn writeback_texture<M: HostMemory + HostOps>(
                 }
             }
         }
-        TextureWriteback::Type11 {
+        TextureWriteback::MapperRefTexture {
             mapping_id,
             surface_offset,
             surface_bpr,
@@ -3314,10 +3331,12 @@ fn writeback_texture<M: HostMemory + HostOps>(
             // rows at a width nothing declared.
             let Some(bpp) = pixel_format::bytes_per_pixel(*format) else {
                 crate::observe::fail(format!(
-                    "compute_writeback_tex fail reason=type11_format_unsized task={task_id} bind={} mid={mapping_id} fmt={format:#x}",
+                    "compute_writeback_tex fail reason=mapper_ref_texture_format_unsized task={task_id} bind={} mid={mapping_id} fmt={format:#x}",
                     tex.binding
                 ));
-                return Err(ComputeStatus::GuestIo("compute_wb_tex_type11_format"));
+                return Err(ComputeStatus::GuestIo(
+                    "compute_wb_tex_mapper_ref_texture_format",
+                ));
             };
             let tight = width.saturating_mul(bpp);
             if !mapping_write::write_full_rect_raw_at(
@@ -3334,7 +3353,7 @@ fn writeback_texture<M: HostMemory + HostOps>(
                 tight,
             ) {
                 crate::observe::fail(format!(
-                    "compute_writeback_tex fail reason=type11_mapping_write task={task_id} bind={} mid={} surface_offset={surface_offset:#x} surface_bpr={} span_end={span_end:#x} dims={}x{} bpp={} bytes={} tight={tight}",
+                    "compute_writeback_tex fail reason=mapper_ref_texture_mapping_write task={task_id} bind={} mid={} surface_offset={surface_offset:#x} surface_bpr={} span_end={span_end:#x} dims={}x{} bpp={} bytes={} tight={tight}",
                     tex.binding,
                     mapping_id,
                     surface_bpr,
@@ -3343,7 +3362,9 @@ fn writeback_texture<M: HostMemory + HostOps>(
                     bpp,
                     tex.bytes.len()
                 ));
-                return Err(ComputeStatus::GuestIo("compute_wb_tex_type11_write"));
+                return Err(ComputeStatus::GuestIo(
+                    "compute_wb_tex_mapper_ref_texture_write",
+                ));
             }
             Ok(())
         }
@@ -3486,7 +3507,7 @@ fn writeback_buffer<M: HostMemory + HostOps>(
     Ok(())
 }
 
-/// An absent IOSurface pixel format means BGRA8: a type-11 surface the guest
+/// An absent IOSurface pixel format means BGRA8: a mapper-ref-texture surface the guest
 /// mapped without a format word is scanout-ordered by the display contract, and
 /// this is the one place that default is written down.
 fn or_bgra8(pixel_format: u16) -> u16 {
@@ -3497,7 +3518,7 @@ fn or_bgra8(pixel_format: u16) -> u16 {
     }
 }
 
-/// Latched geometry and pixel format of a type-11 mapping, for a surface whose
+/// Latched geometry and pixel format of a mapper-ref-texture mapping, for a surface whose
 /// own IOSurface descriptor could not be read.
 ///
 /// Three separate descriptor failures share this fallback, and spelling it out at

--- a/crates/reims-vgpu/src/runtime/compute_exec/tests.rs
+++ b/crates/reims-vgpu/src/runtime/compute_exec/tests.rs
@@ -13,8 +13,8 @@ use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
 use crate::model::{DeviceId, PAGE_SHIFT_ARM64E, PAGE_SHIFT_X86};
 use crate::runtime::decode::compute;
 use crate::runtime::decode::resource::{
-    list_object_entry_offset, OBJECT_LIST_ENTRY_LEN, OBJECT_TYPE_BUFFER, OBJECT_TYPE_IOSURFACE,
-    RESOURCE_PAGE_SHIFT,
+    list_object_entry_offset, OBJECT_LIST_ENTRY_LEN, OBJECT_TYPE_BUFFER,
+    OBJECT_TYPE_MAPPER_REF_TEXTURE, RESOURCE_PAGE_SHIFT,
 };
 /// Compute-pipeline descriptor constants used by the backend execute test.
 #[cfg(any(
@@ -22,12 +22,13 @@ use crate::runtime::decode::resource::{
     all(feature = "backend-metal", target_os = "macos")
 ))]
 use crate::runtime::decode::resource::{
-    OBJECT_TYPE_FUNCTION, PIPELINE_TAG_KERNEL_FUNC, TYPE7_FIRST_TLVS, TYPE7_OBJECT_COMPUTE_PIPELINE,
+    OBJECT_TYPE_FUNCTION, PIPELINE_TAG_KERNEL_FUNC, SERIALIZER_OBJECT_COMPUTE_PIPELINE,
+    SERIALIZER_OBJECT_FIRST_TLVS,
 };
 use crate::runtime::gva_mem;
 use crate::runtime::gva_mem::write_task_gva_arm64e;
 use crate::runtime::host::FakeHost;
-use reims_vgpu_wire::device_desc::Type5Builder;
+use reims_vgpu_wire::device_desc::RefTextureBuilder;
 
 #[cfg(feature = "backend-vulkan")]
 #[test]
@@ -110,7 +111,7 @@ fn argument_buffer_reflection_decline_carries_the_owner_coordinate() {
     );
 }
 
-/// A type-5 view names its IOSurface plane on the wire (record `+0x20`, the
+/// A ref-texture view names its IOSurface plane on the wire (record `+0x20`, the
 /// `newTextureWithDescriptor:iosurface:plane:` argument). When two planes share
 /// geometry and bytes-per-element the geometry scan cannot separate them and
 /// falls back to inventing a packed window at offset 0 — which is the *first*
@@ -120,7 +121,7 @@ fn argument_buffer_reflection_decline_carries_the_owner_coordinate() {
 /// Shape is the live v0a8 (biplanar video + alpha) layout scaled down: plane 0
 /// and plane 2 are both R8 at identical dims, plane 1 is the RG8 chroma.
 #[test]
-fn stage_texture_type5_plane_index_beats_the_ambiguous_geometry_scan() {
+fn stage_texture_ref_texture_plane_index_beats_the_ambiguous_geometry_scan() {
     use crate::contract::endian::st16;
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_ALLOC_SIZE, DEVICE_DESC_LEN, DEVICE_DESC_PLANES, DEVICE_DESC_PLANE_COUNT,
@@ -141,7 +142,7 @@ fn stage_texture_type5_plane_index_beats_the_ambiguous_geometry_scan() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
+    let ref_texture_ref = 10u32;
     let pfn = 0x20u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0x5a);
@@ -176,28 +177,28 @@ fn stage_texture_type5_plane_index_beats_the_ambiguous_geometry_scan() {
     }
     assert!(state.set_mapping_device_desc(sid, &device_desc));
 
-    // 56-byte type-5 blob: 8-byte head, then kind/blob_len/own_ref and a 0x24
+    // 56-byte ref-texture blob: 8-byte head, then kind/blob_len/own_ref and a 0x24
     // record whose `+0x20` carries the plane index.
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E;
-    let type5_desc = Type5Builder::new(sid, 0, 10, 0x42)
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 10, 0x42)
         .unknown(0x01)
         .geometry(MTL_FORMAT_R8_UNORM, 4, 4, 1)
         .trailer([1, 0, 1, 0, 1, 0, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         // IOSurface plane index = 2 (alpha)
         .plane_index(2);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
-    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((type5_desc.len() as u32) << 8);
+    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((ref_texture_desc.len() as u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let staged = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 33, true)
-        .expect("a type-5 plane view over a mapped surface must stage");
+    let staged = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 33, true)
+        .expect("a ref-texture plane view over a mapped surface must stage");
     match staged.writeback {
-        TextureWriteback::Type11 {
+        TextureWriteback::MapperRefTexture {
             surface_offset,
             surface_bpr,
             ..
@@ -209,7 +210,9 @@ fn stage_texture_type5_plane_index_beats_the_ambiguous_geometry_scan() {
                  over plane 0 that the ambiguous geometry scan falls back to"
             );
         }
-        _ => panic!("a type-5 view over a surface mapping must write back as type-11"),
+        _ => panic!(
+            "a ref-texture view over a surface mapping must write back as mapper-ref-texture"
+        ),
     }
 }
 
@@ -701,8 +704,8 @@ fn a_compute_refusal_names_its_check_and_ok_names_nothing() {
         "an Ok must not be loggable — that is what keeps the sink clean"
     );
 
-    let st = ComputeStatus::MissingTexture("compute_stage_tex_type5_no_map");
-    assert_eq!(st.refusal(), Some("compute_stage_tex_type5_no_map"));
+    let st = ComputeStatus::MissingTexture("compute_stage_tex_ref_texture_no_map");
+    assert_eq!(st.refusal(), Some("compute_stage_tex_ref_texture_no_map"));
     assert_eq!(st.class(), "missing_texture");
     let line = Emit::refusal("compute_record", &st)
         .expect("a refusal renders a line")
@@ -710,7 +713,7 @@ fn a_compute_refusal_names_its_check_and_ok_names_nothing() {
         .render();
     assert_eq!(
         line,
-        "compute_record reason=compute_stage_tex_type5_no_map \
+        "compute_record reason=compute_stage_tex_ref_texture_no_map \
              class=missing_texture pipe=7"
     );
 
@@ -1070,18 +1073,18 @@ fn dispatch_buffer_kernel_mul3add1() {
     }
 
     let mut pdesc = vec![0u8; 32];
-    st32(&mut pdesc[0..], TYPE7_OBJECT_COMPUTE_PIPELINE);
+    st32(&mut pdesc[0..], SERIALIZER_OBJECT_COMPUTE_PIPELINE);
     st32(&mut pdesc[4..], 32); // declared descriptor length
-    pdesc[TYPE7_FIRST_TLVS] = 1;
-    pdesc[TYPE7_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
-    pdesc[TYPE7_FIRST_TLVS + 2] = 4;
-    st32(&mut pdesc[TYPE7_FIRST_TLVS + 3..], 5);
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS] = 1;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 2] = 4;
+    st32(&mut pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 3..], 5);
     let pdesc_gva = 0x140u64;
     write_task_gva_arm64e(&mut host, &state.tasks[1], pdesc_gva, &pdesc);
     {
         let off = list_object_entry_offset(6, 32).unwrap();
         let mut le = [0u8; OBJECT_LIST_ENTRY_LEN];
-        let packed = (OBJECT_TYPE_TYPE7 as u32) | (32u32 << 8);
+        let packed = (OBJECT_TYPE_SERIALIZER_OBJECT as u32) | (32u32 << 8);
         st32(&mut le[0..], packed);
         le[4..12].copy_from_slice(&pdesc_gva.to_le_bytes());
         write_task_gva_arm64e(&mut host, &state.tasks[1], off, &le);
@@ -1189,12 +1192,12 @@ fn dispatch_missing_texture_fails() {
     ));
 }
 
-/// Live CI wallpaper: type-5 RefTexture → type-4 surface_id must stage via
+/// Live CI wallpaper: ref-texture RefTexture → backing record_id must stage via
 /// ensure_surface + mapping (same order as the `runtime::draw` sample). Without
-/// ensure, stage fell through to type-2/3 with the type-5 ref → always
+/// ensure, stage fell through to normal-texture with the ref-texture ref → always
 /// MissingTexture (`compute_stage_tex … ot=5`).
 #[test]
-fn stage_texture_type5_ref_resolves_surface_mapping() {
+fn stage_texture_ref_texture_ref_resolves_surface_mapping() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{list_object_entry_offset, OBJECT_LIST_ENTRY_LEN};
@@ -1205,8 +1208,8 @@ fn stage_texture_type5_ref_resolves_surface_mapping() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
-    // Pre-mapped type-4 surface (CI storage target) with one valid page.
+    let ref_texture_ref = 10u32;
+    // Pre-mapped backing record (CI storage target) with one valid page.
     let pfn = 0x20u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0x5a);
@@ -1220,34 +1223,34 @@ fn stage_texture_type5_ref_resolves_surface_mapping() {
     }
     assert!(state.set_mapping_geom(sid, 4, 4, MTL_FORMAT_BGRA8_UNORM));
 
-    // Object-list: type-5 at ref 10 → surface_id=3 (mapping already seeded).
+    // Object-list: ref-texture at ref 10 → surface_id=3 (mapping already seeded).
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E; // data pfn base 4 + 2
-    let type5_desc = Type5Builder::new(sid, 0, 0, 0).with_len(16);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 0, 0).with_len(16);
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((16u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let staged = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, true)
-        .expect("type-5→surface stage must succeed after ensure");
+    let staged = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, true)
+        .expect("ref-texture→surface stage must succeed after ensure");
     assert_eq!((staged.width, staged.height), (4, 4));
     assert_eq!(staged.bytes.len(), 4 * 4 * 4);
     assert!(matches!(
         staged.writeback,
-        TextureWriteback::Type11 { mapping_id: 3, .. }
+        TextureWriteback::MapperRefTexture { mapping_id: 3, .. }
     ));
 }
 
-/// A type-5 record is the exact Metal view, even when its single-plane
+/// A ref-texture record is the exact Metal view, even when its single-plane
 /// backing already has valid base geometry. Live pipe 5 exposes each row
 /// of a 1920-wide BGRA8 surface as a 480-wide RGBA32Uint view so one
 /// `uint4` image write stores four packed BGRA pixels.
 #[test]
-fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
+fn stage_texture_ref_texture_record_reshapes_stageable_single_plane_surface() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
     use crate::contract::pixel_format::{
         StorageImageSelector, MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_R32_UINT, MTL_FORMAT_RGBA32_UINT,
@@ -1260,7 +1263,7 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
+    let ref_texture_ref = 10u32;
     let pfn = 0x20u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0x5a);
@@ -1276,21 +1279,21 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
 
     // Same 16 bytes per logical row: 4 BGRA8 texels = one RGBA32Uint texel.
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E;
-    let type5_desc = Type5Builder::new(sid, 0, 10, 0x42)
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 10, 0x42)
         .unknown(0x02)
         .geometry(MTL_FORMAT_RGBA32_UINT, 1, 4, 1)
         .trailer([1, 0, 1, 0, 1, 0, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
-    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((type5_desc.len() as u32) << 8);
+    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((ref_texture_desc.len() as u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let staged = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 33, true)
-        .expect("serialized type-5 view must override base surface geometry");
+    let staged = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 33, true)
+        .expect("serialized ref-texture view must override base surface geometry");
     assert_eq!((staged.width, staged.height), (1, 4));
     assert_eq!(
         staged.storage_selector,
@@ -1299,7 +1302,7 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
     assert_eq!(staged.bytes.len(), 4 * 16);
     assert!(staged.bytes.iter().all(|&b| b == 0x5a));
     match staged.writeback {
-        TextureWriteback::Type11 {
+        TextureWriteback::MapperRefTexture {
             mapping_id,
             surface_bpr,
             width,
@@ -1312,7 +1315,7 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
             assert_eq!((width, height), (1, 4));
             assert_eq!(pixel_format::bytes_per_pixel(format), Some(16));
         }
-        _ => panic!("expected Type11 writeback through the texture view"),
+        _ => panic!("expected MapperRefTexture writeback through the texture view"),
     }
 
     // A sampled R32Uint view retains its exact format/geometry. R32Uint is
@@ -1320,12 +1323,12 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
     // path), so `storage_selector` is populated — but it is inert here: this
     // view is staged sampled (`is_storage=false`, binding 32), and the
     // selector is only consulted on the storage-bind path.
-    let reshaped = Type5Builder::new(sid, 0, 10, 0x42)
+    let reshaped = RefTextureBuilder::new(sid, 0, 10, 0x42)
         .unknown(0x02)
         .geometry(MTL_FORMAT_R32_UINT, 4, 4, 1)
         .trailer([1, 0, 1, 0, 1, 0, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, reshaped.bytes());
-    let sampled = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, false)
+    let sampled = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, false)
         .expect("sample-only R32Uint view must stage from the same IOSurface bytes");
     assert_eq!((sampled.width, sampled.height), (4, 4));
     assert_eq!(sampled.pixel_format, MTL_FORMAT_R32_UINT);
@@ -1337,12 +1340,12 @@ fn stage_texture_type5_record_reshapes_stageable_single_plane_surface() {
     assert!(matches!(sampled.writeback, TextureWriteback::None));
 }
 
-/// Biplanar surface (device_desc plane_count=2) + type-5 args plane record:
+/// Biplanar surface (device_desc plane_count=2) + ref-texture args plane record:
 /// stage the named plane view (R8 Y) from the plane offset — live class
-/// `compute_dispatch st=Unsupported` / `type11_fail reason=multiplane`
+/// `compute_dispatch st=Unsupported` / `mapper_ref_texture_fail reason=multiplane`
 /// (wallpaper '420f', journal 2026-07-14 compute census).
 #[test]
-fn stage_texture_type5_record_stages_biplanar_y_plane() {
+fn stage_texture_ref_texture_record_stages_biplanar_y_plane() {
     use crate::contract::endian::{st16, st64};
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_ALLOC_SIZE, DEVICE_DESC_LEN, DEVICE_DESC_PLANES, DEVICE_DESC_PLANE_COUNT,
@@ -1360,7 +1363,7 @@ fn stage_texture_type5_record_stages_biplanar_y_plane() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
+    let ref_texture_ref = 10u32;
     let pfn = 0x20u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0x77);
@@ -1399,22 +1402,22 @@ fn stage_texture_type5_record_stages_biplanar_y_plane() {
         state.mappings.get(&sid).unwrap()
     ));
 
-    // Type-5 descriptor: sid + args blob carrying the R8 16×8 plane record.
+    // Ref-texture descriptor: sid + args blob carrying the R8 16×8 plane record.
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E;
     // tag, unk, fmt=R8
-    let type5_desc = Type5Builder::new(sid, 0, 10, 0x42)
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 10, 0x42)
         .unknown(0x01)
         .geometry(0x0a, 16, 8, 1);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
-    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((type5_desc.len() as u32) << 8);
+    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((ref_texture_desc.len() as u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let staged = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, true)
+    let staged = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, true)
         .expect("plane record must stage the Y plane of a biplanar surface");
     assert_eq!((staged.width, staged.height), (16, 8));
     assert_eq!(
@@ -1424,7 +1427,7 @@ fn stage_texture_type5_record_stages_biplanar_y_plane() {
     assert_eq!(staged.bytes.len(), 16 * 8);
     assert!(staged.bytes.iter().all(|&b| b == 0x77));
     match staged.writeback {
-        TextureWriteback::Type11 {
+        TextureWriteback::MapperRefTexture {
             mapping_id,
             surface_offset,
             surface_bpr,
@@ -1434,10 +1437,10 @@ fn stage_texture_type5_record_stages_biplanar_y_plane() {
             assert_eq!(surface_offset, 0);
             assert_eq!(surface_bpr, 64);
         }
-        _ => panic!("expected Type11 writeback"),
+        _ => panic!("expected MapperRefTexture writeback"),
     }
-    let sampled = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, false)
-        .expect("sampled type-5 plane must stage without writeback");
+    let sampled = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, false)
+        .expect("sampled ref-texture plane must stage without writeback");
     assert!(!sampled.is_storage);
     assert!(matches!(sampled.writeback, TextureWriteback::None));
     let _ = MTL_FORMAT_R8_UNORM;
@@ -1446,7 +1449,7 @@ fn stage_texture_type5_record_stages_biplanar_y_plane() {
 /// Biplanar surface **without** a plane record still fails closed
 /// (no BGRA invent over multi-plane bytes).
 #[test]
-fn stage_texture_type5_multiplanar_without_record_fails_closed() {
+fn stage_texture_ref_texture_multiplanar_without_record_fails_closed() {
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_LEN, DEVICE_DESC_PLANE_COUNT, PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID,
     };
@@ -1458,7 +1461,7 @@ fn stage_texture_type5_multiplanar_without_record_fails_closed() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
+    let ref_texture_ref = 10u32;
     let pfn = 0x20u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0x5a);
@@ -1478,19 +1481,19 @@ fn stage_texture_type5_multiplanar_without_record_fails_closed() {
         m.format = 0;
     }
 
-    // Type-5 descriptor with sid but NO args record.
+    // Ref-texture descriptor with sid but NO args record.
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E;
-    let type5_desc = Type5Builder::new(sid, 0, 0, 0).with_len(8);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 0, 0).with_len(8);
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
-    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((type5_desc.len() as u32) << 8);
+    let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((ref_texture_desc.len() as u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    match stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, true) {
+    match stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, true) {
         Err(ComputeStatus::Unsupported(_)) => {}
         Err(other) => panic!("expected Unsupported, got {other:?}"),
         Ok(_) => panic!("multiplanar without plane record must fail closed"),
@@ -1619,7 +1622,7 @@ fn stage_heap_texture_uses_host_only_residency_identity() {
 
 #[cfg(feature = "backend-vulkan")]
 /// UnmapMemory removes the guest page-table alias, not the discrete
-/// type-2/3 texture body. Compute writeback must retain raw output, mirror
+/// normal texture body. Compute writeback must retain raw output, mirror
 /// normalized color for render sampling, and complete without attempting
 /// a fail-closed write into freed guest pages.
 #[test]
@@ -1704,12 +1707,12 @@ fn compute_stage_admits_full_screen_wide_gamut_without_cap() {
     );
 }
 
-/// Type-5 surface id must not be re-resolved through this task's object
+/// Ref-texture surface id must not be re-resolved through this task's object
 /// list: slot `sid` can be a different texture-ref object (id collision).
-/// Live class: ensure=1 then MissingTexture when resolve_type11_ref(task,sid)
+/// Live class: ensure=1 then MissingTexture when resolve_mapper_ref_texture(task,sid)
 /// returned the wrong mapping.
 #[test]
-fn stage_texture_type5_ignores_task_object_list_slot_collision() {
+fn stage_texture_ref_texture_ignores_task_object_list_slot_collision() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{list_object_entry_offset, OBJECT_LIST_ENTRY_LEN};
@@ -1720,7 +1723,7 @@ fn stage_texture_type5_ignores_task_object_list_slot_collision() {
     assert!(state.set_object_list(1, 0, 32));
 
     let sid = 3u32;
-    let type5_ref = 10u32;
+    let ref_texture_ref = 10u32;
     let pfn = 0x21u32;
     let gpa = (pfn as u64) << PAGE_SHIFT_ARM64E;
     host.map_range(gpa, 0x4000, 0xa5);
@@ -1734,45 +1737,45 @@ fn stage_texture_type5_ignores_task_object_list_slot_collision() {
     }
     assert!(state.set_mapping_geom(sid, 4, 4, MTL_FORMAT_BGRA8_UNORM));
 
-    // Poison: object-list slot `sid` is type-11 with mapping_id=99 (not mapped).
-    // Pre-fix path would resolve_type11_ref(task, sid) → 99 → MissingTexture.
+    // Poison: object-list slot `sid` is mapper-ref-texture with mapping_id=99 (not mapped).
+    // Pre-fix path would resolve_mapper_ref_texture(task, sid) → 99 → MissingTexture.
     let poison_desc_gva = (4u64 + 1) << PAGE_SHIFT_ARM64E;
     let mut iosurf = vec![0u8; 64];
     st32(&mut iosurf[0..], 99); // fake mapping_id
     write_task_gva_arm64e(&mut host, &state.tasks[1], poison_desc_gva, &iosurf);
     let off_sid = list_object_entry_offset(sid, 32).unwrap();
     let mut le_sid = [0u8; OBJECT_LIST_ENTRY_LEN];
-    // type-11 = OBJECT_TYPE_IOSURFACE
-    let packed_t11 = (OBJECT_TYPE_IOSURFACE as u32) | ((64u32) << 8);
+    // mapper-ref-texture = OBJECT_TYPE_MAPPER_REF_TEXTURE
+    let packed_t11 = (OBJECT_TYPE_MAPPER_REF_TEXTURE as u32) | ((64u32) << 8);
     st32(&mut le_sid[0..], packed_t11);
     le_sid[4..12].copy_from_slice(&poison_desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off_sid, &le_sid);
 
-    // type-5 at ref 10 → surface_id 3
+    // ref-texture at ref 10 → surface_id 3
     let desc_gva = (4u64 + 2) << PAGE_SHIFT_ARM64E;
-    let type5_desc = Type5Builder::new(sid, 0, 0, 0).with_len(16);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 0, 0).with_len(16);
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((16u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let staged = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, true)
-        .expect("type-5 must stage mapping sid, not poisoned type-11 slot");
+    let staged = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, true)
+        .expect("ref-texture must stage mapping sid, not poisoned mapper-ref-texture slot");
     assert_eq!((staged.width, staged.height), (4, 4));
     assert!(matches!(
         staged.writeback,
-        TextureWriteback::Type11 { mapping_id: 3, .. }
+        TextureWriteback::MapperRefTexture { mapping_id: 3, .. }
     ));
 }
 
-/// Type-5 whose surface_id never maps must fail MissingTexture (not pretend
-/// type-2/3 success).
+/// Ref-texture whose surface_id never maps must fail MissingTexture (not pretend
+/// normal-texture success).
 #[test]
-fn stage_texture_type5_without_surface_is_missing() {
+fn stage_texture_ref_texture_without_surface_is_missing() {
     use crate::runtime::decode::resource::{list_object_entry_offset, OBJECT_LIST_ENTRY_LEN};
 
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -1780,20 +1783,20 @@ fn stage_texture_type5_without_surface_is_missing() {
     gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 8);
     assert!(state.set_object_list(1, 0, 32));
 
-    let type5_ref = 11u32;
+    let ref_texture_ref = 11u32;
     let sid = 99u32; // no mapping
     let desc_gva = (4u64 + 3) << PAGE_SHIFT_ARM64E;
-    let type5_desc = Type5Builder::new(sid, 0, 0, 0).with_len(16);
-    let type5_desc = type5_desc.bytes();
-    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, type5_desc);
-    let off = list_object_entry_offset(type5_ref, 32).unwrap();
+    let ref_texture_desc = RefTextureBuilder::new(sid, 0, 0, 0).with_len(16);
+    let ref_texture_desc = ref_texture_desc.bytes();
+    write_task_gva_arm64e(&mut host, &state.tasks[1], desc_gva, ref_texture_desc);
+    let off = list_object_entry_offset(ref_texture_ref, 32).unwrap();
     let mut list_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     let packed = (objects::OBJECT_TYPE_REF_TEXTURE as u32) | ((16u32) << 8);
     st32(&mut list_entry[0..], packed);
     list_entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &list_entry);
 
-    let st = stage_texture_raw(&mut state, &mut host, 1, type5_ref, 32, false);
+    let st = stage_texture_raw(&mut state, &mut host, 1, ref_texture_ref, 32, false);
     assert!(matches!(st, Err(ComputeStatus::MissingTexture(_))));
 }
 
@@ -2320,7 +2323,7 @@ fn a_staged_buffer_carries_the_pages_its_writeback_is_bounded_to() {
 ///
 /// Both destination shapes have one, and the shapes differ only in which licence
 /// answers — a guest-linear plane goes to `licence_gva_plane` and a tiled surface
-/// mapping to `licence_type11_surface`. Residency is not a shape at all: a
+/// mapping to `licence_mapper_ref_texture_surface`. Residency is not a shape at all: a
 /// registered resident is a perfectly good source for a copy, and
 /// what holds it across a submitted-not-waited copy is the engine's pin, taken
 /// where the write debt is armed and released from the ring slot's cleanup.
@@ -2336,7 +2339,7 @@ fn a_staged_buffer_carries_the_pages_its_writeback_is_bounded_to() {
 /// identically to one an earlier gate caught. The census route is what
 /// distinguishes them, so each case is asserted on its own counter.
 ///
-/// The type-11 cases assert the thing that is easiest to regress back to. That
+/// The mapper-ref-texture cases assert the thing that is easiest to regress back to. That
 /// class was the largest this arm did not reach — 35 of the 51 storage
 /// destinations of a driven macos-13 boot — and the reason was a `return` on the
 /// destination's *shape*, before anything about the surface had been asked. A
@@ -2411,11 +2414,11 @@ fn a_licence_and_not_the_destinations_shape_decides_the_direct_arm() {
         "the licence refusal is the gate that caught it"
     );
 
-    // A type-11 destination is not a guest-linear plane at all. It is also the
+    // A mapper-ref-texture destination is not a guest-linear plane at all. It is also the
     // largest class this arm does not reach, so the same call must band whether
     // a raw copy could ever have served it — the route counter says how many
     // there are and the split says how many are reachable.
-    let type11 = |mapping_id, format| TextureWriteback::Type11 {
+    let mapper_ref_texture = |mapping_id, format| TextureWriteback::MapperRefTexture {
         mapping_id,
         surface_offset: 0,
         surface_bpr: 8,
@@ -2424,7 +2427,7 @@ fn a_licence_and_not_the_destinations_shape_decides_the_direct_arm() {
         height: 2,
         format,
     };
-    let unlicensed = || store_route_count("compute_dst_host_type11_unlicensed");
+    let unlicensed = || store_route_count("compute_dst_host_mapper_ref_texture_unlicensed");
     for mapping_id in [1, 2] {
         state.mappings.insert(
             mapping_id,
@@ -2442,7 +2445,7 @@ fn a_licence_and_not_the_destinations_shape_decides_the_direct_arm() {
     // serve it; mapping 2 is staged at a different one, and a copy converts
     // nothing, so no licence could land it however the pages resolve. The format
     // that decides is the bind's own, not the mapping's declaration — the bind
-    // may be a type-5 view reinterpreting the surface, and the staged format is
+    // may be a ref-texture view reinterpreting the surface, and the staged format is
     // the one both the seeding read and the landing write are arithmetic over.
     //
     // Mapping 3 is never registered, so there is nothing to write into.
@@ -2464,16 +2467,16 @@ fn a_licence_and_not_the_destinations_shape_decides_the_direct_arm() {
             is_host(&direct_destination(
                 &mut state,
                 &mut host,
-                &staged(type11(mapping_id, format), None),
+                &staged(mapper_ref_texture(mapping_id, format), None),
                 held,
             )),
-            "no guest-RAM import, so every type-11 licence is refused here"
+            "no guest-RAM import, so every mapper-ref-texture licence is refused here"
         );
     }
     assert_eq!(
         unlicensed(),
         before + 3,
-        "the type-11 licence is what refused, not the destination's shape"
+        "the mapper-ref-texture licence is what refused, not the destination's shape"
     );
     // A delta and not an absolute: these counters are process-global and this
     // suite runs serially in one binary, so a zero read absolutely would be
@@ -2481,7 +2484,7 @@ fn a_licence_and_not_the_destinations_shape_decides_the_direct_arm() {
     assert_eq!(
         store_route_count("compute_dst_host_not_linear"),
         not_linear,
-        "a type-11 destination is no longer turned away for not being linear"
+        "a mapper-ref-texture destination is no longer turned away for not being linear"
     );
 
     // And the case this test exists for: a resident window is routed on its
@@ -2957,7 +2960,7 @@ fn a_sampled_image_the_kernel_uses_and_the_guest_left_empty_gets_a_neutral_textu
 }
 
 /// A buffer-backed texture (opcode 9) bound to a compute *read* is staged from
-/// the type-1 buffer's own bytes, de-pitched to tight rows in its native
+/// the buffer's own bytes, de-pitched to tight rows in its native
 /// format.
 ///
 /// This arm refused the whole wire form until now, while `runtime::draw`
@@ -3002,7 +3005,7 @@ fn a_buffer_backed_texture_stages_its_texels_without_the_row_padding() {
     let buf_gva = 5u64 << RESOURCE_PAGE_SHIFT;
     write_task_gva_arm64e(&mut host, &state.tasks[1], buf_gva, &pixels);
 
-    // Type-1 buffer object naming that storage.
+    // Buffer buffer object naming that storage.
     let mut bdesc = vec![0u8; 16];
     st64(&mut bdesc[0..], (PITCH * H_ROWS) as u64);
     st32(&mut bdesc[8..], 5);
@@ -3016,7 +3019,7 @@ fn a_buffer_backed_texture_stages_its_texels_without_the_row_padding() {
         write_task_gva_arm64e(&mut host, &state.tasks[1], off, &le);
     }
 
-    // Type-8 buffer-backed texture record over it.
+    // Texture-view buffer-backed texture record over it.
     let mut body = vec![0u8; crate::runtime::heap_query::WIDE_TEXTURE_BODY_LEN];
     body[std::mem::offset_of!(W, type_and_flags)] = 0x02; // 2D
     st16(
@@ -3158,7 +3161,7 @@ fn a_declared_mip_chain_stages_every_level_and_not_only_its_base() {
     let allocation_size = image.len() as u64;
     write_task_gva_arm64e(&mut host, &state.tasks[1], base_gva, &image);
 
-    // The type-2 descriptor that declares it: geometry prefix for level 0 and
+    // The texture descriptor that declares it: geometry prefix for level 0 and
     // one 36-byte record for each level after it.
     let desc_len =
         TEXTURE_DESC_BASE_LEN + (LEVELS as usize - 1) * TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;

--- a/crates/reims-vgpu/src/runtime/compute_exec/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/compute_exec/vulkan.rs
@@ -94,10 +94,10 @@ impl crate::observe::Decline for NeutralSampledImage {
 ///
 /// Two conditions, and each names a contract term rather than an observation:
 ///
-/// - the writeback must be a **guest-linear plane**. A type-11 destination is a
+/// - the writeback must be a **guest-linear plane**. A mapper-ref-texture destination is a
 ///   tiled surface mapping, which [`crate::runtime::render_writeback::vulkan::GvaPlaneDestination`]
 ///   cannot describe and the licence therefore cannot walk. It is the largest
-///   class this arm does not reach, so [`note_type11_shape`] bands how much of
+///   class this arm does not reach, so [`note_mapper_ref_texture_shape`] bands how much of
 ///   it a raw copy could ever serve — see that function for why the route
 ///   counter alone does not say.
 /// - the licence must be granted. That is where the format, the complete page
@@ -135,7 +135,7 @@ pub(super) fn direct_destination<M: HostMemory + HostOps>(
         ..
     } = &tex.writeback
     else {
-        return type11_destination(state, host, tex, held);
+        return mapper_ref_texture_destination(state, host, tex, held);
     };
     let Ok(row_stride) = u32::try_from(*row_stride) else {
         crate::runtime::drain::note_store_route("compute_dst_host_stride_width");
@@ -187,7 +187,7 @@ pub(super) fn direct_destination<M: HostMemory + HostOps>(
     }
 }
 
-/// [`direct_destination`] for a type-11 surface mapping.
+/// [`direct_destination`] for a mapper-ref-texture surface mapping.
 ///
 /// A tiled surface mapping is not a guest-linear plane and the GVA licence
 /// cannot describe one — but it is not therefore unreachable, and treating it as
@@ -198,21 +198,21 @@ pub(super) fn direct_destination<M: HostMemory + HostOps>(
 /// The destination that *can* describe it already existed on the render rail,
 /// resolving the sample window, walking the mapping's page entries and building
 /// the same [`crate::backend::vulkan::engine::GuestPageTarget`] this rail wants.
-/// It is now [`crate::runtime::mapping_write::vulkan::licence_type11_surface`] and both
+/// It is now [`crate::runtime::mapping_write::vulkan::licence_mapper_ref_texture_surface`] and both
 /// rails ask it, so the surface geometry, the format rule, the page walk and the
 /// guest-RAM references have one spelling rather than two.
 ///
 /// Every decline is a routing answer on the `OFF` channel, not a loss: readback
 /// lands identical bytes, and on a host without the guest-RAM import it is the
 /// only rail there is.
-pub(super) fn type11_destination<M: HostMemory + HostOps>(
+pub(super) fn mapper_ref_texture_destination<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     tex: &StagedTexture,
     held: ash::vk::Format,
 ) -> crate::backend::vulkan::engine::ComputeImageDestination {
     use crate::backend::vulkan::engine::ComputeImageDestination;
-    let TextureWriteback::Type11 {
+    let TextureWriteback::MapperRefTexture {
         mapping_id,
         surface_offset,
         surface_bpr,
@@ -229,14 +229,14 @@ pub(super) fn type11_destination<M: HostMemory + HostOps>(
         return ComputeImageDestination::Host;
     };
     // The window this bind staged against, not one resolved here. It is already
-    // plane-correct for a type-5 view and already a sub-rectangle where the
+    // plane-correct for a ref-texture view and already a sub-rectangle where the
     // dispatch writes one, and it is the same window the readback rail lands
     // through — so the two rails cannot name different bytes of one surface.
-    match crate::runtime::mapping_write::vulkan::licence_type11_surface(
+    match crate::runtime::mapping_write::vulkan::licence_mapper_ref_texture_surface(
         state,
         host,
         held,
-        &crate::runtime::mapping_write::vulkan::Type11SurfaceDestination {
+        &crate::runtime::mapping_write::vulkan::MapperRefTextureSurfaceDestination {
             mapping_id: *mapping_id,
             base_off: *surface_offset,
             bpr: *surface_bpr,
@@ -249,9 +249,9 @@ pub(super) fn type11_destination<M: HostMemory + HostOps>(
         Ok(licence) => {
             crate::runtime::drain::note_store_route("compute_dst_guest_pages");
             crate::runtime::drain::note_store_route(if tex.residency.is_some() {
-                "compute_dst_guest_pages_type11_resident"
+                "compute_dst_guest_pages_mapper_ref_texture_resident"
             } else {
-                "compute_dst_guest_pages_type11_transient"
+                "compute_dst_guest_pages_mapper_ref_texture_transient"
             });
             ComputeImageDestination::GuestPages {
                 target: Box::new(licence.target),
@@ -266,10 +266,12 @@ pub(super) fn type11_destination<M: HostMemory + HostOps>(
             // nothing — and no copy can serve those, so a boot where it is most
             // of this counter is this arm working rather than failing.
             crate::observe::off(format!(
-                "compute_dst_type11 bind={} mid={mapping_id} dims={width}x{height} held={held:?} reason={decline:?}",
+                "compute_dst_mapper_ref_texture bind={} mid={mapping_id} dims={width}x{height} held={held:?} reason={decline:?}",
                 tex.binding
             ));
-            crate::runtime::drain::note_store_route("compute_dst_host_type11_unlicensed");
+            crate::runtime::drain::note_store_route(
+                "compute_dst_host_mapper_ref_texture_unlicensed",
+            );
             ComputeImageDestination::Host
         }
     }
@@ -422,7 +424,7 @@ pub(crate) fn resident_serve(
 /// Stages buffers/textures with device `page_shift`, translates the kernel AIR
 /// via [`crate::runtime::m2v_cache::translate_cached_kernel_reflected`], dispatches on the
 /// process-global [`crate::backend::vulkan::engine`] (shared GRAPHICS|COMPUTE
-/// device), then writebacks GVA / type-11.
+/// device), then writebacks GVA / mapper-ref-texture.
 ///
 /// Nested/ICB/stage-in stay Unsupported (engine surface is storage buffers +
 /// storage images only).
@@ -1308,15 +1310,15 @@ pub(crate) fn execute_dispatch_linux<M: HostMemory + HostOps>(
                     // destination owes exactly the same set. Both call it.
                     //
                     // The offsets are the staged ones rather than the licence's,
-                    // and they are the same offsets: `licence_type11_surface`
-                    // resolves the window through `type11_sample_window`, which
+                    // and they are the same offsets: `licence_mapper_ref_texture_surface`
+                    // resolves the window through `mapper_ref_texture_sample_window`, which
                     // is where these came from when the texture was staged.
-                    TextureWriteback::Type11 {
+                    TextureWriteback::MapperRefTexture {
                         mapping_id,
                         surface_offset,
                         span_end,
                         ..
-                    } => crate::runtime::mapping_write::vulkan::note_type11_landed(
+                    } => crate::runtime::mapping_write::vulkan::note_mapper_ref_texture_landed(
                         state,
                         *mapping_id,
                         *surface_offset,

--- a/crates/reims-vgpu/src/runtime/compute_session/mod.rs
+++ b/crates/reims-vgpu/src/runtime/compute_session/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! ## ICB (`0xe4` / `0xe5`)
 //!
-//! Type-7 tag `0x36` materializes a host `MTLIndirectCommandBuffer` (cached per
+//! Serializer-object tag `0x36` materializes a host `MTLIndirectCommandBuffer` (cached per
 //! task/ref). Command fills use the host Metal fill API in
 //! [`crate::runtime::icb`] — the stream carries no fill opcodes. Execute
 //! applies **parent-encoder inheritance** from stream [`ComputeAccum`] (Metal:
@@ -401,8 +401,8 @@ mod tests {
         use crate::runtime::compute_exec::ComputeBufferBind;
         use crate::runtime::decode::compute::Size3;
         use crate::runtime::decode::resource::{
-            OBJECT_TYPE_FUNCTION, OBJECT_TYPE_TYPE7, PIPELINE_TAG_KERNEL_FUNC, TYPE7_FIRST_TLVS,
-            TYPE7_OBJECT_COMPUTE_PIPELINE,
+            OBJECT_TYPE_FUNCTION, OBJECT_TYPE_SERIALIZER_OBJECT, PIPELINE_TAG_KERNEL_FUNC,
+            SERIALIZER_OBJECT_COMPUTE_PIPELINE, SERIALIZER_OBJECT_FIRST_TLVS,
         };
         use std::path::PathBuf;
 
@@ -454,18 +454,18 @@ mod tests {
             write_task_gva_arm64e(&mut host, &state.tasks[1], off, &le);
         }
         let mut pdesc = vec![0u8; 32];
-        st32(&mut pdesc[0..], TYPE7_OBJECT_COMPUTE_PIPELINE);
+        st32(&mut pdesc[0..], SERIALIZER_OBJECT_COMPUTE_PIPELINE);
         st32(&mut pdesc[4..], 32);
-        pdesc[TYPE7_FIRST_TLVS] = 1;
-        pdesc[TYPE7_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
-        pdesc[TYPE7_FIRST_TLVS + 2] = 4;
-        st32(&mut pdesc[TYPE7_FIRST_TLVS + 3..], 5);
+        pdesc[SERIALIZER_OBJECT_FIRST_TLVS] = 1;
+        pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
+        pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 2] = 4;
+        st32(&mut pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 3..], 5);
         let pdesc_gva = 0x180u64;
         write_task_gva_arm64e(&mut host, &state.tasks[1], pdesc_gva, &pdesc);
         {
             let off = list_object_entry_offset(6, 32).unwrap();
             let mut le = [0u8; OBJECT_LIST_ENTRY_LEN];
-            let packed = (OBJECT_TYPE_TYPE7 as u32) | (32u32 << 8);
+            let packed = (OBJECT_TYPE_SERIALIZER_OBJECT as u32) | (32u32 << 8);
             st32(&mut le[0..], packed);
             le[4..12].copy_from_slice(&pdesc_gva.to_le_bytes());
             write_task_gva_arm64e(&mut host, &state.tasks[1], off, &le);

--- a/crates/reims-vgpu/src/runtime/decode/render/mod.rs
+++ b/crates/reims-vgpu/src/runtime/decode/render/mod.rs
@@ -591,7 +591,7 @@ impl From<ColorAttachment> for AttachSubresource {
 /// second predicate. The colour rail materializes a level's own plane inside the
 /// guest allocation — `TextureDescriptor::level_gva` gives its address, stride
 /// and geometry, and `render_target`'s linear rung has rendered into one since
-/// type-8 mip views existed. The depth/stencil rail has no such rung: it would
+/// texture-view mip views existed. The depth/stencil rail has no such rung: it would
 /// bind level 0 and the guest would read a level it never wrote.
 ///
 /// Making it an enum rather than a `bool` is the point — an arm has to say which
@@ -606,10 +606,9 @@ pub enum LevelSupport {
 
 /// Whether this device can honour an attachment's subresource as decoded.
 ///
-/// Slice 0, plane 0, no multisample resolve for callers using this predicate,
-/// and a level the caller's rail can reach. `slice` and `depth_plane` joined the test when they became decodable:
-/// a depth buffer bound at slice 5 was previously read as slice 0 and silently
-/// accepted.
+/// Slice 0, plane 0, no multisample resolve for callers using this predicate, and a level the
+/// caller's rail can reach. `slice` and `depth_plane` joined the test when they became decodable: a
+/// depth buffer bound at slice 5 was previously read as slice 0 and silently accepted.
 ///
 /// It lives beside the structs it reads because four arms apply it — the stream
 /// decode that admits an attachment into a pass, once per aspect, and the Metal
@@ -824,13 +823,12 @@ pub struct Command {
 /// `reims_vgpu_wire`'s manifest rather than from observation.
 /// An opcode inside the accepted window that no decode arm claims.
 ///
-/// Two tests need one -- this module's catch-all test and `runtime::exec`'s
-/// fail-visible test -- and both used to hardcode it. Both went stale, twice:
-/// `wire::OPCODE_SET_VERTEX_BUFFER_OFFSET_STRIDE` stopped working when that bound was corrected to `0xa6`,
-/// and its replacement `0x99` lasted one commit until
-/// `setVertexAmplificationMode:value:` turned out to be exactly that number.
-/// Searching keeps them honest as arms are added, because what they test is
-/// that the catch-all exists and reports, not that any number is in it.
+/// Two tests need one -- this module's catch-all test and `runtime::exec`'s fail-visible test --
+/// and both used to hardcode it. Both went stale, twice:
+/// `wire::OPCODE_SET_VERTEX_BUFFER_OFFSET_STRIDE` stopped working when that bound was corrected to
+/// `0xa6`, and its replacement `0x99` lasted one commit until `setVertexAmplificationMode:value:`
+/// turned out to be exactly that number. Searching keeps them honest as arms are added, because
+/// what they test is that the catch-all exists and reports, not that any number is in it.
 #[cfg(test)]
 pub(crate) fn unclaimed_accepted_opcode() -> u32 {
     (0..=wire::OPCODE_SET_VERTEX_BUFFER_OFFSET_STRIDE)

--- a/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/mod.rs
@@ -19,7 +19,7 @@ use reims_vgpu_wire::OP_HEADER_LEN as OP_HDR;
 /// here means some object the guest created is unusable everywhere. The payload
 /// is the registered slug naming which check refused: **29 of the 40 sites were
 /// `ErrShort`**, one name for twenty-nine different reads, from a 12-byte
-/// object-list entry to a vertex-attribute table offset inside a type-7 body.
+/// object-list entry to a vertex-attribute table offset inside a serializer-object body.
 ///
 /// Slugs carry a `res_` prefix. Six modules under `runtime/decode/` define a
 /// type called `DecodeStatus` and five of them have an `ErrShort` meaning a
@@ -68,30 +68,75 @@ impl crate::observe::Decline for DecodeStatus {
     }
 }
 
-/// Live object-list type tags (`reims_vgpu_resource_decode.h` / arm contract).
+/// Live object-list type tags: Apple's `APVObjectType`.
 ///
-/// Type 3 carries the same geometry prefix as type 2 (WindowServer composite
-/// and glyph sources); type 7 is the container for sampler, depth-stencil and
-/// render/compute pipeline descriptors.
+/// The enum name is Apple's own — it appears in the mangled symbol
+/// `AppleParavirtResourceHeap::addObject(APVObjectType, unsigned int, unsigned
+/// int, void const*)`, the one function that writes an object-list entry. Each
+/// tag below is the constant that reaches that call, read from the guest driver
+/// the device actually faces, and cross-checked against the tag the host side
+/// dispatches on in `PGResourceManager::createObject`.
+///
+/// **The tag space is shared but the rails use disjoint halves**, because the
+/// two guests load different drivers: an x86 guest loads `AppleParavirtGPU`
+/// (IOAccelerator), an arm64 guest loads `AppleParavirtGPUIOGPUFamily`. That is
+/// why nothing here ever sees a backing (4) on arm or a mapper-ref texture (11)
+/// on x86, and why neither absence is a decode gap.
+///
+/// | Tag | Guest assigns it in | Host builds | Rail |
+/// |---|---|---|---|
+/// | 1 | `allocateBufferHandle` | `createBuffer` | both |
+/// | 2 | `allocateTextureHandle` | `createNormalTexture` | both |
+/// | 3 | `allocateTextureHandle` | `createNormalTexture`, `_generateMipmaps` | both |
+/// | 4 | `allocateBackingHandle` | `createBacking` | x86 |
+/// | 5 | `allocateRefTextureHandle` | `createBackingRefTexture` | x86 |
+/// | 6 | `createFunction` | `createObject<id<MTLFunction>>` | both |
+/// | 7 | `createObjectInternal` | `createObject<T>`, `T` by subtype | both |
+/// | 8 | `addChildResource` | `createSerializerTexture` | both |
+/// | 11 | `allocateMapperRefTextureHandle` | `createMapperRefTexture` | arm |
+/// | 12 | `allocateTextureHandle` | `createNormalTexture`, dual-plane | arm |
+/// | 13, 14, 15 | heap, heap buffer, mapper-ref buffer | `createHeap*`, `createMapperRefBuffer` | arm |
+///
+/// **2 and 3 differ only in who builds the mip chain.** Both are one
+/// `APVObjectTexture` and both land on `PGSinglePlaneTextureResource`; the host
+/// sets that resource's `_generateMipmaps` exactly when the tag is 3, and then
+/// reads **one** 36-byte level record instead of the count the descriptor's
+/// leading 14-bit field states. So a 3 is a texture whose base level the guest
+/// describes and whose remaining levels the host generates — not a "variant",
+/// and not a different layout. Identical in Ventura and in the current host.
+///
+/// Tag 11 is a *mapper* ref texture: the guest reaches it through
+/// `IOSurfaceParavirtMapperService`, which is why its descriptor names a
+/// mapping rather than pages, and why the host class that owns it
+/// (`PGMapperRefTextureResource`) keys on `_mappingID`.
 pub const OBJECT_TYPE_BUFFER: u8 = 1;
 pub const OBJECT_TYPE_TEXTURE: u8 = 2;
-pub const OBJECT_TYPE_TEXTURE_VARIANT: u8 = 3;
+pub const OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS: u8 = 3;
 pub const OBJECT_TYPE_FUNCTION: u8 = 6;
-pub const OBJECT_TYPE_TYPE7: u8 = 7;
+pub const OBJECT_TYPE_SERIALIZER_OBJECT: u8 = 7;
 pub const OBJECT_TYPE_TEXTURE_VIEW: u8 = 8;
-pub const OBJECT_TYPE_IOSURFACE: u8 = 11;
+pub const OBJECT_TYPE_MAPPER_REF_TEXTURE: u8 = 11;
 
-/// Type-7 first dword subtypes.
-pub const TYPE7_OBJECT_SAMPLER: u32 = w_smp::OPCODE_NEW_SAMPLER;
-pub const TYPE7_OBJECT_DEPTH_STENCIL: u32 = w_ds::OPCODE_NEW_DEPTH_STENCIL;
-pub const TYPE7_OBJECT_COMPUTE_PIPELINE: u32 = 0x0b;
-pub const TYPE7_OBJECT_RENDER_PIPELINE: u32 = 0x0e;
+/// Serializer-object first dword subtypes.
+///
+/// A tag-7 entry carries no type of its own: the host reads the descriptor's
+/// first dword and that alone decides which Metal object it builds. Each
+/// `PGResourceManager::createObject<T>` instantiation requires the entry tag to
+/// be 7 and then accepts exactly one of these — sampler `0x3`, depth-stencil
+/// `0x4`, compute pipeline `0xb`, fence `0xd`, render pipeline `0xe`,
+/// rasterization rate map `0x32`. Fence and rate map have no reader here; a
+/// descriptor carrying either reaches `res_serializer_object_subtype_unknown`
+/// rather than being mistaken for a pipeline.
+pub const SERIALIZER_OBJECT_SAMPLER: u32 = w_smp::OPCODE_NEW_SAMPLER;
+pub const SERIALIZER_OBJECT_DEPTH_STENCIL: u32 = w_ds::OPCODE_NEW_DEPTH_STENCIL;
+pub const SERIALIZER_OBJECT_COMPUTE_PIPELINE: u32 = 0x0b;
+pub const SERIALIZER_OBJECT_RENDER_PIPELINE: u32 = 0x0e;
 /// Indirect command buffer create body from
 /// `PGSerializer newIndirectCommandBufferWithDescriptor:layout:maxCommandCount:options:allocator:`.
-pub const TYPE7_OBJECT_ICB: u32 = w_icb::OPCODE_NEW_INDIRECT_COMMAND_BUFFER;
-/// End of the 16-byte type-7 header, which is also where its first TLV
+pub const SERIALIZER_OBJECT_ICB: u32 = w_icb::OPCODE_NEW_INDIRECT_COMMAND_BUFFER;
+/// End of the 16-byte serializer-object header, which is also where its first TLV
 /// starts — one boundary, so one name.
-pub const TYPE7_FIRST_TLVS: usize = 16;
+pub const SERIALIZER_OBJECT_FIRST_TLVS: usize = 16;
 /// Serialized ICB descriptor length (allocateOperationBytes 0x58).
 pub const ICB_DESC_LEN: usize = w_icb::NEW_INDIRECT_COMMAND_BUFFER_TOTAL_LEN as usize;
 /// Per-stage max bind counts are single bytes (PGSerializer create body).
@@ -266,7 +311,7 @@ pub const MTL_INDIRECT_CMD_CONCURRENT_DISPATCH_THREADS: u32 = 1 << 6;
 pub const MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS: u32 = 1 << 7;
 pub const MTL_INDIRECT_CMD_DRAW_MESH_THREADS: u32 = 1 << 8;
 
-/// Compact type-7 TLV field: `[tag:u8][length:u8][value…]` after a field-count byte.
+/// Compact serializer-object TLV field: `[tag:u8][length:u8][value…]` after a field-count byte.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CompactTlv {
     pub tag: u8,
@@ -276,7 +321,7 @@ pub struct CompactTlv {
     pub has_u32: bool,
 }
 
-/// Linear buffer descriptor (type-1): allocation size + guest page handle.
+/// Linear buffer descriptor (buffer): allocation size + guest page handle.
 ///
 /// Contract: `reims_vgpu_resource_format.h` `REIMS_VGPU_RESOURCE_LINEAR_DESC_*`.
 /// Backing GVA = `(handle as u64) << PAGE_SHIFT` (14 on arm64e guest).
@@ -287,7 +332,7 @@ pub struct BufferDescriptor {
     pub handle: u32,
 }
 
-/// Linear descriptor offsets (shared with type-2 texture prefix).
+/// Linear descriptor offsets (shared with texture texture prefix).
 pub const LINEAR_DESC_MIN_LEN: usize = 16;
 pub const LINEAR_DESC_SIZE: usize = 0;
 pub const LINEAR_DESC_HANDLE: usize = 8;
@@ -308,7 +353,7 @@ impl BufferDescriptor {
     }
 }
 
-/// One mip level layout inside a type-2/3 texture allocation.
+/// One mip level layout inside a normal texture allocation.
 ///
 /// Level 0 comes from the geometry prefix; levels 1..N-1 are 36-byte records at
 /// `TEXTURE_DESC_LEVEL_RECORDS` (offset/size/row_stride from allocation base).
@@ -424,7 +469,7 @@ impl TextureLevelLayout {
     }
 }
 
-/// Type-2/3 linear texture geometry (`REIMS_VGPU_RESOURCE_TEXTURE_DESC_*`).
+/// normal-texture linear texture geometry (`REIMS_VGPU_RESOURCE_TEXTURE_DESC_*`).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TextureDescriptor {
     pub allocation_size: u64,
@@ -630,7 +675,7 @@ pub(crate) const TEXTURE_DESC_BASE_LEN: usize = 116;
 /// explicit `levels > TEXTURE_MAX_MIP_LEVELS` test for exactly that reason.
 pub const TEXTURE_MAX_MIP_LEVELS: usize = 16;
 
-/// Vertex attribute from a type-7 render-pipeline vertex-input block.
+/// Vertex attribute from a serializer-object render-pipeline vertex-input block.
 ///
 /// The two step fields are `Option` rather than a value beside its own presence
 /// bit. The serializer writes a layout's `stepFunction` and `stepRate` as tagged
@@ -713,7 +758,7 @@ impl ColorWriteMask {
     }
 }
 
-/// One pipeline color-attachment entry (format + blend) from the type-7 color section.
+/// One pipeline color-attachment entry (format + blend) from the serializer-object color section.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PipelineColorAttachment {
     pub slot: u32,
@@ -732,7 +777,7 @@ pub struct PipelineColorAttachment {
     pub write_mask: ColorWriteMask,
 }
 
-/// Decoded type-7 render pipeline (functions + optional stage-in attrs).
+/// Decoded serializer-object render pipeline (functions + optional stage-in attrs).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RenderPipelineDescriptor {
     pub object_id: u32,
@@ -743,10 +788,10 @@ pub struct RenderPipelineDescriptor {
     /// decoded, which made it indistinguishable from a field nobody had
     /// identified. It is not: the header is `objType`, declared length, the new
     /// object's ref, and this — and the declared length is exactly
-    /// [`TYPE7_FIRST_TLVS`] plus this rounded up to four.
+    /// [`SERIALIZER_OBJECT_FIRST_TLVS`] plus this rounded up to four.
     ///
     /// That relation is checkable from the header alone, which is what
-    /// [`note_type7_payload_len`] does. Nothing else reads the field: the walks
+    /// [`note_serializer_object_payload_len`] does. Nothing else reads the field: the walks
     /// below bound themselves on the *declared* length, which is the larger of
     /// the two and the one that describes the bytes actually present.
     pub serialized_payload_len: u32,
@@ -796,7 +841,7 @@ pub struct RenderPipelineDescriptor {
     pub color_attachments: Vec<PipelineColorAttachment>,
 }
 
-/// Compute stage-input attribute from type-7 compute pipeline compact block.
+/// Compute stage-input attribute from serializer-object compute pipeline compact block.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ComputeStageInputAttribute {
     pub raw_bits: u32,
@@ -806,7 +851,7 @@ pub struct ComputeStageInputAttribute {
     pub buffer_index: u32,
 }
 
-/// Compute stage-input layout from type-7 compute pipeline compact block.
+/// Compute stage-input layout from serializer-object compute pipeline compact block.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ComputeStageInputLayout {
     pub raw_bits: u32,
@@ -816,7 +861,7 @@ pub struct ComputeStageInputLayout {
     pub stride: u64,
 }
 
-/// Decoded compute `stageInputDescriptor` from a type-7 compute pipeline.
+/// Decoded compute `stageInputDescriptor` from a serializer-object compute pipeline.
 ///
 /// Layout is the MetalSerializer compact block after the first TLV record:
 /// `word0`, `header0` (payload len + counts + index metadata), `header1`
@@ -842,7 +887,7 @@ pub struct ComputeStageInputDescriptor {
     pub dropped_layouts: u32,
 }
 
-/// Decoded type-7 compute pipeline (kernel function + optional stage-input).
+/// Decoded serializer-object compute pipeline (kernel function + optional stage-input).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ComputePipelineDescriptor {
     pub kernel_func_ref: u32,
@@ -973,7 +1018,7 @@ const COMPUTE_STAGE_INPUT_ATTR_BITS_READ: u32 = COMPUTE_STAGE_INPUT_ATTR_BITS_LO
     | (COMPUTE_STAGE_INPUT_ATTR_BITS_BUFFER_MASK << COMPUTE_STAGE_INPUT_ATTR_BITS_BUFFER_SHIFT)
     | (COMPUTE_STAGE_INPUT_ATTR_BITS_FORMAT_MASK << COMPUTE_STAGE_INPUT_ATTR_BITS_FORMAT_SHIFT);
 
-/// Type-8 texture view (base texture + optional format/level/slice/swizzle).
+/// Texture-view texture view (base texture + optional format/level/slice/swizzle).
 ///
 /// Which fields the wire carried is a property of `view_opcode` and nothing
 /// else: the three forms are three distinct records, and the swizzle body
@@ -1028,7 +1073,7 @@ impl TextureViewDescriptor {
     }
 }
 
-// The record header every type-8 blob starts with. Named here because this
+// The record header every texture-view blob starts with. Named here because this
 // file reads it on five different records, and derived from the wire crate's
 // `OpHeader` so the two words cannot be swapped in one place and not the other.
 pub const TEXTURE_VIEW_DESC_OPCODE: usize = offset_of!(reims_vgpu_wire::OpHeader, opcode);
@@ -1076,7 +1121,7 @@ pub const TEXTURE_VIEW_OPCODE_SIMPLE: u32 = w_view::OPCODE_TEXTURE_VIEW;
 pub const TEXTURE_VIEW_OPCODE_RANGED: u32 = w_view::OPCODE_TEXTURE_VIEW_RANGED;
 pub const TEXTURE_VIEW_OPCODE_SWIZZLE: u32 = w_view::OPCODE_TEXTURE_VIEW_SWIZZLE;
 // Heap-backed texture (`newTextureWithDescriptor:heap:offset:useOffset:
-// allocator:`). It shares the type-8 object tag, but is a complete texture
+// allocator:`). It shares the texture-view object tag, but is a complete texture
 // resource rather than a view: a heap ref, the embedded
 // PGSerializedTextureDescriptor, then `useOffset` and the heap byte offset.
 //
@@ -1115,7 +1160,7 @@ const HEAP_TEXTURE_WIDE_OFFSET: usize = OP_HDR + offset_of!(w_heap::NewHeapTextu
 // Opcode 9 is NOT a view: it is a buffer-backed texture (`newTextureWithBuffer:
 // descriptor:offset:bytesPerRow:`) serialized by `-[PGSerializer newTextureWith
 // Buffer:...]`.
-// It shares only the type-8 object tag + 16-byte header (opcode@0, len@4,
+// It shares only the texture-view object tag + 16-byte header (opcode@0, len@4,
 // self-ref@8, source-ref@0xc); the source ref @0xc is a BUFFER, not a texture,
 // and the body is {u64 offset, u64 bytesPerRow, embedded MTLTextureDescriptor}.
 pub const TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE: u32 = w_backed::OPCODE_BUFFER_TEXTURE;
@@ -1153,7 +1198,7 @@ pub const TEXTURE_VIEW_MTL_TYPE_CUBE: u16 = 5;
 pub const TEXTURE_VIEW_MTL_TYPE_CUBE_ARRAY: u16 = 6;
 pub const TEXTURE_VIEW_MTL_TYPE_3D: u16 = 7;
 
-/// Whether a type-8 view `texture_type` is supported for product-path blit/sample.
+/// Whether a texture-view `texture_type` is supported for product-path blit/sample.
 pub fn texture_view_type_supported(texture_type: u16) -> bool {
     matches!(
         texture_type,
@@ -1237,7 +1282,7 @@ pub const MTL_COLOR_WRITE_MASK_GREEN: u32 = 1 << 2;
 pub const MTL_COLOR_WRITE_MASK_RED: u32 = 1 << 3;
 pub const MTL_COLOR_WRITE_MASK_ALL: u32 = 0xf;
 
-/// Where the sampler-creation record (type-7 subtype 0x03) puts each field, for
+/// Where the sampler-creation record (serializer-object subtype 0x03) puts each field, for
 /// the synthetic buffers the tests below assemble.
 ///
 /// Derived from the view `decode_sampler_descriptor` actually reads. These were
@@ -1251,7 +1296,7 @@ pub const MTL_COLOR_WRITE_MASK_ALL: u32 = 0xf;
 /// oracle does — `flags`, whose low nibble is the only written part, and
 /// `lodMinClamp` — so they are named for the fields now.
 ///
-/// The cfg is their one consumer's, `icb::tests::put_type7_sampler`, which
+/// The cfg is their one consumer's, `icb::tests::put_serializer_object_sampler`, which
 /// builds a sampler for the Metal ICB encoder and is gated the same way. Naming
 /// that cfg here rather than reaching for `allow(dead_code)` is what keeps the
 /// Vulkan arm able to say these are unreferenced if the consumer ever goes.
@@ -1275,7 +1320,7 @@ pub const FUNCTION_DESC_BLOB_SIZE: usize = 8;
 pub const FUNCTION_DESC_FUNCTION_ID: usize = 0x14;
 pub const FUNCTION_DESC_MIN_LEN: usize = 12;
 
-/// Compact first-subrecord tags (u8) on type-7 pipelines.
+/// Compact first-subrecord tags (u8) on serializer-object pipelines.
 pub const PIPELINE_TAG_KERNEL_FUNC: u8 = 0x00;
 /// Classic: vertex function. Mesh SPI: object function.
 pub const PIPELINE_TAG_VERTEX_FUNC: u8 = 0x01;
@@ -1285,7 +1330,7 @@ pub const PIPELINE_TAG_FRAGMENT_FUNC: u8 = 0x02;
 pub const PIPELINE_TAG_MESH_FRAGMENT_FUNC: u8 = 0x03;
 /// Classic: where the serialized `vertexDescriptor` starts, in the same units as
 /// [`PIPELINE_TAG_COLOR_ATTACH_OFFSET`] — a byte offset from the end of the
-/// 16-byte type-7 header.
+/// 16-byte serializer-object header.
 ///
 /// The same wire tag as [`PIPELINE_TAG_MESH_FRAGMENT_FUNC`], whose role it takes
 /// on the mesh shape. The pair is the third instance of this file's standing
@@ -1406,7 +1451,7 @@ pub const PIPELINE_TAG_LOGIC_OP: u8 = 0x37;
 ///
 /// Live host Metal `-[_MTLDevice serializeMeshRenderPipelineDescriptor:]`
 /// differentials (2026-07-12, Apple M3 Max): same compact first-subrecord
-/// grammar as classic type-7 (`[fieldCount]×[tag][0x04][u32]`). Presence of
+/// grammar as classic serializer-object (`[fieldCount]×[tag][0x04][u32]`). Presence of
 /// this tag selects the mesh role map for tags 0x01/0x02/0x03.
 pub const PIPELINE_TAG_MESH_SECTION_OFFSET: u8 = 0x14;
 /// Mesh object-stage function — same wire tag as classic vertex (`0x01`).
@@ -1591,7 +1636,7 @@ pub struct SamplerDescriptor {
     pub lod_average: bool,
 }
 
-/// Type-7 depth-stencil face (12 bytes).
+/// Serializer-object depth-stencil face (12 bytes).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DepthStencilFace {
     pub compare_function: u32,
@@ -1602,7 +1647,7 @@ pub struct DepthStencilFace {
     pub write_mask: u32,
 }
 
-/// Type-7 depth-stencil state (40 bytes).
+/// Serializer-object depth-stencil state (40 bytes).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct DepthStencilDescriptor {
     pub depth_stencil_id: u32,
@@ -1659,7 +1704,7 @@ pub struct IcbCommandLayout {
     pub command_size: u32,
 }
 
-/// Decoded type-7 ICB create descriptor (88-byte MetalSerializer body).
+/// Decoded serializer-object ICB create descriptor (88-byte MetalSerializer body).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct IndirectCommandBufferDescriptor {
     pub command_types: u32,
@@ -1821,7 +1866,7 @@ impl IndirectCommandBufferDescriptor {
 /// One decoded object-list descriptor.
 ///
 /// There is deliberately no `Unknown`: an object type this host has no contract
-/// for is [`DecodeStatus::ErrUnknownType`], and a type-7 subtype it does not
+/// for is [`DecodeStatus::ErrUnknownType`], and a serializer-object subtype it does not
 /// implement is [`DecodeStatus::ErrUnsupported`]. Both name the check that
 /// refused. An `Unknown` variant would let the same condition arrive as a
 /// successful decode carrying nothing, which every consumer would then have to
@@ -2175,7 +2220,7 @@ pub fn decode_function_descriptor(bytes: &[u8]) -> Result<FunctionDescriptor, De
     })
 }
 
-/// Compact type-7 first sub-record: `[fieldCount:u8]` × `[tag:u8][len:u8][value…]`.
+/// Compact serializer-object first sub-record: `[fieldCount:u8]` × `[tag:u8][len:u8][value…]`.
 pub fn decode_compact_tlv_record(
     bytes: &[u8],
     offset: usize,
@@ -2405,7 +2450,7 @@ pub fn decode_depth_stencil_descriptor(
 ) -> Result<DepthStencilDescriptor, DecodeStatus> {
     let op = reims_vgpu_wire::op(bytes, 0)
         .map_err(|_| DecodeStatus::ErrShort("res_depth_stencil_short"))?;
-    if op.opcode() != TYPE7_OBJECT_DEPTH_STENCIL || op.length() as usize != bytes.len() {
+    if op.opcode() != SERIALIZER_OBJECT_DEPTH_STENCIL || op.length() as usize != bytes.len() {
         return Err(DecodeStatus::ErrUnsupported("res_depth_stencil_tag"));
     }
     let body = w_ds::new_depth_stencil(&op)
@@ -2480,7 +2525,7 @@ fn wire_max_anisotropy(value: u8) -> u32 {
 pub fn decode_sampler_descriptor(bytes: &[u8]) -> Result<SamplerDescriptor, DecodeStatus> {
     let op =
         reims_vgpu_wire::op(bytes, 0).map_err(|_| DecodeStatus::ErrShort("res_sampler_short"))?;
-    if op.opcode() != TYPE7_OBJECT_SAMPLER || op.length() as usize != bytes.len() {
+    if op.opcode() != SERIALIZER_OBJECT_SAMPLER || op.length() as usize != bytes.len() {
         return Err(DecodeStatus::ErrUnsupported("res_sampler_tag"));
     }
     let body = w_smp::new_sampler(&op).map_err(|_| DecodeStatus::ErrShort("res_sampler_short"))?;
@@ -2566,7 +2611,7 @@ const COMPUTE_PIPELINE_TAG_THREADGROUP_MULTIPLE: u8 = 0x01;
 /// constant's doc gives.
 const COMPUTE_PIPELINE_TAG_LABEL: u8 = 0x02;
 /// `MTLComputePipelineDescriptor.stageInputDescriptor` — a byte offset from the
-/// end of the 16-byte type-7 header to a nested property list, in the same units
+/// end of the 16-byte serializer-object header to a nested property list, in the same units
 /// as [`PIPELINE_TAG_VERTEX_DESCRIPTOR_OFFSET`] and
 /// [`PIPELINE_TAG_COLOR_ATTACH_OFFSET`]. `COMPUTE_PIPELINE_TAG_LABEL` is the same
 /// kind of offset, to a NUL-terminated string.
@@ -2707,7 +2752,7 @@ const COMPUTE_PIPELINE_TAGS_BENIGN: [u8; 2] = [
 /// or how often.
 ///
 /// It is now a refusal on that same sibling's licence, and the licence is what
-/// took the work: the sibling refuses because `type7_color_attach_shape`
+/// took the work: the sibling refuses because `serializer_object_color_attach_shape`
 /// measured its zero first. This block's `unconsumed` count is *not* zero and
 /// never will be — two labels arrive on every boot — so the zero that had to be
 /// measured was a different one. Splitting the unread tags into
@@ -2822,7 +2867,7 @@ const COMPUTE_PIPELINE_TAGS_BENIGN: [u8; 2] = [
 /// perturbation against Apple's own serializer, not by reading ordinals. In the
 /// guest, `-[_MTLDevice serializeRenderPipelineDescriptor:]` returns this exact
 /// compact-TLV block (its `NSData` **starts** at the `fieldCount` byte; the
-/// 16-byte type-7 header this decoder reads is added by the transport). Build a
+/// 16-byte serializer-object header this decoder reads is added by the transport). Build a
 /// baseline descriptor, set exactly one property through the runtime, serialize,
 /// and the tag that appears is that property's. Fifty-odd scalar setters on
 /// `MTLRenderPipelineDescriptor` and `MTLRenderPipelineDescriptorInternal`, one
@@ -2925,14 +2970,14 @@ impl crate::observe::Decline for PipelineFieldDropped {
     }
 }
 
-/// Report the shape of a type-7 pipeline's own compact-TLV block and every
+/// Report the shape of a serializer-object pipeline's own compact-TLV block and every
 /// field in it this decoder does not consume.
 ///
 /// Two lines with the two jobs [`note_color_entry_fields`] splits for the same
 /// reason: a silent census cannot tell "the guest sends only the tags we read"
 /// from "this walk never ran on a live guest".
 ///
-/// * `type7_pipeline_shape` is the *branch*, on the off channel, deduped per
+/// * `serializer_object_pipeline_shape` is the *branch*, on the off channel, deduped per
 ///   distinct `(kind, tag, len)` sequence and starring the unread tags. A boot
 ///   with pipeline shapes and no drop line is a positive reading.
 /// * `pipeline_descriptor_field_dropped` is the *loss*, one typed decline per
@@ -3064,9 +3109,9 @@ fn report_tlv_shape(
             }
         }
     }
-    if crate::observe::first_sight("type7_pipeline_shape", shape_key) {
+    if crate::observe::first_sight("serializer_object_pipeline_shape", shape_key) {
         crate::observe::off(format!(
-            "type7_pipeline_shape kind={kind} nfields={field_count} tags=[{shape}] \
+            "serializer_object_pipeline_shape kind={kind} nfields={field_count} tags=[{shape}] \
              unconsumed={} unknown={}",
             dropped.len(),
             unknown.len()
@@ -3078,7 +3123,7 @@ fn report_tlv_shape(
     // it stays visible.
     for &(tag, len, first_value) in &unknown {
         crate::observe::Emit::decline(
-            "type7_pipeline",
+            "serializer_object_pipeline",
             &PipelineFieldDropped {
                 kind,
                 tag,
@@ -3100,7 +3145,7 @@ pub fn decode_render_pipeline_descriptor(
     }
     let obj_type = ld32(&bytes[0..]);
     let declared = ld32(&bytes[4..]) as usize;
-    if obj_type != TYPE7_OBJECT_RENDER_PIPELINE {
+    if obj_type != SERIALIZER_OBJECT_RENDER_PIPELINE {
         return Err(DecodeStatus::ErrUnsupported("res_render_pipeline_tag"));
     }
     if declared != bytes.len() || declared < TYPE7_MIN_LEN {
@@ -3111,8 +3156,8 @@ pub fn decode_render_pipeline_descriptor(
         serialized_payload_len: ld32(&bytes[12..]),
         ..Default::default()
     };
-    note_type7_payload_len("render", out.serialized_payload_len, declared);
-    let (fields, consumed) = decode_compact_tlv_record(bytes, TYPE7_FIRST_TLVS)?;
+    note_serializer_object_payload_len("render", out.serialized_payload_len, declared);
+    let (fields, consumed) = decode_compact_tlv_record(bytes, SERIALIZER_OBJECT_FIRST_TLVS)?;
     let tag01 = compact_tlv_u32(&fields, PIPELINE_TAG_VERTEX_FUNC).unwrap_or(0);
     let tag02 = compact_tlv_u32(&fields, PIPELINE_TAG_FRAGMENT_FUNC).unwrap_or(0);
     let tag03 = compact_tlv_u32(&fields, PIPELINE_TAG_MESH_FRAGMENT_FUNC).unwrap_or(0);
@@ -3128,7 +3173,7 @@ pub fn decode_render_pipeline_descriptor(
     out.tessellation_output_winding_order =
         compact_tlv_u32(&fields, PIPELINE_TAG_TESSELLATION_OUTPUT_WINDING_ORDER).unwrap_or(0);
     // Mesh SPI shape: tag 0x14 section offset (host serializeMeshRenderPipelineDescriptor).
-    // Classic type-7 uses tag 0x08. Roles for 0x01/0x02/0x03 differ by shape.
+    // Classic serializer-object uses tag 0x08. Roles for 0x01/0x02/0x03 differ by shape.
     if let Some(off) = compact_tlv_u32(&fields, PIPELINE_TAG_MESH_SECTION_OFFSET) {
         note_pipeline_tlv_fields(
             "render_mesh",
@@ -3166,9 +3211,9 @@ pub fn decode_render_pipeline_descriptor(
             out.has_color_attachment_offset = true;
         }
     }
-    let first_tlv_end = TYPE7_FIRST_TLVS + consumed;
+    let first_tlv_end = SERIALIZER_OBJECT_FIRST_TLVS + consumed;
     if out.has_color_attachment_offset {
-        let color_abs = TYPE7_FIRST_TLVS + out.color_attachment_offset as usize;
+        let color_abs = SERIALIZER_OBJECT_FIRST_TLVS + out.color_attachment_offset as usize;
         // The vertex block runs from where the descriptor says it starts to
         // where the colour section begins. Only the classic shape states that
         // start; the mesh shape does not, so it keeps the old inference —
@@ -3179,7 +3224,7 @@ pub fn decode_render_pipeline_descriptor(
         let start = if inferred {
             first_tlv_end
         } else {
-            TYPE7_FIRST_TLVS + out.vertex_descriptor_offset as usize
+            SERIALIZER_OBJECT_FIRST_TLVS + out.vertex_descriptor_offset as usize
         };
         if color_abs <= declared && start < color_abs {
             out.vertex_attributes = parse_vertex_block(bytes, start, color_abs)?;
@@ -3197,12 +3242,12 @@ pub fn decode_render_pipeline_descriptor(
     Ok(out)
 }
 
-/// The two lengths in a type-7 header disagree about the same payload.
+/// The two lengths in a serializer-object header disagree about the same payload.
 ///
 /// The header states the payload's length twice: the declared length at `+4`
 /// covers the header and the payload padded to four bytes, and
 /// [`RenderPipelineDescriptor::serialized_payload_len`] at `+0xc` is the same
-/// payload unpadded. So `declared == TYPE7_FIRST_TLVS + round_up_4(payload)`
+/// payload unpadded. So `declared == SERIALIZER_OBJECT_FIRST_TLVS + round_up_4(payload)`
 /// always, and a record where it does not hold is one whose two halves were
 /// written by different ideas of how long it is.
 ///
@@ -3226,7 +3271,7 @@ pub fn decode_render_pipeline_descriptor(
 /// state a payload length first. A reader who measures only the boot will
 /// conclude the promotion is free, and it is not.
 ///
-/// Both pipeline subtypes reach this, and **only** those two: the other type-7
+/// Both pipeline subtypes reach this, and **only** those two: the other serializer-object
 /// subtypes — sampler, depth-stencil, ICB — are fixed-layout wire structs rather
 /// than property-list containers, so their fourth header word is a declared
 /// field of the struct and not a payload length. The relation would be false
@@ -3235,26 +3280,26 @@ pub fn decode_render_pipeline_descriptor(
 /// **Both halves have now been booted, which is worth stating because a
 /// `kind=compute` zero could have meant the arm never ran.** The compute arm was
 /// added a commit after the render one and had no boot behind it; a later driven
-/// x86 boot reported `type7_pipeline_shape kind=compute` twice against
+/// x86 boot reported `serializer_object_pipeline_shape kind=compute` twice against
 /// `kind=render` four times, so the compute arm decoded two real descriptors and
 /// agreed on both. The denominator to quote for this instrument is that shape
 /// line, not this one, because this one is silent on success by construction.
-fn note_type7_payload_len(kind: &'static str, payload: u32, declared: usize) {
+fn note_serializer_object_payload_len(kind: &'static str, payload: u32, declared: usize) {
     let padded = (payload as usize).next_multiple_of(4);
-    if TYPE7_FIRST_TLVS.checked_add(padded) == Some(declared) {
+    if SERIALIZER_OBJECT_FIRST_TLVS.checked_add(padded) == Some(declared) {
         return;
     }
     if crate::observe::first_sight(
-        "type7_payload_len_disagrees",
+        "serializer_object_payload_len_disagrees",
         ((payload as u64) << 32) | declared as u64,
     ) {
         crate::observe::fail(format!(
-            "type7_payload_len kind={kind} reason=type7_payload_len_disagrees \
+            "serializer_object_payload_len kind={kind} reason=serializer_object_payload_len_disagrees \
              payload={payload} padded={padded} declared={declared} \
              expected={} (the header states its payload length twice and the \
              two do not agree; nothing is refused, the walks below bound \
              themselves on the declared length)",
-            TYPE7_FIRST_TLVS + padded
+            SERIALIZER_OBJECT_FIRST_TLVS + padded
         ));
     }
 }
@@ -3276,7 +3321,7 @@ fn note_type7_payload_len(kind: &'static str, payload: u32, declared: usize) {
 /// **Its zero is not yet a measurement, and the denominator says so.** Both
 /// callers sit inside [`parse_compute_stage_input_block`], and on a driven x86
 /// boot — Safari composited over a Ventura desktop, 25 s of window drag —
-/// `type7_pipeline_shape` reported two compute pipelines while
+/// `serializer_object_pipeline_shape` reported two compute pipelines while
 /// `compute_stage_input_decoded` reported **none**. Neither compute pipeline
 /// carried a stage-input block at all, so no entry word was ever offered to this
 /// function and its silence is an empty walk rather than a clean one. That is
@@ -3334,11 +3379,11 @@ fn note_unread_bits(kind: &'static str, word: u32, read_mask: u32) {
 /// is the whole of what the offset was read for.
 fn note_vertex_block_inferred(start: usize, color_abs: usize) {
     if crate::observe::first_sight(
-        "type7_vertex_block_inferred",
+        "serializer_object_vertex_block_inferred",
         ((start as u64) << 32) | color_abs as u64,
     ) {
         crate::observe::off(format!(
-            "type7_vertex_block_inferred start={start} color={color_abs} \
+            "serializer_object_vertex_block_inferred start={start} color={color_abs} \
              (the descriptor stated no vertexDescriptor offset, so the block was \
               located by stepping over the label)"
         ));
@@ -3372,7 +3417,7 @@ fn note_vertex_block_inferred(start: usize, color_abs: usize) {
 ///
 /// # What licenses it
 ///
-/// A bare zero would not. `type7_color_attach_shape` is the sibling that fires:
+/// A bare zero would not. `serializer_object_color_attach_shape` is the sibling that fires:
 /// it reports every entry's tag sequence and stars the unread ones, and across
 /// every driven boot in the record it appears 4–13 times per boot, each one
 /// `unconsumed=0`, over the tag set `00,01,02,04,07`. So the walk runs on a live
@@ -3491,7 +3536,7 @@ const COLOR_ATTACH_DROP_VALUE_CAP: u32 = 64;
 /// "the guest sends nothing but the eight tags we read" from "this walk never
 /// ran on a live guest":
 ///
-/// * `type7_color_attach_shape` is the *branch*, deduped per distinct `(tag,
+/// * `serializer_object_color_attach_shape` is the *branch*, deduped per distinct `(tag,
 ///   len)` sequence. A boot with entries but no drop line is then a positive
 ///   reading — the entries were seen and carried only consumed tags — rather
 ///   than an absence.
@@ -3554,9 +3599,9 @@ fn note_color_entry_fields(bytes: &[u8], entry: usize, slot: u32) -> Result<(), 
         }
         p += 2 + field_len;
     }
-    if crate::observe::first_sight("type7_color_attach_shape", shape_key) {
+    if crate::observe::first_sight("serializer_object_color_attach_shape", shape_key) {
         crate::observe::off(format!(
-            "type7_color_attach_shape slot={slot} nfields={field_count} \
+            "serializer_object_color_attach_shape slot={slot} nfields={field_count} \
              tags=[{shape}] unconsumed={}",
             dropped.len()
         ));
@@ -3569,7 +3614,7 @@ fn note_color_entry_fields(bytes: &[u8], entry: usize, slot: u32) -> Result<(), 
             ((slot as u64) << 40) | ((read as u64) << 16) | (field_count as u64),
         ) {
             crate::observe::Emit::decline(
-                "type7_color_attach",
+                "serializer_object_color_attach",
                 &ColorAttachEntryShort {
                     read,
                     declared: field_count,
@@ -3593,11 +3638,14 @@ fn note_color_entry_fields(bytes: &[u8], entry: usize, slot: u32) -> Result<(), 
         if !crate::observe::first_sight("color_attachment_field_dropped", disc) {
             continue;
         }
-        crate::observe::Emit::decline("type7_color_attach", &ColorAttachDropped { tag })
-            .field("slot", slot)
-            .field("len", field_len)
-            .field("value", value)
-            .fail();
+        crate::observe::Emit::decline(
+            "serializer_object_color_attach",
+            &ColorAttachDropped { tag },
+        )
+        .field("slot", slot)
+        .field("len", field_len)
+        .field("value", value)
+        .fail();
     }
     // Outside the loop, so the refusal does not inherit `first_sight`'s latch:
     // the line names a tag once, the pipeline is refused every time.
@@ -3623,7 +3671,9 @@ fn parse_one_color_entry(
                 // attachments are not a dense in-order prefix, so every consumer
                 // that matches `a.slot == c.slot` was reading another slot's
                 // blend state, write mask and pixel format.
-                crate::runtime::drain::note_store_route("type7_color_slot_off_position");
+                crate::runtime::drain::note_store_route(
+                    "serializer_object_color_slot_off_position",
+                );
             }
             declared
         }
@@ -3638,7 +3688,7 @@ fn parse_one_color_entry(
                 u64::from(declared),
             ) {
                 crate::observe::Emit::decline(
-                    "type7_color_attach",
+                    "serializer_object_color_attach",
                     &ColorAttachIndexOutOfRange { declared },
                 )
                 .field("position", position)
@@ -3703,10 +3753,13 @@ fn parse_one_color_entry(
             // has none — every representable mask is a mask the guest might
             // have meant, and picking one is guessing which channels it wanted.
             if crate::observe::first_sight("color_write_mask_out_of_range", u64::from(mask)) {
-                crate::observe::Emit::decline("type7_color_attach", &ColorWriteMaskOutOfRange)
-                    .field("slot", slot)
-                    .field("value", mask)
-                    .fail();
+                crate::observe::Emit::decline(
+                    "serializer_object_color_attach",
+                    &ColorWriteMaskOutOfRange,
+                )
+                .field("slot", slot)
+                .field("value", mask)
+                .fail();
             }
             return Err(DecodeStatus::ErrUnsupported("res_color_write_mask_over"));
         };
@@ -3772,7 +3825,7 @@ fn note_color_table_truncated(
         return;
     }
     crate::observe::Emit::decline(
-        "type7_color_attach",
+        "serializer_object_color_attach",
         &ColorAttachTableTruncated { declared, decoded },
     )
     .field("section_off", section_off)
@@ -3886,7 +3939,7 @@ pub fn parse_color_attachments(
 
 /// A heap-placed texture record, opcode [`HEAP_TEXTURE_OPCODE`].
 ///
-/// It shares the type-8 object tag with the texture views, so it arrives at the
+/// It shares the texture-view object tag with the texture views, so it arrives at the
 /// same peek, but it is a complete texture resource: a heap ref, the same
 /// 32-byte `PGSerializedTextureDescriptor` a plain creation carries, and where
 /// in the heap to put it.
@@ -4039,7 +4092,7 @@ pub fn decode_texture_view_descriptor(bytes: &[u8]) -> Result<TextureViewDescrip
     }
 }
 
-/// A texture aliased over an MTLBuffer's storage — object type 8, view_opcode 9
+/// A texture aliased over an MTLBuffer's storage — object texture-view, view_opcode 9
 /// (`newTextureWithDescriptor:offset:bytesPerRow:`). Distinct from a texture view:
 /// the source ref is a BUFFER and the sampled bytes come straight from that
 /// buffer's guest storage at `offset`, `bytes_per_row` stride.
@@ -4061,7 +4114,7 @@ pub struct BufferTextureDescriptor {
     pub desc: crate::runtime::heap_query::TextureDescriptor,
 }
 
-/// Decode the opcode-9 (buffer-backed texture) type-8 descriptor — the
+/// Decode the opcode-9 (buffer-backed texture) texture-view descriptor — the
 /// serialized form of
 /// `newTextureWithBuffer:descriptor:offset:bytesPerRow:allocator:`.
 ///
@@ -4130,12 +4183,12 @@ pub fn decode_buffer_texture_descriptor(
     }
 }
 
-/// Peek the raw `(view_opcode, declared length)` header of a type-8 descriptor
+/// Peek the raw `(view_opcode, declared length)` header of a texture-view descriptor
 /// (opcode 9 = buffer-backed texture, 7/8/0x1b = texture view). `None` only for
 /// a blob too short to hold the header.
 ///
 /// The bound is [`OP_HDR`] — the bytes this actually reads — and not any one
-/// variant's total length. The type-8 forms do not share a length (20 / 36 / 44
+/// variant's total length. The texture-view forms do not share a length (20 / 36 / 44
 /// / 64 / 72 …), so guarding a header peek with one of those totals hides every
 /// shorter variant behind `None` before its own decoder ever sees the opcode.
 /// That is the same mistake `compute_stage_tex` had to unpick at its call site,
@@ -4146,7 +4199,7 @@ pub fn decode_buffer_texture_descriptor(
 /// want both use them for the length-mismatch and unknown-opcode census, which
 /// needs the guest's declared value precisely when it disagrees with what
 /// arrived. [`decode_texture_view_descriptor`] is the checked reader.
-pub fn texture_type8_header(bytes: &[u8]) -> Option<(u32, u32)> {
+pub fn texture_view_header(bytes: &[u8]) -> Option<(u32, u32)> {
     if bytes.len() < OP_HDR {
         return None;
     }
@@ -4156,22 +4209,22 @@ pub fn texture_type8_header(bytes: &[u8]) -> Option<(u32, u32)> {
     ))
 }
 
-/// The opcode half of [`texture_type8_header`], for callers routing on the
+/// The opcode half of [`texture_view_header`], for callers routing on the
 /// variant alone.
-pub fn texture_type8_opcode(bytes: &[u8]) -> Option<u32> {
-    texture_type8_header(bytes).map(|(opcode, _)| opcode)
+pub fn texture_view_opcode(bytes: &[u8]) -> Option<u32> {
+    texture_view_header(bytes).map(|(opcode, _)| opcode)
 }
 
 const TYPE7_MIN_LEN: usize = 17;
 
 /// **Unused on the x86 PCI pathway.** A probe placed at the top of this function
 /// — before the length check, so a short record would also report — emitted
-/// nothing across a full interactive session. Type-11 geometry on that pathway
-/// is latched from the **type-4** surface backing descriptor instead
-/// (`runtime/objects`, `decode_type4_surface` -> `set_mapping_geom`). Do not
+/// nothing across a full interactive session. Mapper-ref-texture geometry on that pathway
+/// is latched from the **backing** surface backing descriptor instead
+/// (`runtime/objects`, `decode_backing` -> `set_mapping_geom`). Do not
 /// reason about what the guest tells us at surface-create time from this
-/// decoder without re-confirming it runs; measure `decode_type4_surface`.
-/// Offsets in the type-11 IOSurface-texture descriptor. Named rather than
+/// decoder without re-confirming it runs; measure `decode_backing`.
+/// Offsets in the mapper-ref-texture IOSurface-texture descriptor. Named rather than
 /// written as hex at the read sites, which is the convention every other
 /// decoder in this file already follows — an offset that appears only as a
 /// literal cannot be found by a reader checking whether the layout still holds.
@@ -4187,7 +4240,7 @@ pub const IOSURFACE_TEX_HEIGHT: usize = 0x1c;
 /// settle it.** A probe emitting every distinct (length, tail) shape from this
 /// decoder was run against a driven x86 PCI boot and emitted nothing at all,
 /// which confirms rather than contradicts
-/// [`crate::runtime::objects::undecoded_type4_surface_bytes`] — that doc already
+/// [`crate::runtime::objects::undecoded_backing_bytes`] — that doc already
 /// records that this decoder does not run on that pathway. The 0x38/0x58 blobs
 /// are an arm64 phenomenon.
 ///
@@ -4199,12 +4252,12 @@ pub const IOSURFACE_TEX_MIN_LEN: usize = 0x20;
 
 pub fn decode_iosurface_texture_descriptor(bytes: &[u8]) -> Result<Descriptor, DecodeStatus> {
     // Matches reims-vgpu-iosurface-pages texture descriptor min layout (mappingID,
-    // object self-ref, format, width, height). Live type-11 blobs are longer
+    // object self-ref, format, width, height). Live mapper-ref-texture blobs are longer
     // (0x38/0x58); multi-mip level records are **not** part of this object type
     // — Metal forbids mipmapped IOSurface textures
     // (`newTextureWithDescriptor:iosurface:` rejects mipmapLevelCount > 1),
     // and product resolve fail-closes non-zero levels rather than inventing
-    // a pyramid packing in the mapping (see blit_exec::Type11Texture).
+    // a pyramid packing in the mapping (see blit_exec::MapperRefTexture).
     if bytes.len() < IOSURFACE_TEX_MIN_LEN {
         return Err(DecodeStatus::ErrShort("res_iosurface_short"));
     }
@@ -4268,7 +4321,7 @@ fn parse_compute_stage_input_section(
     if declared_offset == 0 {
         return Ok(None);
     }
-    let section = TYPE7_FIRST_TLVS.saturating_add(declared_offset as usize);
+    let section = SERIALIZER_OBJECT_FIRST_TLVS.saturating_add(declared_offset as usize);
     if section >= bytes.len() {
         return Err(DecodeStatus::ErrShort("res_compute_stage_input_off_oob"));
     }
@@ -4529,14 +4582,14 @@ pub fn parse_compute_stage_input_block(
     Ok(Some(out))
 }
 
-/// Decode type-7 compute pipeline (`objType=0x0b`): kernel TLV + optional stage-input.
+/// Decode serializer-object compute pipeline (`objType=0x0b`): kernel TLV + optional stage-input.
 pub fn decode_compute_pipeline_descriptor(
     bytes: &[u8],
 ) -> Result<ComputePipelineDescriptor, DecodeStatus> {
     if bytes.len() < TYPE7_MIN_LEN {
         return Err(DecodeStatus::ErrShort("res_compute_pipeline_short"));
     }
-    if ld32(&bytes[0..]) != TYPE7_OBJECT_COMPUTE_PIPELINE {
+    if ld32(&bytes[0..]) != SERIALIZER_OBJECT_COMPUTE_PIPELINE {
         return Err(DecodeStatus::ErrUnsupported("res_compute_pipeline_tag"));
     }
     let declared = ld32(&bytes[4..]) as usize;
@@ -4547,8 +4600,8 @@ pub fn decode_compute_pipeline_descriptor(
     // between its two lengths holds. Checked rather than stored: this descriptor
     // has no consumer for the value, and the walks below bound themselves on the
     // declared length.
-    note_type7_payload_len("compute", ld32(&bytes[12..]), declared);
-    let (fields, consumed) = decode_compact_tlv_record(bytes, TYPE7_FIRST_TLVS)?;
+    note_serializer_object_payload_len("compute", ld32(&bytes[12..]), declared);
+    let (fields, consumed) = decode_compact_tlv_record(bytes, SERIALIZER_OBJECT_FIRST_TLVS)?;
     note_pipeline_tlv_fields(
         "compute",
         &COMPUTE_PIPELINE_TAGS_CONSUMED,
@@ -4562,7 +4615,7 @@ pub fn decode_compute_pipeline_descriptor(
     // therefore does not replace.
     let stage_input = match compact_tlv_u32(&fields, PIPELINE_TAG_COMPUTE_STAGE_INPUT_OFFSET) {
         Some(off) => parse_compute_stage_input_section(bytes, off)?,
-        None => parse_compute_stage_input_block(bytes, TYPE7_FIRST_TLVS + consumed)?,
+        None => parse_compute_stage_input_block(bytes, SERIALIZER_OBJECT_FIRST_TLVS + consumed)?,
     };
     Ok(ComputePipelineDescriptor {
         kernel_func_ref: compact_tlv_u32(&fields, PIPELINE_TAG_KERNEL_FUNC).unwrap_or(0),
@@ -4886,7 +4939,7 @@ pub fn icb_layout_attribute_stride_slot_count(layout: &IcbCommandLayout) -> u32 
     icb_layout_table_len(start, end, ICB_ATTRIBUTE_STRIDE_ENTRY_SIZE)
 }
 
-/// Decode type-7 ICB create descriptor (tag 0x36, length 0x58).
+/// Decode serializer-object ICB create descriptor (tag 0x36, length 0x58).
 ///
 /// Field map from PGSerializer
 /// `newIndirectCommandBufferWithDescriptor:layout:maxCommandCount:options:allocator:`
@@ -4896,7 +4949,7 @@ pub fn decode_icb_descriptor(
 ) -> Result<IndirectCommandBufferDescriptor, DecodeStatus> {
     let op =
         reims_vgpu_wire::op(bytes, 0).map_err(|_| DecodeStatus::ErrShort("res_icb_desc_short"))?;
-    if op.opcode() != TYPE7_OBJECT_ICB
+    if op.opcode() != SERIALIZER_OBJECT_ICB
         || op.length() as usize != ICB_DESC_LEN
         || bytes.len() != ICB_DESC_LEN
     {
@@ -4927,42 +4980,44 @@ pub fn decode_icb_descriptor(
     })
 }
 
-/// Decode type-7 container (sampler / depth-stencil / pipelines / ICB).
-pub fn decode_type7_descriptor(bytes: &[u8]) -> Result<Descriptor, DecodeStatus> {
+/// Decode serializer-object container (sampler / depth-stencil / pipelines / ICB).
+pub fn decode_serializer_object_descriptor(bytes: &[u8]) -> Result<Descriptor, DecodeStatus> {
     if bytes.len() < 4 {
-        return Err(DecodeStatus::ErrShort("res_type7_short"));
+        return Err(DecodeStatus::ErrShort("res_serializer_object_short"));
     }
     let first = ld32(&bytes[0..]);
     match first {
-        TYPE7_OBJECT_SAMPLER => Ok(Descriptor::Sampler(decode_sampler_descriptor(bytes)?)),
-        TYPE7_OBJECT_DEPTH_STENCIL => Ok(Descriptor::DepthStencil(
+        SERIALIZER_OBJECT_SAMPLER => Ok(Descriptor::Sampler(decode_sampler_descriptor(bytes)?)),
+        SERIALIZER_OBJECT_DEPTH_STENCIL => Ok(Descriptor::DepthStencil(
             decode_depth_stencil_descriptor(bytes)?,
         )),
-        TYPE7_OBJECT_RENDER_PIPELINE => Ok(Descriptor::RenderPipeline(
+        SERIALIZER_OBJECT_RENDER_PIPELINE => Ok(Descriptor::RenderPipeline(
             decode_render_pipeline_descriptor(bytes)?,
         )),
-        TYPE7_OBJECT_COMPUTE_PIPELINE => Ok(Descriptor::ComputePipeline(
+        SERIALIZER_OBJECT_COMPUTE_PIPELINE => Ok(Descriptor::ComputePipeline(
             decode_compute_pipeline_descriptor(bytes)?,
         )),
-        TYPE7_OBJECT_ICB => Ok(Descriptor::IndirectCommandBuffer(decode_icb_descriptor(
+        SERIALIZER_OBJECT_ICB => Ok(Descriptor::IndirectCommandBuffer(decode_icb_descriptor(
             bytes,
         )?)),
-        _ => Err(DecodeStatus::ErrUnsupported("res_type7_subtype_unknown")),
+        _ => Err(DecodeStatus::ErrUnsupported(
+            "res_serializer_object_subtype_unknown",
+        )),
     }
 }
 
 pub fn decode_descriptor(object_type: u8, bytes: &[u8]) -> Result<Descriptor, DecodeStatus> {
     match object_type {
         OBJECT_TYPE_BUFFER => Ok(Descriptor::Buffer(decode_buffer_descriptor(bytes)?)),
-        OBJECT_TYPE_TEXTURE | OBJECT_TYPE_TEXTURE_VARIANT => {
+        OBJECT_TYPE_TEXTURE | OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS => {
             Ok(Descriptor::Texture(decode_texture_descriptor(bytes)?))
         }
         OBJECT_TYPE_FUNCTION => Ok(Descriptor::Function(decode_function_descriptor(bytes)?)),
-        OBJECT_TYPE_TYPE7 => decode_type7_descriptor(bytes),
+        OBJECT_TYPE_SERIALIZER_OBJECT => decode_serializer_object_descriptor(bytes),
         OBJECT_TYPE_TEXTURE_VIEW => Ok(Descriptor::TextureView(decode_texture_view_descriptor(
             bytes,
         )?)),
-        OBJECT_TYPE_IOSURFACE => decode_iosurface_texture_descriptor(bytes),
+        OBJECT_TYPE_MAPPER_REF_TEXTURE => decode_iosurface_texture_descriptor(bytes),
         _ => Err(DecodeStatus::ErrUnknownType("res_object_type_unknown")),
     }
 }

--- a/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
+++ b/crates/reims-vgpu/src/runtime/decode/resource/tests.rs
@@ -8,7 +8,7 @@ use crate::contract::endian::st32;
 fn sampler_record(state: u32) -> Vec<u8> {
     use reims_vgpu_wire::ops::sampler::NEW_SAMPLER_TOTAL_LEN;
     let mut b = vec![0u8; NEW_SAMPLER_TOTAL_LEN as usize];
-    st32(&mut b[0..], TYPE7_OBJECT_SAMPLER);
+    st32(&mut b[0..], SERIALIZER_OBJECT_SAMPLER);
     st32(&mut b[4..], NEW_SAMPLER_TOTAL_LEN);
     st32(&mut b[8..], 7);
     st32(&mut b[12..], state);
@@ -136,7 +136,7 @@ fn a_vertex_entry_tag_with_no_reader_is_reported() {
     assert!(
         clean
             .iter()
-            .filter(|l| l.contains("type7_pipeline_shape"))
+            .filter(|l| l.contains("serializer_object_pipeline_shape"))
             .all(|l| l.contains("unconsumed=0")),
         "the entries a guest sends are read whole; that is the reading this \
          instrument exists to make, and it must not be an absence: {clean:?}"
@@ -155,7 +155,9 @@ fn a_vertex_entry_tag_with_no_reader_is_reported() {
     let lines = cap2.lines();
     let shape: Vec<&String> = lines
         .iter()
-        .filter(|l| l.contains("type7_pipeline_shape") && l.contains("kind=vertex_layout"))
+        .filter(|l| {
+            l.contains("serializer_object_pipeline_shape") && l.contains("kind=vertex_layout")
+        })
         .collect();
     assert_eq!(
         shape.len(),
@@ -549,7 +551,7 @@ fn a_heap_texture_record_of_the_wrong_length_or_opcode_is_refused_by_name() {
 #[test]
 fn the_embedded_descriptor_decodes_through_the_shared_reader() {
     let mut bytes = heap_texture_record(0x01, 0x00, 0);
-    // packed: type 2, GPU-optimized contents, usage 5, format 80 — the
+    // packed: texture, GPU-optimized contents, usage 5, format 80 — the
     // shape the serializer produced for the oracle's baseline.
     st32(&mut bytes[HEAP_TEXTURE_DESCRIPTOR..], 0x0050_05c2);
     st32(&mut bytes[HEAP_TEXTURE_DESCRIPTOR + 4..], 0x1111);
@@ -572,7 +574,7 @@ fn the_embedded_descriptor_decodes_through_the_shared_reader() {
 ///
 /// This is the collapse the payload closes: **29 of the decoder's 40 sites
 /// were `ErrShort`**, one name for twenty-nine different reads spanning a
-/// 12-byte object-list entry, a type-7 TLV walk and a vertex-attribute
+/// 12-byte object-list entry, a serializer-object TLV walk and a vertex-attribute
 /// table offset. Asserting the class alone would pass on any of them.
 #[test]
 fn every_short_read_names_the_field_it_ran_out_on() {
@@ -599,11 +601,13 @@ fn every_short_read_names_the_field_it_ran_out_on() {
         decode_descriptor(0xfe, &[0u8; 64]).unwrap_err().slug(),
         "res_object_type_unknown"
     );
-    let mut type7 = [0u8; 64];
-    st32(&mut type7[0..], 0xdead_beef);
+    let mut serializer_object = [0u8; 64];
+    st32(&mut serializer_object[0..], 0xdead_beef);
     assert_eq!(
-        decode_type7_descriptor(&type7).unwrap_err().slug(),
-        "res_type7_subtype_unknown"
+        decode_serializer_object_descriptor(&serializer_object)
+            .unwrap_err()
+            .slug(),
+        "res_serializer_object_subtype_unknown"
     );
 }
 
@@ -611,7 +615,7 @@ fn every_short_read_names_the_field_it_ran_out_on() {
 fn icb_descriptor_from_serializer_fixture() {
     // PGSerializer emission: ConcurrentDispatch, maxKernel=4, maxCmd=8, options=0.
     let mut b = [0u8; ICB_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_ICB);
+    st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
     st32(&mut b[4..], ICB_DESC_LEN as u32);
     st32(&mut b[8..], MTL_INDIRECT_CMD_CONCURRENT_DISPATCH);
     // bind counts as u8: vertex, fragment, kernel, …
@@ -720,7 +724,7 @@ fn the_decoded_flag_word_holds_no_bit_the_serializer_never_wrote() {
     let mut seen = std::collections::BTreeSet::new();
     for ring in [0x00u8, 0x80, 0xff] {
         let mut b = [0u8; ICB_DESC_LEN];
-        st32(&mut b[0..], TYPE7_OBJECT_ICB);
+        st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
         st32(&mut b[4..], ICB_DESC_LEN as u32);
         st32(&mut b[8..], MTL_INDIRECT_CMD_DRAW);
         // Every written bit set, plus whatever the ring left in bit 15.
@@ -851,7 +855,7 @@ fn the_options_word_ignores_the_two_bytes_the_serializer_never_writes() {
     let mut decoded = Vec::new();
     for ring in [0x00u8, 0xaa, 0x55, 0xff] {
         let mut b = [0u8; ICB_DESC_LEN];
-        st32(&mut b[0..], TYPE7_OBJECT_ICB);
+        st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
         st32(&mut b[4..], ICB_DESC_LEN as u32);
         st32(&mut b[8..], MTL_INDIRECT_CMD_DRAW);
         b[ICB_DESC_MAX_VERTEX_BINDS] = 4;
@@ -885,7 +889,7 @@ fn the_options_word_ignores_the_two_bytes_the_serializer_never_writes() {
 #[test]
 fn a_dispatch_only_command_mask_keeps_the_stated_fragment_bind_count() {
     let mut b = [0u8; ICB_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_ICB);
+    st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
     st32(&mut b[4..], ICB_DESC_LEN as u32);
     // Dispatch bits only — no draw bit anywhere in the mask.
     st32(
@@ -910,7 +914,7 @@ fn a_dispatch_only_command_mask_keeps_the_stated_fragment_bind_count() {
     assert_eq!(icb.max_kernel_buffer_bind_count, 4);
     assert_eq!(icb.layout.command_size, layout.command_size);
     assert_eq!(icb.layout.kernel_buffer_bind_offset, 0x64);
-    match decode_type7_descriptor(&b).unwrap() {
+    match decode_serializer_object_descriptor(&b).unwrap() {
         Descriptor::IndirectCommandBuffer(d) => assert_eq!(d.max_command_count, 8),
         _ => panic!("expected ICB"),
     }
@@ -931,7 +935,7 @@ fn icb_create_body_max_count_matrix() {
 
     // --- Decode: single-byte fields at RE offsets ---
     let mut b = [0u8; ICB_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_ICB);
+    st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
     st32(&mut b[4..], ICB_DESC_LEN as u32);
     st32(
         &mut b[8..],
@@ -1118,7 +1122,7 @@ fn macos12_shaped_compute_pipeline(kernel_ref: u32, attrs: u32, layouts: u32) ->
     // Two fields of `[tag][len][u32]` behind a one-byte count, then padding to
     // the section's four-byte alignment.
     const TLV_TWO_FIELDS: usize = 1 + 2 * (1 + 1 + 4);
-    let section = (TYPE7_FIRST_TLVS + TLV_TWO_FIELDS).next_multiple_of(4);
+    let section = (SERIALIZER_OBJECT_FIRST_TLVS + TLV_TWO_FIELDS).next_multiple_of(4);
     // The section's own two fields, then its two offset arrays and compact-TLV
     // entries. Both entry kinds carry four u32 properties.
     const ENTRY_LEN: usize = 1 + 4 * (1 + 1 + 4);
@@ -1129,17 +1133,17 @@ fn macos12_shaped_compute_pipeline(kernel_ref: u32, attrs: u32, layouts: u32) ->
     let total = section + layout_rel + layout_array_len;
 
     let mut b = vec![0u8; total];
-    st32(&mut b[0..], TYPE7_OBJECT_COMPUTE_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_COMPUTE_PIPELINE);
     st32(&mut b[4..], total as u32);
     st32(&mut b[8..], kernel_ref + 1);
-    st32(&mut b[12..], (total - TYPE7_FIRST_TLVS) as u32);
+    st32(&mut b[12..], (total - SERIALIZER_OBJECT_FIRST_TLVS) as u32);
 
-    b[TYPE7_FIRST_TLVS] = 2;
-    let mut p = TYPE7_FIRST_TLVS + 1;
+    b[SERIALIZER_OBJECT_FIRST_TLVS] = 2;
+    let mut p = SERIALIZER_OBJECT_FIRST_TLVS + 1;
     for (tag, value) in [
         (
             PIPELINE_TAG_COMPUTE_STAGE_INPUT_OFFSET,
-            (section - TYPE7_FIRST_TLVS) as u32,
+            (section - SERIALIZER_OBJECT_FIRST_TLVS) as u32,
         ),
         (PIPELINE_TAG_KERNEL_FUNC, kernel_ref),
     ] {
@@ -1264,9 +1268,9 @@ fn a_populated_compute_stage_input_section_preserves_every_field() {
 #[test]
 fn a_compute_stage_input_offset_is_bounds_checked_and_zero_means_nil() {
     // The offset field sits at the start of the first TLV entry's value.
-    let off_at = TYPE7_FIRST_TLVS + 1 + 2;
+    let off_at = SERIALIZER_OBJECT_FIRST_TLVS + 1 + 2;
     assert_eq!(
-        macos12_shaped_compute_pipeline(9, 0, 0)[TYPE7_FIRST_TLVS + 1],
+        macos12_shaped_compute_pipeline(9, 0, 0)[SERIALIZER_OBJECT_FIRST_TLVS + 1],
         PIPELINE_TAG_COMPUTE_STAGE_INPUT_OFFSET,
         "the builder emits the offset tag first"
     );
@@ -1302,14 +1306,14 @@ fn a_stage_input_at_the_wire_count_field_maximum_loses_nothing() {
     let n = COMPUTE_STAGE_INPUT_HEADER0_COUNT_MASK;
     let ns = n as usize;
 
-    // Same 24-byte type-7 prefix as the fixture above (tag, declared length,
+    // Same 24-byte serializer-object prefix as the fixture above (tag, declared length,
     // then an empty first TLV record), so the stage-input block starts at 24.
     const BLOCK: usize = 24;
     let layout_section = BLOCK + COMPUTE_STAGE_INPUT_MIN_LEN;
     let attr_section = layout_section + ns * COMPUTE_STAGE_INPUT_LAYOUT_ENTRY_SIZE;
     let total = attr_section + ns * COMPUTE_STAGE_INPUT_ATTR_ENTRY_SIZE;
     let mut b = vec![0u8; total];
-    st32(&mut b[0..], TYPE7_OBJECT_COMPUTE_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_COMPUTE_PIPELINE);
     st32(&mut b[4..], total as u32);
     // word0, then header0: payload length (everything after word0) plus both
     // count fields at their maximum.
@@ -1338,7 +1342,7 @@ fn a_stage_input_at_the_wire_count_field_maximum_loses_nothing() {
     }
 
     let si = decode_compute_pipeline_descriptor(&b)
-        .expect("type-7 decodes")
+        .expect("serializer-object decodes")
         .stage_input
         .expect("stage-input block");
     assert_eq!(si.dropped_attributes, 0, "no attribute may be dropped");
@@ -1382,7 +1386,7 @@ fn list_entry_and_buffer() {
 }
 
 #[test]
-fn iosurface_type11() {
+fn iosurface_mapper_ref_texture() {
     let mut b = [0u8; 0x20];
     b[0] = 2;
     b[0x16] = 0x50;
@@ -1761,7 +1765,7 @@ fn a_level_record_the_body_does_not_reach_is_reported_not_dropped() {
     );
 }
 
-/// The type-7 header states its payload length twice, and a record where the
+/// The serializer-object header states its payload length twice, and a record where the
 /// two disagree says so.
 ///
 /// The declared length at `+4` covers the header plus the payload padded to
@@ -1773,14 +1777,14 @@ fn a_level_record_the_body_does_not_reach_is_reported_not_dropped() {
 /// why it reports rather than refuses, and why a future promotion to a refusal
 /// has to fix the fixtures first rather than only measure a boot.
 #[test]
-fn a_type7_header_states_its_payload_length_twice_and_says_when_they_disagree() {
+fn a_serializer_object_header_states_its_payload_length_twice_and_says_when_they_disagree() {
     use crate::contract::endian::st32;
 
     // A minimal classic pipeline: header, then a one-field TLV block of seven
     // bytes, padded to eight by the declared length.
     let mut b = vec![0u8; 16 + 8];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 3);
     st32(&mut b[12..], 7);
@@ -1796,7 +1800,7 @@ fn a_type7_header_states_its_payload_length_twice_and_says_when_they_disagree() 
     assert!(
         !cap.lines()
             .iter()
-            .any(|l| l.contains("type7_payload_len_disagrees")),
+            .any(|l| l.contains("serializer_object_payload_len_disagrees")),
         "7 rounds up to 8 and 16 + 8 is the declared length, so the two agree: \
          {:?}",
         cap.lines()
@@ -1810,7 +1814,7 @@ fn a_type7_header_states_its_payload_length_twice_and_says_when_they_disagree() 
     assert!(
         lines
             .iter()
-            .any(|l| l.contains("type7_payload_len_disagrees")
+            .any(|l| l.contains("serializer_object_payload_len_disagrees")
                 && l.contains("payload=9")
                 && l.contains("declared=24")
                 && l.contains("expected=28")),
@@ -1822,10 +1826,10 @@ fn a_type7_header_states_its_payload_length_twice_and_says_when_they_disagree() 
 #[test]
 fn compact_render_pipeline_funcs() {
     use crate::contract::endian::st32;
-    // Minimal type-7 render pipeline: header + fieldCount=2 with vert/frag refs.
+    // Minimal serializer-object render pipeline: header + fieldCount=2 with vert/frag refs.
     let mut b = vec![0u8; 16 + 1 + 6 + 6];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 9);
     b[16] = 2;
@@ -1858,7 +1862,7 @@ fn compact_render_pipeline_funcs() {
 fn a_depth_stencil_pipeline_with_a_sample_count_decodes() {
     let mut b = vec![0u8; 16 + 1 + 5 * 6];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 20);
     // Written in the order the guest's serializer emits them: the descriptor's
@@ -1888,20 +1892,20 @@ fn a_depth_stencil_pipeline_with_a_sample_count_decodes() {
     );
 }
 
-/// Build a type-7 render-pipeline descriptor out of a compact-TLV field list.
+/// Build a serializer-object render-pipeline descriptor out of a compact-TLV field list.
 ///
 /// Three tests below differ only in the fields, and each hand-rolled the same
 /// header/offset arithmetic. One builder means a layout change fails once.
 #[cfg(test)]
 fn render_pipeline_desc(object_id: u32, fields: &[(u8, u32)]) -> Vec<u8> {
-    let mut b = vec![0u8; TYPE7_FIRST_TLVS + 1 + fields.len() * 6];
+    let mut b = vec![0u8; SERIALIZER_OBJECT_FIRST_TLVS + 1 + fields.len() * 6];
     let len = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], len);
     st32(&mut b[8..], object_id);
-    st32(&mut b[12..], len - TYPE7_FIRST_TLVS as u32);
-    b[TYPE7_FIRST_TLVS] = fields.len() as u8;
-    let mut p = TYPE7_FIRST_TLVS + 1;
+    st32(&mut b[12..], len - SERIALIZER_OBJECT_FIRST_TLVS as u32);
+    b[SERIALIZER_OBJECT_FIRST_TLVS] = fields.len() as u8;
+    let mut p = SERIALIZER_OBJECT_FIRST_TLVS + 1;
     for &(tag, value) in fields {
         b[p] = tag;
         b[p + 1] = 4;
@@ -1974,7 +1978,7 @@ fn a_declared_input_primitive_topology_does_not_refuse_the_pipeline() {
     let decode_at = |topology: u32| {
         let mut b = vec![0u8; 16 + 1 + 6 + 6];
         let blen = b.len() as u32;
-        st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+        st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
         st32(&mut b[4..], blen);
         st32(&mut b[8..], 9);
         b[16] = 2;
@@ -2044,14 +2048,14 @@ fn a_classic_tessellation_pipeline_preserves_its_three_properties() {
         (PIPELINE_TAG_TESSELLATION_FACTOR_STEP_FUNCTION, 1),
         (PIPELINE_TAG_TESSELLATION_OUTPUT_WINDING_ORDER, 1),
     ];
-    let mut b = vec![0u8; TYPE7_FIRST_TLVS + 1 + fields.len() * 6];
+    let mut b = vec![0u8; SERIALIZER_OBJECT_FIRST_TLVS + 1 + fields.len() * 6];
     let len = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], len);
     st32(&mut b[8..], 22);
-    st32(&mut b[12..], len - TYPE7_FIRST_TLVS as u32);
-    b[TYPE7_FIRST_TLVS] = fields.len() as u8;
-    let mut p = TYPE7_FIRST_TLVS + 1;
+    st32(&mut b[12..], len - SERIALIZER_OBJECT_FIRST_TLVS as u32);
+    b[SERIALIZER_OBJECT_FIRST_TLVS] = fields.len() as u8;
+    let mut p = SERIALIZER_OBJECT_FIRST_TLVS + 1;
     for (tag, value) in fields {
         b[p] = tag;
         b[p + 1] = 4;
@@ -2082,7 +2086,7 @@ fn a_pipeline_sample_count_is_preserved_for_backend_rasterization() {
     let pipeline = |count: u32| {
         let mut b = vec![0u8; 16 + 1 + 6];
         let blen = b.len() as u32;
-        st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+        st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
         st32(&mut b[4..], blen);
         st32(&mut b[8..], 21);
         b[16] = 1;
@@ -2139,7 +2143,7 @@ fn an_unidentified_pipeline_descriptor_field_refuses_the_pipeline() {
 
     let mut b = vec![0u8; 16 + 1 + 6 + 6 + 6];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 9);
     b[16] = 3;
@@ -2163,7 +2167,7 @@ fn an_unidentified_pipeline_descriptor_field_refuses_the_pipeline() {
 
     let shape: Vec<&String> = lines
         .iter()
-        .filter(|l| l.contains("type7_pipeline_shape"))
+        .filter(|l| l.contains("serializer_object_pipeline_shape"))
         .collect();
     assert_eq!(
         shape.len(),
@@ -2244,7 +2248,7 @@ fn an_identified_but_unapplied_pipeline_field_still_builds_the_pipeline() {
 
     let mut b = vec![0u8; 16 + 1 + 6 + 6 + 6];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 9);
     b[16] = 3;
@@ -2280,7 +2284,7 @@ fn an_identified_but_unapplied_pipeline_field_still_builds_the_pipeline() {
     // for alarm — starred as unread, and not counted as unknown.
     let shape: Vec<&String> = lines
         .iter()
-        .filter(|l| l.contains("type7_pipeline_shape"))
+        .filter(|l| l.contains("serializer_object_pipeline_shape"))
         .collect();
     assert_eq!(shape.len(), 1, "{lines:?}");
     assert!(
@@ -2327,7 +2331,7 @@ fn a_classic_pipeline_takes_its_vertex_block_from_the_stated_offset() {
 
     let mut b = vec![0u8; 16 + color_rel + 8];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 12);
     b[16] = 4;
@@ -2364,7 +2368,7 @@ fn a_classic_pipeline_takes_its_vertex_block_from_the_stated_offset() {
     assert!(
         !cap.lines()
             .iter()
-            .any(|l| l.contains("type7_vertex_block_inferred")),
+            .any(|l| l.contains("serializer_object_vertex_block_inferred")),
         "and a descriptor that stated its offset must not report the fallback: \
          {:?}",
         cap.lines()
@@ -2383,7 +2387,7 @@ fn a_classic_pipeline_without_the_offset_reports_no_vertex_descriptor() {
 
     let mut b = vec![0u8; 16 + 13 + 8];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 13);
     b[16] = 2;
@@ -2417,7 +2421,7 @@ fn compact_render_pipeline_object_mesh_funcs() {
     // offset must carry the eight header bytes a real descriptor carries.
     let mut b = vec![0u8; 16 + 24 + 8];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 7);
     b[16] = 4;
@@ -2447,7 +2451,7 @@ fn compact_render_pipeline_object_mesh_funcs() {
 fn depth_stencil_object_decode() {
     use crate::contract::endian::st32;
     let mut b = vec![0u8; DEPTH_STENCIL_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_DEPTH_STENCIL);
+    st32(&mut b[0..], SERIALIZER_OBJECT_DEPTH_STENCIL);
     st32(&mut b[4..], DEPTH_STENCIL_DESC_LEN as u32);
     st32(&mut b[DEPTH_STENCIL_DESC_ID..], 5);
     // compare Less=1, write enabled, both stencil enabled
@@ -2815,7 +2819,7 @@ fn an_unconsumed_colour_attachment_field_refuses_the_pipeline() {
 
     let shape: Vec<&String> = lines
         .iter()
-        .filter(|l| l.contains("type7_color_attach_shape"))
+        .filter(|l| l.contains("serializer_object_color_attach_shape"))
         .collect();
     assert_eq!(
         shape.len(),
@@ -3319,26 +3323,23 @@ fn decodes_opcode9_buffer_texture_live_blobs() {
         TEXTURE_VIEW_MIN_RANGED as u32,
     );
     assert!(decode_buffer_texture_descriptor(&view).is_err());
+    assert_eq!(texture_view_opcode(&view), Some(TEXTURE_VIEW_OPCODE_RANGED));
     assert_eq!(
-        texture_type8_opcode(&view),
-        Some(TEXTURE_VIEW_OPCODE_RANGED)
-    );
-    assert_eq!(
-        texture_type8_opcode(&b1),
+        texture_view_opcode(&b1),
         Some(TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE)
     );
 }
 
 /// The header peek is bounded by the header, not by one variant's total.
 ///
-/// A truncated type-8 blob still names which variant the guest meant, and
+/// A truncated texture-view blob still names which variant the guest meant, and
 /// that name is what routes it to the decoder that can report the
 /// truncation. Bounding the peek by the *simple view's* total length (20)
 /// instead returned `None` for every blob of 8..20 bytes, so a short record
 /// of any other variant read as "no opcode" and was refused by whichever
 /// caller's fallback ran first, naming the wrong reason.
 #[test]
-fn the_type8_header_peek_is_bounded_by_the_header_it_reads() {
+fn the_texture_view_header_peek_is_bounded_by_the_header_it_reads() {
     // Exactly the header, declaring a 64-byte buffer-backed texture: the
     // shortest blob that carries an opcode at all.
     let mut short = vec![0u8; OP_HDR];
@@ -3348,7 +3349,7 @@ fn the_type8_header_peek_is_bounded_by_the_header_it_reads() {
     );
     crate::contract::endian::st32(&mut short[TEXTURE_VIEW_DESC_LEN..], BUF_TEX_MIN_LEN as u32);
     assert_eq!(
-        texture_type8_header(&short),
+        texture_view_header(&short),
         Some((TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE, BUF_TEX_MIN_LEN as u32)),
         "a header-length blob must still name its variant and its declared length"
     );
@@ -3356,8 +3357,8 @@ fn the_type8_header_peek_is_bounded_by_the_header_it_reads() {
     assert!(decode_buffer_texture_descriptor(&short).is_err());
 
     // One byte short of a header is the only case with nothing to read.
-    assert_eq!(texture_type8_header(&short[..OP_HDR - 1]), None);
-    assert_eq!(texture_type8_opcode(&short[..OP_HDR - 1]), None);
+    assert_eq!(texture_view_header(&short[..OP_HDR - 1]), None);
+    assert_eq!(texture_view_opcode(&short[..OP_HDR - 1]), None);
 }
 
 fn hex_to_bytes(s: &str) -> Vec<u8> {
@@ -3376,10 +3377,10 @@ fn property_fuzz_types() {
     }
 }
 
-/// A type-7 subtype **is** a `PGSerializer` opcode, and the two this module
+/// A serializer-object subtype **is** a `PGSerializer` opcode, and the two this module
 /// still spells as numbers are exactly the two nothing has driven.
 ///
-/// The type-7 object-list entry is reached by object *type* rather than off
+/// The serializer object's object-list entry is reached by object *type* rather than off
 /// the command stream, which is why its subtypes look like a private
 /// enumeration and were written as one. They are not: `0x03` is
 /// `newSamplerState`, `0x04` is `newDepthStencilState` and `0x36` is
@@ -3400,7 +3401,7 @@ fn property_fuzz_types() {
 /// number from the wrong opcode space — the same trap `0x1b` sets, where
 /// the texture-view creation and `useHeap:` share a value.
 #[test]
-fn the_undrivable_type7_subtypes_are_the_pipeline_pair_and_nothing_claims_them() {
+fn the_undrivable_serializer_object_subtypes_are_the_pipeline_pair_and_nothing_claims_them() {
     let serializer_opcodes = |op: u32| {
         reims_vgpu_wire::manifest::MANIFEST
             .iter()
@@ -3410,9 +3411,12 @@ fn the_undrivable_type7_subtypes_are_the_pipeline_pair_and_nothing_claims_them()
 
     // The three that are derived must still be, in the serializer's space.
     for (tag, name) in [
-        (TYPE7_OBJECT_SAMPLER, "TYPE7_OBJECT_SAMPLER"),
-        (TYPE7_OBJECT_DEPTH_STENCIL, "TYPE7_OBJECT_DEPTH_STENCIL"),
-        (TYPE7_OBJECT_ICB, "TYPE7_OBJECT_ICB"),
+        (SERIALIZER_OBJECT_SAMPLER, "SERIALIZER_OBJECT_SAMPLER"),
+        (
+            SERIALIZER_OBJECT_DEPTH_STENCIL,
+            "SERIALIZER_OBJECT_DEPTH_STENCIL",
+        ),
+        (SERIALIZER_OBJECT_ICB, "SERIALIZER_OBJECT_ICB"),
     ] {
         assert!(
             serializer_opcodes(tag),
@@ -3425,10 +3429,13 @@ fn the_undrivable_type7_subtypes_are_the_pipeline_pair_and_nothing_claims_them()
     // derivation and must come from it rather than stay a literal.
     for (tag, name) in [
         (
-            TYPE7_OBJECT_COMPUTE_PIPELINE,
-            "TYPE7_OBJECT_COMPUTE_PIPELINE",
+            SERIALIZER_OBJECT_COMPUTE_PIPELINE,
+            "SERIALIZER_OBJECT_COMPUTE_PIPELINE",
         ),
-        (TYPE7_OBJECT_RENDER_PIPELINE, "TYPE7_OBJECT_RENDER_PIPELINE"),
+        (
+            SERIALIZER_OBJECT_RENDER_PIPELINE,
+            "SERIALIZER_OBJECT_RENDER_PIPELINE",
+        ),
     ] {
         assert!(
             !serializer_opcodes(tag),

--- a/crates/reims-vgpu/src/runtime/decode/stream.rs
+++ b/crates/reims-vgpu/src/runtime/decode/stream.rs
@@ -177,7 +177,7 @@ pub fn segment_type_name(type_: u32) -> &'static str {
 /// What the stream walker should do with a segment family.
 ///
 /// This exists so the walker's "everything else" arm is a decision rather than a
-/// fallthrough. It used to be `_ => {}`, which gave the same silence to a type-5
+/// fallthrough. It used to be `_ => {}`, which gave the same silence to a ref-texture
 /// envelope the contract says to skip and to a segment family the host has never
 /// seen — and the second of those is unknown wire format.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -195,7 +195,7 @@ pub enum SegmentDisposition {
     /// The wording here was "raw envelope bytes carrying no decodable protection
     /// value", which was a guess written where a measurement now sits. Driven
     /// under `-setSupportsProtectionOptionsEnvelope:` the burst is exactly three
-    /// records: this type-5 header, then **eight fully-written bytes that are the
+    /// records: this ref-texture header, then **eight fully-written bytes that are the
     /// `protectionOptions:` argument verbatim**, then the ordinary segment
     /// header. `reims_vgpu_wire::ops::segment::ProtectionOptionsEnvelope` is the
     /// view; `blit_begin_segment_protected` sends `0x44` and `..._alt` sends

--- a/crates/reims-vgpu/src/runtime/drain/census/mod.rs
+++ b/crates/reims-vgpu/src/runtime/drain/census/mod.rs
@@ -2865,10 +2865,10 @@ pub fn note_drain_tranche(
             crate::observe::off(routes);
         }
         // Beside `store_routes` deliberately: the two are read against each
-        // other. `type4_backing_fail` lines equal `type4_backing_recovered +
-        // type4_backing_superseded` from that line plus this one's `n`, and a
+        // other. `backing_fail` lines equal `backing_recovered +
+        // backing_superseded` from that line plus this one's `n`, and a
         // refusal that never recovered is only visible as the residue.
-        if let Some(outstanding) = crate::runtime::objects::type4_backing_outstanding_census() {
+        if let Some(outstanding) = crate::runtime::objects::backing_outstanding_census() {
             crate::observe::off(outstanding);
         }
         // The same reason and the same place: `store_routes` counts the watches
@@ -3091,7 +3091,7 @@ pub fn note_readback_gpu_us(barrier_us: u64, copy_us: u64) {
 /// The routes are the attribution for `engine_delta`'s readback bytes: only
 /// `cpu_portability` reads a full frame back and CPU-copies it into the guest's
 /// pages, and only it is forced to — `gva_store_defer_eligible` refuses any
-/// target with a nonzero `mapping_id`, so a type-11 composite Store has no
+/// target with a nonzero `mapping_id`, so a mapper-ref-texture composite Store has no
 /// deferred rail to take. Whether that is 2 Stores a second or 20 decides
 /// whether building one is worth it, and the route's own first-appearance line
 /// is deduplicated per process and cannot say.
@@ -3125,14 +3125,14 @@ thread_local! {
 /// ```text
 /// AUC 0.75  surface_flush             permutation p = 0.021 raw
 /// AUC 0.73  load_seed_ok                            p = 0.914 Bonferroni
-/// AUC 0.72  type11_seed_uploaded      (43 columns tested)
-/// AUC 0.72  type11_seed_guest_wrote
+/// AUC 0.72  mapper_ref_texture_seed_uploaded      (43 columns tested)
+/// AUC 0.72  mapper_ref_texture_seed_guest_wrote
 /// AUC 0.71  t11_gw_ref_moved
 /// ```
 ///
 /// Corrected for having looked at 43 columns, nothing is distinguishable from
 /// noise. The leaders are also largely one quantity wearing different names — a
-/// type-11 seed upload is a `load_seed_ok_mapping` — so they are one weak
+/// mapper-ref-texture seed upload is a `load_seed_ok_mapping` — so they are one weak
 /// signal, not five.
 ///
 /// The reason is structural rather than a gap to be filled by adding counters.
@@ -3291,12 +3291,11 @@ mod drain_gap_tests {
         // divide the whole process lifetime into one tranche — so the window
         // under test has to be opened before anything is accumulated into it.
         assert!(c.note(0, 0, 1).is_none(), "the first call arms the window");
-        // Six entries on a fixed stride, each: 40 idle, 10 lock, 30 drain, 5
-        // publish, 16 post — 16 so the four-way sweep split divides it whole and
-        // the shortfall check below reads truncation as nothing. Times are microseconds on the crate clock. The
-        // first entry's idle is the one span that cannot be measured — there is
-        // no previous exit to measure it from — so it lies before `t0` and is
-        // not part of what has to tile.
+        // Six entries on a fixed stride, each: 40 idle, 10 lock, 30 drain, 5 publish, 16 post — 16
+        // so the four-way sweep split divides it whole and the shortfall check below reads
+        // truncation as nothing. Times are microseconds on the crate clock. The first entry's idle
+        // is the one span that cannot be measured — there is no previous exit to measure it from —
+        // so it lies before `t0` and is not part of what has to tile.
         let (idle, lock, drain, publish, post) = (40u64, 10u64, 30u64, 5u64, 16u64);
         let stride = idle + lock + drain + publish + post;
         let entries = 6u64;

--- a/crates/reims-vgpu/src/runtime/drain/mod.rs
+++ b/crates/reims-vgpu/src/runtime/drain/mod.rs
@@ -3199,9 +3199,9 @@ fn present_named_mapping<H: HostMemory + HostOps>(
     state.present.present_mapping = mapping;
     state.present.host_mapping = mapping;
     state.present.valid = true;
-    // x86: present surface_id → type-4 object-list slot (heap index =
+    // x86: present surface_id → backing object-list slot (heap index =
     // IOSurface getSurfaceID). Arm: MappingInternal page-table resolve.
-    // Always attempt type-4 when pages empty; then iosfc/mapper path.
+    // Always attempt backing when pages empty; then iosfc/mapper path.
     let _ = crate::runtime::objects::ensure_surface_for_present(state, host, mapping);
     let force = state
         .mappings
@@ -3774,7 +3774,7 @@ fn apply_map_family<H: HostMemory + HostOps>(
         //   host_gva_surfaces for sample (wallpaper wipe class).
         // - Map notify: PTEs already live → flush host_gva encode into
         //   **new** PFNs (not invent PTEs; not invent geom). Discrete
-        //   type-2/3 content may live only in host_cache until this.
+        //   normal-texture content may live only in host_cache until this.
         // Samples still prefer host_cache GVA key on Load.
         //
         // HostOps **views** (gva_host_views) are the opposite of encode
@@ -4091,7 +4091,7 @@ fn process_child_packet<H: HostMemory + HostOps>(
             apply_define_task2(state, host, &packet.payload, Some(channel_id));
         }
         // A short SET_OBJECT_LIST leaves the task's object list unbound — every
-        // type-11 texture/object resolve on it then fails
+        // mapper-ref-texture/object resolve on it then fails
         // (object_list_count==0). Never on a well-formed boot.
         CHILD_OP_SET_OBJECT_LIST => {
             apply_set_object_list(state, &packet.payload, Some(channel_id));
@@ -4153,7 +4153,7 @@ fn process_child_packet<H: HostMemory + HostOps>(
         }
         /*
          * Scanout policy:
-         * - Early boot: front type-11 writebacks paint while !frame_flush_seen
+         * - Early boot: front mapper-ref-texture writebacks paint while !frame_flush_seen
          *   and job W×H matches established console (no mid-switch thrash).
          * - After first boundary: display presents paint (op8 DisplaySwap on
          *   arm ch4, **or** the op6/op7 transactions on x86 Ventura/Tahoe
@@ -4312,7 +4312,7 @@ fn process_child_packet<H: HostMemory + HostOps>(
             } else {
                 // Process this channel's exec packet. Archive does not drain
                 // other child FIFOs here; surface RAW is render_wait_surface on
-                // the specific type-11/GVA key at sample/Load/swap sites.
+                // the specific mapper-ref-texture/GVA key at sample/Load/swap sites.
                 let result =
                     crate::runtime::exec::process_exec_indirect2(state, host, &packet.payload);
                 let channel_bit = 1u32.checked_shl(channel_id).unwrap_or(0);

--- a/crates/reims-vgpu/src/runtime/drain/tests.rs
+++ b/crates/reims-vgpu/src/runtime/drain/tests.rs
@@ -514,7 +514,7 @@ fn replace_physical_drops_the_cached_page_list() {
         let m = state.mappings.get_mut(&7).unwrap();
         m.mapped = true;
         m.page_entries = vec![0x11, 0x22, 0x33];
-        m.type4_walk = Some(crate::model::Type4Walk {
+        m.backing_walk = Some(crate::model::BackingWalk {
             task_id: 0,
             backing_pfn: 0x20,
             map_generation: m.map_generation,
@@ -549,11 +549,11 @@ fn replace_physical_drops_the_cached_page_list() {
     assert_ne!(
         m.map_generation, generation_before,
         "dropping the list must bump the incarnation, which is what retires the \
-         type-4 walk latch and any state keyed on it"
+         backing walk latch and any state keyed on it"
     );
 }
 
-/// A re-point naming a type-11 resource reaches the mapping associated with its
+/// A re-point naming a mapper-ref-texture resource reaches the mapping associated with its
 /// task-local ref. This is the packet family the arm used to drop entirely —
 /// 57 % of the re-points on a driven boot found no mapping under `object_id` —
 /// and dropping it leaves the texture's page list trusted while it names pages
@@ -562,7 +562,7 @@ fn replace_physical_drops_the_cached_page_list() {
 fn replace_physical_routes_through_the_texture_ref_when_no_mapping_owns_the_id() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     let mut host = FakeHost::new();
-    // Mapping 41 backs a type-11 texture the guest registered at object-list
+    // Mapping 41 backs a mapper-ref-texture the guest registered at object-list
     // ref 12 of task 3. Nothing is mapped under id 12.
     state.map_surface(41);
     {
@@ -660,7 +660,7 @@ fn replace_physical_retires_only_the_named_resource() {
 
 /// A same-number mapping owned by another task must not capture a task-local
 /// resource re-point. The association names mapping 99; mapping 7 merely shares
-/// its integer and has independent type-4 provenance.
+/// its integer and has independent backing provenance.
 #[test]
 fn replace_physical_does_not_confuse_another_tasks_mapping_for_the_resource() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -670,7 +670,7 @@ fn replace_physical_does_not_confuse_another_tasks_mapping_for_the_resource() {
         let m = state.mappings.get_mut(&7).unwrap();
         m.mapped = true;
         m.page_entries = vec![0x77];
-        m.type4_walk = Some(crate::model::Type4Walk {
+        m.backing_walk = Some(crate::model::BackingWalk {
             task_id: 1,
             backing_pfn: 0x20,
             map_generation: m.map_generation,

--- a/crates/reims-vgpu/src/runtime/draw/metal/depth_stencil.rs
+++ b/crates/reims-vgpu/src/runtime/draw/metal/depth_stencil.rs
@@ -2,16 +2,15 @@
 //!
 //! Metal is handed a pointer to host memory for each aspect, seeded from the
 //! guest's CLEAR value or read back from its texture, and written back into the
-//! guest's type-11 mapping when the pass stores. That is one procedure over a
+//! guest's mapper-ref-texture mapping when the pass stores. That is one procedure over a
 //! buffer whose texel is four bytes for depth and one for stencil — and it used
 //! to be written out twice, once per aspect, in the caller.
 //!
-//! The two copies had already drifted. Both tested `level` and
-//! `resolve_texture_ref` and neither tested `slice` or `depth_plane`, while the
-//! owning rule they were copies of
+//! The two copies had already drifted. Both tested `level` and `resolve_texture_ref` and neither
+//! tested `slice` or `depth_plane`, while the owning rule they were copies of
 //! ([`attachment_subresource_is_bindable`](crate::runtime::decode::render::attachment_subresource_is_bindable))
-//! tests all four; and both refused in silence, so an attachment this rail
-//! could not carry vanished with nothing in the log.
+//! tests all four; and both refused in silence, so an attachment this rail could not carry vanished
+//! with nothing in the log.
 
 use super::{degrade_log_first, load_linear_raw, DeviceState, DrawEncodeRequest};
 use crate::contract::pass_action::{
@@ -119,7 +118,7 @@ impl From<StencilAttachment> for HostAttachment {
 /// where a STORE puts them back.
 pub(super) struct HostDepthStencil {
     pub(super) data: Vec<u8>,
-    /// Type-11 mapping behind the attachment's texture, or 0 when the texture
+    /// Mapper-ref-texture mapping behind the attachment's texture, or 0 when the texture
     /// resolved to none — a STORE has nowhere to go in that case.
     mapping_id: u32,
     store_action: u16,
@@ -210,7 +209,8 @@ pub(super) fn seed_host_depth_stencil<M: HostMemory + HostOps>(
     let row_bytes = width.saturating_mul(spec.bytes_per_texel);
     let mut data = vec![0u8; (row_bytes as usize).saturating_mul(height as usize)];
     let mapping_id =
-        objects::resolve_type11_ref(state, host, req.task_id, attach.texture_ref).unwrap_or(0);
+        objects::resolve_mapper_ref_texture(state, host, req.task_id, attach.texture_ref)
+            .unwrap_or(0);
     if mapping_id != 0 {
         let _ = mapper::ensure_resolved_for_scanout(state, host, mapping_id);
     }

--- a/crates/reims-vgpu/src/runtime/draw/metal/icb.rs
+++ b/crates/reims-vgpu/src/runtime/draw/metal/icb.rs
@@ -720,7 +720,7 @@ fn render_icb_declined(
     }
 }
 
-/// Materializes type-7 ICB `0x36`, optionally re-fills from bound command
+/// Materializes serializer-object ICB `0x36`, optionally re-fills from bound command
 /// memory (`0x1d1` / associate), then `executeCommandsInBuffer:withRange:`.
 /// Empty ranges are valid Metal (no-op). Color writeback mirrors draw path.
 ///
@@ -909,7 +909,7 @@ pub fn encode_icb_execute_and_writeback<M: HostMemory + HostOps>(
         return EncodeStatus::MetalFailed("icb_exec_command_buffer_error");
     }
 
-    // Writeback each color RT (type-11 mapping or type-2/3 GVA).
+    // Writeback each color RT (mapper-ref-texture mapping or normal-texture GVA).
     // Same one derivation as the seed side above, so the two halves of this
     // function cannot disagree about the layout of the buffer they share.
     let Some((stride, need)) =

--- a/crates/reims-vgpu/src/runtime/draw/metal/mod.rs
+++ b/crates/reims-vgpu/src/runtime/draw/metal/mod.rs
@@ -237,7 +237,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         frag_storage.push(bytes);
     }
 
-    // Stage-in attrs: layout always comes from the type-7 pipeline vertex
+    // Stage-in attrs: layout always comes from the serializer-object pipeline vertex
     // block (ICB path already does this). Host bytes attach when the stream
     // bound that buffer index; otherwise Metal still needs the descriptor or
     // PSO create fails with "Vertex function has input attributes but no
@@ -332,7 +332,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         frag_bufs.push(ab);
     }
 
-    // Sampled textures: type-11 mapping pages, then type-2/3 linear GVA.
+    // Sampled textures: mapper-ref-texture mapping pages, then normal-texture linear GVA.
     struct TexItem {
         index: u32,
         w: u32,
@@ -424,7 +424,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         })
         .collect();
 
-    // Samplers: type-7 subtype 0x03 when present. A nonzero ref is an explicit
+    // Samplers: serializer-object subtype 0x03 when present. A nonzero ref is an explicit
     // guest bind; if it cannot be resolved, keep the correct fallback but make
     // the degradation visible with the exact resolver reason.
     let mut vtx_samps: Vec<ReimsVgpuSampler> = Vec::new();
@@ -562,7 +562,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
     });
     let depth_bias_opt = depth_bias_state.as_ref();
 
-    // Type-7 depth-stencil object + optional stencil reference.
+    // Serializer-object depth-stencil object + optional stencil reference.
     let depth_stencil_state = if req.depth_stencil_ref != 0 {
         match load_depth_stencil_state(state, host, req.task_id, req.depth_stencil_ref) {
             Ok(depth_stencil) => Some(depth_stencil),
@@ -683,7 +683,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         req.vertex_count
     };
 
-    // Type-11 color targets render into a host RT and are written back by the
+    // Mapper-ref-texture color targets render into a host RT and are written back by the
     // CPU. The guest-backed attachment that used to sit here aliased the
     // mapping's `mach_vm_remap` view with `newBufferWithBytesNoCopy`, so Load
     // read and Store wrote guest pages in place; that is exactly the access the
@@ -855,8 +855,8 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         return (EncodeStatus::MetalBackend(st), None);
     }
 
-    // Convert each color RT RGBA8 → guest format and writeback (type-11 mapping
-    // or type-2/3 GVA — archive write_type11_rgba / write_gva_rgba).
+    // Convert each color RT RGBA8 → guest format and writeback (mapper-ref-texture mapping
+    // or normal-texture GVA — archive write_mapper_ref_texture_rgba / write_gva_rgba).
     // Multi-draw intermediate records skip guest store (archive one writeback).
     let mut any_write = false;
     if !writeback_guest {
@@ -868,7 +868,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
             continue;
         }
         let out_rgba = &color_outs[i];
-        // Type-2/3 GVA keeps archive image_changed via store_seed_policy.
+        // normal-texture GVA keeps archive image_changed via store_seed_policy.
         let load_seed = color_seeds.get(i).and_then(|s| s.as_deref());
         let seed_for_store = store_seed_policy(force_full_store, c.load_action, load_seed);
         // The same coverage question the draw census asks, from the same
@@ -961,7 +961,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         };
         if wrote {
             any_write = true;
-            // Early-boot logo+pill: paint type-11 front before first DisplaySwap.
+            // Early-boot logo+pill: paint mapper-ref-texture front before first DisplaySwap.
             if c.mapping_id != 0 {
                 crate::runtime::scanout::note_front_buffer_writeback(
                     state,
@@ -990,7 +990,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
         );
     }
 
-    // Optional depth/stencil store writeback into type-11 mappings.
+    // Optional depth/stencil store writeback into mapper-ref-texture mappings.
     for seeded in [depth_storage.as_ref(), stencil_storage.as_ref()]
         .into_iter()
         .flatten()
@@ -1001,7 +1001,7 @@ fn encode_draw_chain_inner<M: HostMemory + HostOps>(
     (EncodeStatus::Ok, color0_rgba)
 }
 
-/// Type-2/3 linear GVA raw image read (tight dst rows of `row_bytes`).
+/// normal-texture linear GVA raw image read (tight dst rows of `row_bytes`).
 // A raw image read is addressed by texture, level, geometry and destination
 // stride; every one of those is a separate wire-decoded value.
 #[allow(clippy::too_many_arguments)]
@@ -1024,7 +1024,7 @@ fn load_linear_raw<M: HostMemory + HostOps>(
         host,
         task_id,
         texture_ref,
-        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT],
+        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS],
     ) else {
         return false;
     };
@@ -1289,7 +1289,7 @@ fn load_depth_stencil_state<M: HostMemory + HostOps>(
         host,
         task_id,
         ds_ref,
-        &[OBJECT_TYPE_TYPE7],
+        &[OBJECT_TYPE_SERIALIZER_OBJECT],
     )
     .map_err(|rung| match rung {
         objects::LadderRung::NoListEntry => MetalStateDecline::DepthStencilEntryMissing {
@@ -1387,7 +1387,7 @@ fn default_sampler(binding: u32) -> crate::backend::metal::abi::ReimsVgpuSampler
     }
 }
 
-/// The Metal sampler ABI record for a decoded type-7 sampler descriptor.
+/// The Metal sampler ABI record for a decoded serializer-object sampler descriptor.
 ///
 /// One constructor for every encoder that builds this record — the render path,
 /// the direct compute path, and both ICB-inherit paths. It is an eighteen-field
@@ -1402,7 +1402,7 @@ fn default_sampler(binding: u32) -> crate::backend::metal::abi::ReimsVgpuSampler
 ///   clamp; the binding is the later statement.
 /// - `argument_buffers` forces `support_argument_buffers` on for a sampler that
 ///   is resident in an argument buffer. That residency is a property of how the
-///   pipeline binds it, which the type-7 descriptor cannot state.
+///   pipeline binds it, which the serializer-object descriptor cannot state.
 ///
 /// `has_lod_clamp` is always 1: both clamp fields are filled on every path
 /// here, from the binding when it carried one and from the descriptor
@@ -1518,7 +1518,8 @@ mod sampler_record_tests {
     }
 }
 
-/// Load a sampled texture as tight RGBA8: type-11, type-8→base+mip+format+swizzle, or type-2/3.
+/// Load a sampled texture as tight RGBA8: mapper-ref-texture, texture-view→base+mip+format+swizzle,
+/// or normal-texture.
 fn load_sampled_rgba<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
@@ -1528,23 +1529,23 @@ fn load_sampled_rgba<M: HostMemory + HostOps>(
     if texture_ref == 0 {
         return None;
     }
-    // Opcode-9 buffer-backed texture (type-8): sample the source buffer directly.
+    // Opcode-9 buffer-backed texture (texture-view): sample the source buffer directly.
     if let Some(bt) = buffer_texture_descriptor(state, host, task_id, texture_ref, None) {
         return load_buffer_texture_rgba(state, host, task_id, texture_ref, &bt);
     }
-    if let Some(v) = load_type11_rgba(state, host, task_id, texture_ref, None) {
+    if let Some(v) = load_mapper_ref_texture_rgba(state, host, task_id, texture_ref, None) {
         return Some(v);
     }
-    // Type-8 view → base texture + selected mip + format override + optional swizzle.
+    // Texture-view view → base texture + selected mip + format override + optional swizzle.
     if let Some(view) = resolve_texture_view(state, host, task_id, texture_ref) {
-        let mut loaded = if let Some(v) = load_type11_rgba(
+        let mut loaded = if let Some(v) = load_mapper_ref_texture_rgba(
             state,
             host,
             task_id,
             view.base_texture_ref,
             view.pixel_format,
         ) {
-            // Type-11 IOSurface textures are single-level only: Metal rejects
+            // Mapper-ref-texture IOSurface textures are single-level only: Metal rejects
             // mipmapped IOSurface descriptors. Non-zero view level_base fails.
             if view.level != 0 {
                 return None;
@@ -1566,20 +1567,20 @@ fn load_sampled_rgba<M: HostMemory + HostOps>(
     load_linear_texture_rgba_at_level(state, host, task_id, texture_ref, 0, None)
 }
 
-fn load_type11_rgba<M: HostMemory + HostOps>(
+fn load_mapper_ref_texture_rgba<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     task_id: u32,
     texture_ref: u32,
     format_override: Option<u16>,
 ) -> Option<(u32, u32, Vec<u8>)> {
-    let mapping_id = objects::resolve_type11_ref(state, host, task_id, texture_ref)?;
-    load_type11_mapping_rgba(state, host, mapping_id, format_override)
+    let mapping_id = objects::resolve_mapper_ref_texture(state, host, task_id, texture_ref)?;
+    load_mapper_ref_texture_mapping_rgba(state, host, mapping_id, format_override)
 }
 
-/// Type-2/3 linear texture at mip `level`: strided guest rows → tight RGBA8.
+/// normal-texture linear texture at mip `level`: strided guest rows → tight RGBA8.
 ///
-/// `format_override` is the type-8 view pixel format when present. Base storage
+/// `format_override` is the texture-view pixel format when present. Base storage
 /// geometry (row_stride / level layout) stays on the base texture; the sample
 /// format must be bpp-compatible with the base (Metal texture-view contract).
 fn load_linear_texture_rgba_at_level<M: HostMemory + HostOps>(
@@ -1595,7 +1596,7 @@ fn load_linear_texture_rgba_at_level<M: HostMemory + HostOps>(
         host,
         task_id,
         texture_ref,
-        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT],
+        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS],
     )
     .ok()?;
     let tex = decode_texture_descriptor(&desc_bytes).ok()?;
@@ -1699,7 +1700,7 @@ fn load_sampler<M: HostMemory + HostOps>(
     ))
 }
 
-/// Store scissor rect of tight RGBA8 into a type-11 mapping (BGRA host → guest fmt).
+/// Store scissor rect of tight RGBA8 into a mapper-ref-texture mapping (BGRA host → guest fmt).
 // Source geometry, destination geometry and the scissor rect are three
 // independent rectangles and stay three: collapsing them into one struct would
 // invite exactly the mix-up the separate names prevent.

--- a/crates/reims-vgpu/src/runtime/draw/mod.rs
+++ b/crates/reims-vgpu/src/runtime/draw/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! Loads per-function MTLB containers from the object list, materializes stream
 //! binds (vertex/fragment buffers, optional index buffer, viewport/scissor),
-//! hands them to the backend, and writes the RGBA result into the type-11
+//! hands them to the backend, and writes the RGBA result into the mapper-ref-texture
 //! mapping via [`mapping_write`]. The encode call is
 //! [`crate::backend::metal::render::render_core_mrt`] on the Metal arm and
 //! `try_metal2vulkan_draw` into `backend::vulkan::engine` on the Vulkan one.
@@ -48,9 +48,10 @@ use crate::runtime::decode::render::{
 };
 use crate::runtime::decode::resource::{
     decode_buffer_texture_descriptor, decode_depth_stencil_descriptor,
-    decode_render_pipeline_descriptor, decode_texture_descriptor, texture_type8_opcode,
-    BufferTextureDescriptor, DecodeStatus, RenderPipelineDescriptor, OBJECT_TYPE_IOSURFACE,
-    OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT, OBJECT_TYPE_TEXTURE_VIEW, OBJECT_TYPE_TYPE7,
+    decode_render_pipeline_descriptor, decode_texture_descriptor, texture_view_opcode,
+    BufferTextureDescriptor, DecodeStatus, RenderPipelineDescriptor,
+    OBJECT_TYPE_MAPPER_REF_TEXTURE, OBJECT_TYPE_SERIALIZER_OBJECT, OBJECT_TYPE_TEXTURE,
+    OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS, OBJECT_TYPE_TEXTURE_VIEW,
     TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE, TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE_WIDE,
 };
 use crate::runtime::gva_mem;
@@ -77,7 +78,7 @@ pub(crate) use vulkan::coverage_band_for_test;
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 pub mod metal;
 
-// Type-8 texture-view resolution and linear texture loads. Backend-independent,
+// Texture-view texture-view resolution and linear texture loads. Backend-independent,
 // so the module carries no gate of its own; the two items inside it that are
 // arm- or test-specific keep theirs.
 mod texture_view;
@@ -470,15 +471,15 @@ pub struct IndexedDrawInfo {
 
 /// One color RT for MRT encode/writeback.
 ///
-/// Archive `ApplePVGPURenderTarget`: either type-11 IOSurface (`mapping_id`) or
-/// type-2/3 guest-VA linear (`target_gva` + `row_stride`). Wallpaper/background
+/// Archive `ApplePVGPURenderTarget`: either mapper-ref-texture IOSurface (`mapping_id`) or
+/// normal-texture guest-VA linear (`target_gva` + `row_stride`). Wallpaper/background
 /// layers are the GVA form.
 #[derive(Clone, Debug, Default)]
 pub struct ColorRtRequest {
     pub slot: u32,
     pub texture_ref: u32,
     pub mapping_id: u32,
-    /// Non-zero ⇒ type-2/3 linear GVA target (mapping_id must be 0).
+    /// Non-zero ⇒ normal-texture linear GVA target (mapping_id must be 0).
     pub target_gva: u64,
     /// Bytes-per-row for GVA target (archive `bpr`).
     pub row_stride: u32,
@@ -834,23 +835,27 @@ pub(crate) fn load_render_pipeline<M: HostMemory + HostOps>(
         return None;
     }
     let report = crate::observe::RungReport::new("draw_load_pipeline", "pipe_ref");
-    // Live object-list: render pipeline is type-7 with subtype 0x0e.
-    let (_entry, desc) =
-        match objects::resolve_descriptor(state, host, task_id, pipeline_ref, &[OBJECT_TYPE_TYPE7])
-        {
-            Ok(found) => found,
-            Err(rung) => {
-                report.rung(task_id, pipeline_ref, rung);
-                return None;
-            }
-        };
+    // Live object-list: render pipeline is serializer-object with subtype 0x0e.
+    let (_entry, desc) = match objects::resolve_descriptor(
+        state,
+        host,
+        task_id,
+        pipeline_ref,
+        &[OBJECT_TYPE_SERIALIZER_OBJECT],
+    ) {
+        Ok(found) => found,
+        Err(rung) => {
+            report.rung(task_id, pipeline_ref, rung);
+            return None;
+        }
+    };
     let p = match decode_render_pipeline_descriptor(&desc) {
         Ok(p) => p,
         Err(status) => {
             // The decoder's own name for what it refused, carried through rather
             // than collapsed into `desc_decode`. Without it this line said only
             // that a 292-byte descriptor did not decode, and finding out *why*
-            // meant correlating its `t=` against an `OFF type7_pipeline_shape`
+            // meant correlating its `t=` against an `OFF serializer_object_pipeline_shape`
             // line in the same millisecond — which is how the alpha-test and
             // logic-op tags were found and is not a step the next reader should
             // have to repeat.
@@ -878,8 +883,8 @@ pub(crate) fn load_render_pipeline<M: HostMemory + HostOps>(
     Some(p)
 }
 
-/// Resolve type-1 buffer object → guest bytes starting at `offset`.
-/// Where a type-1 buffer object's bytes live in the task GVA space. Both the
+/// Resolve buffer object → guest bytes starting at `offset`.
+/// Where a buffer object's bytes live in the task GVA space. Both the
 /// zero-copy gather and the CPU staging read need identical `(gva, size)`;
 /// resolving it once ([`resolve_buffer_backing`]) avoids walking the task page
 /// table twice for every sub-zero-copy-floor bind (the `buf_snap` population —
@@ -891,7 +896,7 @@ pub(super) struct BufferBacking {
     pub(super) size: u64,
 }
 
-/// The slug for each way a type-1 buffer ref fails to yield a span.
+/// The slug for each way a buffer ref fails to yield a span.
 ///
 /// Five refusals, one per condition, in the vocabulary `observe::ladder`
 /// declares — because the five lines this replaced carried **no `reason=` at
@@ -933,7 +938,7 @@ fn buffer_refusal_detail(refusal: objects::BufferSpanRefusal, page_shift: u32) -
     }
 }
 
-/// Resolve a type-1 buffer `ref` to its backing `(gva, size)` (object-list
+/// Resolve a buffer `ref` to its backing `(gva, size)` (object-list
 /// entry read + descriptor read + decode). Fail-visible per failing site —
 /// this is the single owner of the `load_buffer *` reason slugs; the ZC and CPU
 /// binds delegate to it so a failure logs exactly once, not once per attempt.
@@ -1092,10 +1097,10 @@ fn load_buffer_bytes<M: HostMemory + HostOps>(
     read_buffer_bytes_resolved(state, host, task_id, buffer_ref, &backing, offset, None)
 }
 
-/// If `texture_ref` is a type-8 object whose descriptor is a buffer-backed
+/// If `texture_ref` is a texture-view object whose descriptor is a buffer-backed
 /// texture (view_opcode 9, `newTextureWithDescriptor:offset:bytesPerRow:`, or
 /// its `TextureDescriptor2` form), return its decoded descriptor. `None` for a
-/// non-type-8 object or a real texture VIEW (opcode 7/8/0x1b) — those stay on
+/// non-texture-view object or a real texture VIEW (opcode 7/8/0x1b) — those stay on
 /// the view path silently.
 fn buffer_texture_descriptor<M: HostMemory + HostOps>(
     state: &DeviceState,
@@ -1117,7 +1122,7 @@ fn buffer_texture_descriptor<M: HostMemory + HostOps>(
     }
     let desc_bytes = &resource.descriptor;
     if !matches!(
-        texture_type8_opcode(desc_bytes),
+        texture_view_opcode(desc_bytes),
         Some(TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE) | Some(TEXTURE_VIEW_OPCODE_BUFFER_TEXTURE_WIDE)
     ) {
         return None;
@@ -1222,7 +1227,7 @@ fn load_buffer_texture_rgba<M: HostMemory + HostOps>(
     }
     let span = bpr.checked_mul(h as u64)?;
     // A buffer-backed texture is two contract references over one allocation:
-    // the type-8 texture object the guest binds and samples, and the type-1
+    // the texture-view texture object the guest binds and samples, and the buffer
     // buffer that owns the storage. A synchronize names the former and a debt
     // may be armed under either, so both are paid. `load_buffer_bytes` below
     // pays for `bt.buffer_ref`; this is the sibling call every other sampled
@@ -1332,7 +1337,7 @@ fn load_index_bytes_reason<M: HostMemory + HostOps>(
     Ok(buf)
 }
 
-/// Guest Store seed for type-11 `image_changed` / GVA partial writeback.
+/// Guest Store seed for mapper-ref-texture `image_changed` / GVA partial writeback.
 ///
 /// Metal `storeAction=Store` writes the **whole** attachment after the pass.
 /// Diff-only writeback is Store-equivalent only when `loadAction=Load` and
@@ -1481,14 +1486,14 @@ fn sample_miss_detail<M: HostMemory + HostOps>(
         objects::OBJECT_TYPE_REF_TEXTURE => {
             match objects::read_descriptor(state, host, task_id, &entry) {
                 None => format!("type=5 desc_len={desc_len} reason=no_desc"),
-                Some(d) if reims_vgpu_wire::device_desc::type5_header(&d).is_err() => {
+                Some(d) if reims_vgpu_wire::device_desc::ref_texture_header(&d).is_err() => {
                     format!("type=5 desc_len={desc_len} reason=short_desc")
                 }
                 Some(d) => {
-                    let sid = reims_vgpu_wire::device_desc::type5_header(&d)
+                    let sid = reims_vgpu_wire::device_desc::ref_texture_header(&d)
                         .map(|h| h.surface_id.get())
                         .unwrap_or(0);
-                    match objects::decode_type5_texture_view(&d) {
+                    match objects::decode_ref_texture_view(&d) {
                         Some(view) => format!(
                             "type=5 desc_len={desc_len} surface_id={sid} view={}x{} fmt={:#x} reason=ref_texture_view",
                             view.width, view.height, view.pixel_format
@@ -1499,14 +1504,15 @@ fn sample_miss_detail<M: HostMemory + HostOps>(
                 }
             }
         }
-        OBJECT_TYPE_IOSURFACE => {
-            let Some(mid) = objects::resolve_type11_ref(state, host, task_id, texture_ref) else {
-                return format!("type=11 desc_len={desc_len} reason=type11_resolve");
+        OBJECT_TYPE_MAPPER_REF_TEXTURE => {
+            let Some(mid) = objects::resolve_mapper_ref_texture(state, host, task_id, texture_ref)
+            else {
+                return format!("type=11 desc_len={desc_len} reason=mapper_ref_texture_resolve");
             };
             match state.mappings.get(&mid) {
                 None => format!("type=11 mid={mid} desc_len={desc_len} reason=no_mapping"),
                 Some(m) => format!(
-                    "type=11 mid={mid} desc_len={desc_len} geom={} {}x{} fmt={:#x} mapped={} pages={} reason=type11_sample",
+                    "type=11 mid={mid} desc_len={desc_len} geom={} {}x{} fmt={:#x} mapped={} pages={} reason=mapper_ref_texture_sample",
                     m.has_geom as u8,
                     m.width,
                     m.height,
@@ -1516,7 +1522,7 @@ fn sample_miss_detail<M: HostMemory + HostOps>(
                 )}
         }
         OBJECT_TYPE_TEXTURE_VIEW => {
-            // Opcode-9 buffer-backed textures share the type-8 tag but are not views.
+            // Opcode-9 buffer-backed textures share the texture-view tag but are not views.
             if let Some(bt) = buffer_texture_descriptor(state, host, task_id, texture_ref, None) {
                 return format!(
                     "type=8 desc_len={desc_len} buf={} off={} bpr={} {}x{} fmt={:#x} reason=buftex_load",
@@ -1546,7 +1552,7 @@ fn sample_miss_detail<M: HostMemory + HostOps>(
                     view.pixel_format
                 )}
         }
-        OBJECT_TYPE_TEXTURE | OBJECT_TYPE_TEXTURE_VARIANT => {
+        OBJECT_TYPE_TEXTURE | OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS => {
             let Some(desc_bytes) = objects::read_descriptor(state, host, task_id, &entry) else {
                 return format!("type={ot} desc_len={desc_len} reason=desc_read");
             };
@@ -1572,8 +1578,8 @@ fn sample_miss_detail<M: HostMemory + HostOps>(
     }
 }
 
-/// What the guest says a type-11 mapping's texel **values** are, seen through an
-/// optional type-8 view format.
+/// What the guest says a mapper-ref-texture mapping's texel **values** are, seen through an
+/// optional texture-view format.
 ///
 /// Distinct from the byte *order* its loaders hand back, and that distinction is
 /// the whole point. `scanout::read_mapping_bgra8` normalises a mapping's channel
@@ -1616,7 +1622,7 @@ fn mapping_declared_format(
     }
 }
 
-/// Sample a type-11 mapping as tight RGBA8 from guest pages.
+/// Sample a mapper-ref-texture mapping as tight RGBA8 from guest pages.
 ///
 /// Guest pages ARE the surface content: the CPU writeback lands Stores in them
 /// and guest CPU writes are immediately visible. There is exactly one source;
@@ -1626,7 +1632,7 @@ fn mapping_declared_format(
 /// mapped with a live `MappingInternal` and no latched W×H yet; resolving first
 /// decodes the guest device-surface descriptor and latches the geometry, so the
 /// sample succeeds instead of bailing out on `!has_geom` and dropping the bind.
-fn load_type11_mapping_rgba<M: HostMemory + HostOps>(
+fn load_mapper_ref_texture_mapping_rgba<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mapping_id: u32,
@@ -1691,7 +1697,7 @@ fn host_cache_store_rgba8(
     );
 }
 
-/// Advance the guest-visible publish milestones for a type-11 Store whose
+/// Advance the guest-visible publish milestones for a mapper-ref-texture Store whose
 /// pixels have landed in the mapping's guest pages.
 ///
 /// Route-independent: the synchronous `cpu_portability` Store calls it inline,
@@ -1830,7 +1836,7 @@ pub fn writeback_chain_rgba<M: HostMemory + HostOps>(
     }
     // An abandoned portability chain must still preserve the last successful
     // record. This is an error recovery rail, not normal product behavior: land
-    // the resident readback into the type-11 mapping, publish the Composite
+    // the resident readback into the mapper-ref-texture mapping, publish the Composite
     // Store, and keep the degradation fail-visible.
     crate::observe::fail(format!(
         "writeback_chain_rgba reason=resident_chain_abandoned_cpu_recovery \
@@ -2346,7 +2352,7 @@ pub fn mrt_draw_request<M: HostMemory + HostOps>(
             //
             // GVA linear target: ephemeral host RT needs a CPU seed (archive
             // reims_vgpu_backend_metal; NULL seed → Metal Clear invent, still encode).
-            // Type-11 is seeded later instead, at the attachment site in
+            // Mapper-ref-texture is seeded later instead, at the attachment site in
             // `encode_draw` — the same place the guest-backed alias used to be
             // built, and the same seed it already took whenever the alias was
             // refused. Seeding here would need the mapping read twice.
@@ -3015,10 +3021,10 @@ pub(crate) fn write_gva_rgba8_rect<M: HostMemory + HostOps>(
     true
 }
 
-/// Seed color RT LOAD from guest type-11 (BGRA→RGBA) or type-2/3/view linear RGBA.
+/// Seed color RT LOAD from guest mapper-ref-texture (BGRA→RGBA) or normal-texture/view linear RGBA.
 ///
 /// Every color RT is an ephemeral host RT now, so every `Load` needs this: the
-/// type-11 guest-memory alias that let Metal Load read the surface bytes in
+/// mapper-ref-texture guest-memory alias that let Metal Load read the surface bytes in
 /// place is deleted. This used to run only on the alias-reject fallback
 /// (unaligned offset or row stride, span out of range, no device), which is why
 /// it is already a complete path and not a new one.
@@ -3032,8 +3038,8 @@ fn seed_color_load<M: HostMemory + HostOps>(
     height: u32,
 ) -> Option<Vec<u8>> {
     // Discrete GPU: exact target GVA is the strongest identity across object-ref
-    // recycling. Fall back to the type-2/3 texture namespace, never the
-    // unrelated type-4 surface_id namespace. Guest memory is last.
+    // recycling. Fall back to the normal texture namespace, never the
+    // unrelated backing record_id namespace. Guest memory is last.
     if width > 0 && height > 0 {
         if target_gva != 0 {
             // Recency for the encode cache's byte cap; a Load seed served from
@@ -3047,8 +3053,8 @@ fn seed_color_load<M: HostMemory + HostOps>(
         // `.agents/repros/gva-seed-serve-census.sh`) served **1 558 colour LOAD
         // seeds from this lookup and missed 0**. `load_seed_ok_color` was 1 558
         // in the same window, so every colour LOAD seed the device produced came
-        // from here; the other 1 462 of `load_seed_ok` are type-11 and take
-        // `resolve_type11_load_seed`.
+        // from here; the other 1 462 of `load_seed_ok` are mapper-ref-texture and take
+        // `resolve_mapper_ref_texture_load_seed`.
         //
         // That is what a LOAD seed is worth: `MTLLoadActionLoad` says the guest
         // is drawing onto the content already in this attachment, so a seed that
@@ -3229,7 +3235,7 @@ fn seed_color_load<M: HostMemory + HostOps>(
             return Some(swap_rb_channels(bgra));
         }
     }
-    // Type-2/3 (or type-8 base) linear GVA → convert to RGBA8.
+    // normal-texture (or texture-view base) linear GVA → convert to RGBA8.
     //
     // No settle at this fork. It used to sit at the head of this function, above
     // every host-cache lookup, and blocked 5 023 times for 2.63 s on a driven
@@ -3240,7 +3246,7 @@ fn seed_color_load<M: HostMemory + HostOps>(
     //
     // So each leaf under `load_sampled_rgba_static` owns it, narrowed on what it
     // actually reads — `read_buffer_bytes_resolved` on the buffer's span,
-    // `scanout::paint_mapping` behind `load_type11_mapping_rgba`, and
+    // `scanout::paint_mapping` behind `load_mapper_ref_texture_mapping_rgba`, and
     // `draw::texture_view::load_linear_texture_impl` for the linear arm. The
     // buffer leaf had no settle at all before that, on any of its four callers.
     // The seed arm: this leaf is shared with the sampled resolve and the two
@@ -3261,7 +3267,7 @@ fn seed_color_load<M: HostMemory + HostOps>(
 
 /// Resolve sampled texture RGBA without requiring Metal feature (color LOAD seed path).
 ///
-/// Type-8 views with a non-identity swizzle are rejected here: RT materialization does not
+/// Texture-view views with a non-identity swizzle are rejected here: RT materialization does not
 /// rematerialize through a remapped view (contract: swizzled views fail for RT/blit).
 /// View `pixel_format` still overrides the base format when bpp-compatible.
 fn load_sampled_rgba_static<M: HostMemory + HostOps>(
@@ -3272,7 +3278,7 @@ fn load_sampled_rgba_static<M: HostMemory + HostOps>(
     native: NativeUploads,
     site: crate::runtime::render_writeback::SettleSite,
 ) -> Option<(Vec<u8>, SampledByteFormat)> {
-    // Opcode-9 buffer-backed texture (type-8): sample the source buffer directly.
+    // Opcode-9 buffer-backed texture (texture-view): sample the source buffer directly.
     if let Some(bt) = buffer_texture_descriptor(state, host, task_id, texture_ref, None) {
         let source = bt.desc.pixel_format;
         return load_buffer_texture_rgba(state, host, task_id, texture_ref, &bt).map(
@@ -3284,17 +3290,17 @@ fn load_sampled_rgba_static<M: HostMemory + HostOps>(
             },
         );
     }
-    // Type-11 path via resolve.
-    if let Some(mid) = objects::resolve_type11_ref(state, host, task_id, texture_ref) {
+    // Mapper-ref-texture path via resolve.
+    if let Some(mid) = objects::resolve_mapper_ref_texture(state, host, task_id, texture_ref) {
         let source = mapping_declared_format(state, mid, None);
-        return load_type11_mapping_rgba(state, host, mid, None).map(|(_, _, r)| {
+        return load_mapper_ref_texture_mapping_rgba(state, host, mid, None).map(|(_, _, r)| {
             (
                 r,
                 SampledByteFormat::from_source(TexelLayout::Rgba8, source),
             )
         });
     }
-    // Type-8 view → base texture + mip + format. The view's SWIZZLE is
+    // Texture-view view → base texture + mip + format. The view's SWIZZLE is
     // deliberately not consulted here: it is a property of the view, not of the
     // bytes, and the bind applies it as the image view's component mapping so
     // the GPU performs it at sample time. Refusing here (which this path used
@@ -3305,22 +3311,24 @@ fn load_sampled_rgba_static<M: HostMemory + HostOps>(
         } else {
             (texture_ref, 0, None)
         };
-    // Type-11 base through a view (format override may reinterpret BGRA storage).
-    if let Some(mid) = objects::resolve_type11_ref(state, host, task_id, tex_ref) {
+    // Mapper-ref-texture base through a view (format override may reinterpret BGRA storage).
+    if let Some(mid) = objects::resolve_mapper_ref_texture(state, host, task_id, tex_ref) {
         if level != 0 {
             return None;
         }
         let source = mapping_declared_format(state, mid, fmt_override);
-        return load_type11_mapping_rgba(state, host, mid, fmt_override).map(|(_, _, r)| {
-            (
-                r,
-                SampledByteFormat::from_source(TexelLayout::Rgba8, source),
-            )
-        });
+        return load_mapper_ref_texture_mapping_rgba(state, host, mid, fmt_override).map(
+            |(_, _, r)| {
+                (
+                    r,
+                    SampledByteFormat::from_source(TexelLayout::Rgba8, source),
+                )
+            },
+        );
     }
     // The only rung here that can answer in anything but RGBA8. The three above
     // convert unconditionally — `load_buffer_texture_rgba` and
-    // `load_type11_mapping_rgba` have no native arm — so they state the layout
+    // `load_mapper_ref_texture_mapping_rgba` have no native arm — so they state the layout
     // they always produced rather than being handed a choice they cannot make.
     // All four still name the guest format their values were read from, because
     // a convert to RGBA8 reorders channels and does not decode.

--- a/crates/reims-vgpu/src/runtime/draw/render_target.rs
+++ b/crates/reims-vgpu/src/runtime/draw/render_target.rs
@@ -10,18 +10,18 @@
 //!
 //! # The rungs, in the order the archive tries them
 //!
-//! 1. **Type-8 view → base.** A view resolves to the texture it wraps, and
+//! 1. **Texture-view view → base.** A view resolves to the texture it wraps, and
 //!    carries a format override and a mip level forward with it. A swizzled view
 //!    is refused rather than resolved.
-//! 2. **Type-11 IOSurface.** Geometry comes from the live mapping, never from a
+//! 2. **Mapper-ref-texture IOSurface.** Geometry comes from the live mapping, never from a
 //!    sticky latch — the latch exists only for the window where the object-list
 //!    entry is transiently missing, and preferring it has twice routed a
 //!    dual-mapping composite onto one mapping.
-//! 3. **Type-4 surface / type-5 `RefTextureHandle`.** The object-list index is
-//!    the surface id; type-5 wraps type-4 and is what product colour targets
+//! 3. **Backing surface / ref-texture `RefTextureHandle`.** The object-list index is
+//!    the surface id; ref-texture wraps backing and is what product colour targets
 //!    actually bind.
-//! 4. **Type-2/3 linear guest VA.** Wallpaper and background intermediates and
-//!    UI intermediate render targets live here, so a type-11-only resolve drops
+//! 4. **normal-texture linear guest VA.** Wallpaper and background intermediates and
+//!    UI intermediate render targets live here, so a mapper-ref-texture-only resolve drops
 //!    those passes entirely.
 //!
 //! The order is live-type-driven at every step: the object list is re-read and
@@ -47,8 +47,8 @@
 //! A zero over an unstated amount of work is not a measurement, so: on the same
 //! boot `mrt_draw_single` counted **179 123** single-attachment draws reaching
 //! the Vulkan encode, every one of which is a colour attachment this ladder had
-//! already resolved, and `rt_type5_view_same` counted **23 951** attachments
-//! that reached the *bottom* of the type-4/5 rung. Both counters predate the
+//! already resolved, and `rt_ref_texture_view_same` counted **23 951** attachments
+//! that reached the *bottom* of the backing/5 rung. Both counters predate the
 //! typed refusals and sit on the success side, which is what makes them usable
 //! as a denominator here.
 //!
@@ -58,10 +58,10 @@
 //! background noise.
 
 use super::*;
-/// The colour render target's base format for a **type-4** surface, or nothing.
+/// The colour render target's base format for a **backing** surface, or nothing.
 ///
 /// On this arm `m.format == 0` is not "unset", it is a decoded refusal:
-/// [`objects::apply_type4_backing`] is the only writer of it, and it stores 0 for
+/// [`objects::apply_backing`] is the only writer of it, and it stores 0 for
 /// a multi-plane surface and for a single-plane one whose FourCC it does not
 /// know, saying why — "stage/paint must not invent BGRA".
 /// [`objects::iosurface_pixel_format_to_mtl`] repeats it twice more, and the
@@ -84,12 +84,12 @@ use super::*;
 /// not "unreachable" — the first surface to take it will now be named and
 /// refused rather than named and rendered wrong.
 ///
-/// The **type-11** arm deliberately does not come through here. A type-11
+/// The **mapper-ref-texture** arm deliberately does not come through here. A mapper-ref-texture
 /// mapping's format has other writers, so its 0 can mean "not latched yet" rather
 /// than "refused", and BGRA8 is the display contract's stated default for that
 /// case ([`crate::runtime::compute_exec`]'s `or_bgra8` writes the same rule down).
 /// Those are different zeros and only this one is provably a refusal.
-fn rt_type4_base_format(format: u16, mapping_id: u32) -> Option<u16> {
+fn rt_backing_base_format(format: u16, mapping_id: u32) -> Option<u16> {
     if format != 0 {
         return Some(format);
     }
@@ -97,7 +97,7 @@ fn rt_type4_base_format(format: u16, mapping_id: u32) -> Option<u16> {
     if crate::observe::first_sight("rt_base_fmt_declined", mapping_id as u64) {
         crate::observe::fail(format!(
             "rt_base_fmt_declined mapping={mapping_id} \
-             (the mapping's format is the type-4 decoder's multi-plane / \
+             (the mapping's format is the backing decoder's multi-plane / \
              unknown-FourCC refusal, so this surface is not a single-format \
              colour attachment and no format is invented for it)"
         ));
@@ -105,19 +105,19 @@ fn rt_type4_base_format(format: u16, mapping_id: u32) -> Option<u16> {
     None
 }
 
-/// The format a type-4 colour attachment is **declared** in.
+/// The format a backing colour attachment is **declared** in.
 ///
-/// A type-5 object is a texture view over the surface allocation, and its format
+/// A ref-texture object is a texture view over the surface allocation, and its format
 /// is attachment state: the UNORM and sRGB spellings name identical stored bytes
 /// and differ only in the fixed-function conversion the hardware applies on
 /// render writes. The guest declared that view, so the view's format is the
 /// contract and the base mapping's is what a surface bound without one falls
-/// back to. A type-8 view is a further reinterpretation asked for on top, so it
-/// outranks the type-5 record when both are present.
+/// back to. A texture-view is a further reinterpretation asked for on top, so it
+/// outranks the ref-texture record when both are present.
 ///
 /// # Why this stopped answering the base mapping's format
 ///
-/// It used to answer `base_fmt` for every type-5 view, on the ground that
+/// It used to answer `base_fmt` for every ref-texture view, on the ground that
 /// honouring the view would fork the resident — the guest binds one surface
 /// through both spellings, and a second spelling that missed would retire the
 /// resident and recreate it empty, alternating two half-filled images frame to
@@ -127,59 +127,60 @@ fn rt_type4_base_format(format: u16, mapping_id: u32) -> Option<u16> {
 /// `allocation()` (which folds `_SRGB` onto `_UNORM`), the image is created
 /// `MUTABLE_FORMAT` in the allocation format, and the attachment gets its own
 /// view in `declared()`. One allocation, a view per interpretation — which is
-/// what Metal's contract describes. The type-2/3 linear GVA targets have been
+/// what Metal's contract describes. The normal-texture linear GVA targets have been
 /// attaching sRGB through that same machinery all along; only this resolve was
 /// still throwing the qualifier away, so a surface the guest declared sRGB was
 /// rendered into without the linear-to-sRGB encode on write.
 ///
 /// # The geometry half is deliberately not honoured
 ///
-/// A type-5 view is taken only where it agrees with the base *extent*, because
+/// A ref-texture view is taken only where it agrees with the base *extent*, because
 /// the resolve this feeds takes the base mapping's geometry. A view describing a
 /// different grid is one this device is not honouring at all, and lifting its
 /// format alone would attach a reinterpretation to a grid that is not its own —
 /// the row-byte-equivalent quarter-width `RGBA32Uint` view over the desktop
 /// target is exactly that shape. That population is
-/// `rt_type5_view_differs_geometry`; it has never been observed on any boot, and
+/// `rt_ref_texture_view_differs_geometry`; it has never been observed on any boot, and
 /// it still resolves through the base.
 ///
 /// A view format whose texel is a different *width* from the base's is not a
 /// reinterpretation of one allocation at all, so [`effective_view_sample_format`]
 /// refuses it and the base format stands.
-fn rt_type4_declared_format(
+fn rt_backing_declared_format(
     base_fmt: u16,
     base_extent: (u32, u32),
-    type5_view: Option<objects::Type5TextureView>,
+    ref_texture_view: Option<objects::RefTextureView>,
     view_fmt_override: Option<u16>,
 ) -> u16 {
     let (base_w, base_h) = base_extent;
-    let type5_declared = type5_view
+    let ref_texture_declared = ref_texture_view
         .filter(|view| view.width == base_w && view.height == base_h)
         .map(|view| view.pixel_format)
         .filter(|&fmt| fmt != 0);
-    effective_view_sample_format(base_fmt, view_fmt_override.or(type5_declared)).unwrap_or(base_fmt)
+    effective_view_sample_format(base_fmt, view_fmt_override.or(ref_texture_declared))
+        .unwrap_or(base_fmt)
 }
 
-/// Report a type-5 colour attachment whose view record disagrees with the base
+/// Report a ref-texture colour attachment whose view record disagrees with the base
 /// mapping it is resolved through.
 ///
-/// This resolve reads only `surfaceID@0` out of a type-5 descriptor and takes
-/// geometry and format from the mapping. [`objects::decode_type5_texture_view`]'s
+/// This resolve reads only `surfaceID@0` out of a ref-texture descriptor and takes
+/// geometry and format from the mapping. [`objects::decode_ref_texture_view`]'s
 /// own contract forbids that — "callers must not replace it with base mapping
 /// geometry merely because the surface itself is otherwise stageable" — and the
 /// live case it names is real: the BGRA8 desktop target is also exposed as a
-/// row-byte-equivalent quarter-width RGBA32Uint view. Every other type-5
+/// row-byte-equivalent quarter-width RGBA32Uint view. Every other ref-texture
 /// consumer binds the view's own geometry.
 ///
 /// It is harmless exactly while view == base, so the question is how often that
 /// holds for a *render target* specifically, which nothing has measured.
-/// `rt_type5_view_differs` against `rt_type5_view_same` answers it. Reported
+/// `rt_ref_texture_view_differs` against `rt_ref_texture_view_same` answers it. Reported
 /// rather than repaired: taking the view's geometry here changes what every
-/// type-5 colour attachment renders into, and that is not a change to make on an
+/// ref-texture colour attachment renders into, and that is not a change to make on an
 /// unmeasured population.
 ///
 /// **Read on two driven x86/Vulkan boots: `same` 20 273 and 24 360, `differs`
-/// 0, `undecoded` 0.** So on this workload every type-5 colour attachment's view
+/// 0, `undecoded` 0.** So on this workload every ref-texture colour attachment's view
 /// agrees with the base mapping in width, height and format, and resolving
 /// through the base loses nothing. The reinterpretation view the contract names
 /// is real traffic elsewhere — the compute staging path sees it — but it is not
@@ -238,7 +239,7 @@ fn rt_type4_declared_format(
 /// macos-13 boot reads `same` only, with `differs` absent entirely, and
 /// `runtime::census::srgb_census` emits nothing across its six sites. So the
 /// extra encode `bugs/bug-03` measures enters somewhere neither this rail nor
-/// that census watches, and the type-5 view divergence — real, and worth
+/// that census watches, and the ref-texture view divergence — real, and worth
 /// honouring on its own terms — is not its road.
 ///
 /// **`..._geometry` is still a live healthy zero and is still a loss.** It has
@@ -249,18 +250,18 @@ fn rt_type4_declared_format(
 /// surface bound both ways is what exercises the view swap, so a non-zero there
 /// is the reading that says the swap is being taken rather than merely
 /// available.
-fn note_rt_type5_view(
-    view: Option<objects::Type5TextureView>,
+fn note_rt_ref_texture_view(
+    view: Option<objects::RefTextureView>,
     surface_id: u32,
     base: (u32, u32, u16),
 ) {
     let Some(view) = view else {
-        crate::runtime::drain::note_store_route("rt_type5_view_undecoded");
+        crate::runtime::drain::note_store_route("rt_ref_texture_view_undecoded");
         return;
     };
     let (base_w, base_h, base_fmt) = base;
     if view.width == base_w && view.height == base_h && view.pixel_format == base_fmt {
-        crate::runtime::drain::note_store_route("rt_type5_view_same");
+        crate::runtime::drain::note_store_route("rt_ref_texture_view_same");
         if differed_before(surface_id) {
             // The reading that decides whether the format repair above is safe.
             // A surface resolved both ways is one this device would key two
@@ -268,31 +269,31 @@ fn note_rt_type5_view(
             // between two images is worse than a frame in the wrong colour
             // space. A boot reporting `differs_format_only` with this at zero is
             // the one that licenses the repair.
-            crate::runtime::drain::note_store_route("rt_type5_view_sid_both_ways");
+            crate::runtime::drain::note_store_route("rt_ref_texture_view_sid_both_ways");
         }
         return;
     }
-    crate::runtime::drain::note_store_route("rt_type5_view_differs");
+    crate::runtime::drain::note_store_route("rt_ref_texture_view_differs");
     // Which half diverged decides both the counter and what the fail line says
     // happened, so it is asked once. The two halves no longer have the same
     // answer — the format is honoured and the geometry is not — and a single
     // sentence covering both was accurate only while neither was.
     let (route, disposition) = if view.width == base_w && view.height == base_h {
         (
-            "rt_type5_view_differs_format_only",
+            "rt_ref_texture_view_differs_format_only",
             "the colour attachment is resolved in the view's format",
         )
     } else {
         (
-            "rt_type5_view_differs_geometry",
+            "rt_ref_texture_view_differs_geometry",
             "the colour attachment is resolved with the base mapping's geometry, not the view's",
         )
     };
     crate::runtime::drain::note_store_route(route);
     note_differed(surface_id);
-    if crate::observe::first_sight("rt_type5_view_differs", surface_id as u64) {
+    if crate::observe::first_sight("rt_ref_texture_view_differs", surface_id as u64) {
         crate::observe::fail(format!(
-            "rt_type5_view_differs sid={surface_id} view={}x{} fmt={:#x} plane={} \
+            "rt_ref_texture_view_differs sid={surface_id} view={}x{} fmt={:#x} plane={} \
              base={base_w}x{base_h} fmt={base_fmt:#x} ({disposition})",
             view.width, view.height, view.pixel_format, view.plane_index
         ));
@@ -300,14 +301,14 @@ fn note_rt_type5_view(
 }
 
 /// Surface ids this ladder has resolved a render target through a *differing*
-/// type-5 view for.
+/// ref-texture view for.
 ///
 /// Bounded, and the bound is the whole design: this exists to answer whether one
 /// surface is bound both ways in one boot, and the population it watches was one
 /// member on the boot that made it necessary. Past [`DIFFERED_MAX`] it stops
 /// admitting rather than growing or evicting — an evicting set would answer
 /// "not seen before" for a surface it had forgotten, which is the direction that
-/// reports the repair as safe when it is not. `rt_type5_view_differ_set_full`
+/// reports the repair as safe when it is not. `rt_ref_texture_view_differ_set_full`
 /// says the bound bit, and a boot that reports it has not answered the question.
 const DIFFERED_MAX: usize = 64;
 
@@ -317,7 +318,7 @@ static DIFFERED: std::sync::Mutex<std::collections::BTreeSet<u32>> =
 fn note_differed(surface_id: u32) {
     let mut set = DIFFERED.lock().unwrap_or_else(|e| e.into_inner());
     if set.len() >= DIFFERED_MAX && !set.contains(&surface_id) {
-        crate::runtime::drain::note_store_route("rt_type5_view_differ_set_full");
+        crate::runtime::drain::note_store_route("rt_ref_texture_view_differ_set_full");
         return;
     }
     set.insert(surface_id);
@@ -338,7 +339,7 @@ fn differed_before(surface_id: u32) -> bool {
 /// unnoticed: all three orders type-check.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct ResolvedRenderTarget {
-    /// Non-zero ⇒ a host mapping; `0` with `target_gva` non-zero ⇒ type-2/3
+    /// Non-zero ⇒ a host mapping; `0` with `target_gva` non-zero ⇒ normal-texture
     /// linear guest VA. The two are exclusive, the same way
     /// [`ColorRtRequest::target_gva`] documents.
     pub(super) mapping_id: u32,
@@ -350,7 +351,7 @@ pub(super) struct ResolvedRenderTarget {
     pub(super) format: u16,
     /// Attachment samples this target's own declaration asks for.
     ///
-    /// For a type-2/3 linear texture this is the descriptor's decoded sample
+    /// For a normal-texture linear texture this is the descriptor's decoded sample
     /// count — the texture says what it is, and on rail macos-15 four textures a
     /// boot say four. It was a hardcoded provisional `1` until that field was
     /// recovered, and the provisional was indistinguishable from a decoded one:
@@ -359,7 +360,7 @@ pub(super) struct ResolvedRenderTarget {
     /// invention.
     ///
     /// It stays `1` on the two paths whose target is a *mapping* rather than a
-    /// texture (type-11 and type-4 surfaces). Those carry no creation
+    /// texture (mapper-ref-texture and backing records). Those carry no creation
     /// descriptor, so nothing there declares a sample count and `1` is the
     /// display contract's own default rather than a stand-in for an unread
     /// field.
@@ -389,7 +390,7 @@ pub(super) struct ResolvedRenderTarget {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct RenderTargetRefusal {
     /// The ref the ladder was working on: `texture_ref` itself, or the base a
-    /// type-8 view resolved to.
+    /// texture-view resolved to.
     ///
     /// Reported next to the attachment's own ref rather than instead of it,
     /// because they differ exactly when a view is in play — and a refusal
@@ -405,12 +406,12 @@ pub(super) struct RenderTargetRefusal {
 /// contract. Grouped by rung in the order [`lookup_render_target`] tries them.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum RenderTargetCause {
-    /// A type-8 view whose swizzle is not the identity. The archive's
+    /// A texture-view whose swizzle is not the identity. The archive's
     /// `resolve_texture` requires `!has_swizzle` for a linear resolve, so the
     /// channel order this view asks for cannot be honoured by rendering into
     /// the base.
     ViewSwizzled,
-    /// The type-8 view chain ended at ref 0 — the view names no base texture.
+    /// The texture-view chain ended at ref 0 — the view names no base texture.
     ViewBaseUnbound,
 
     /// The view's own level base plus the level the pass named does not fit a
@@ -422,55 +423,55 @@ pub(super) enum RenderTargetCause {
         view_level: u32,
         attachment_level: u32,
     },
-    /// A mip>0 view of an IOSurface. Type-11 sample windows carry planes, not
+    /// A mip>0 view of an IOSurface. Mapper-ref-texture sample windows carry planes, not
     /// mip levels, so this geometry has no contract behind it.
-    Type11MipView { level: u32 },
+    MapperRefTextureMipView { level: u32 },
     /// Neither the live descriptor nor the latch produced a mapping id.
-    Type11Unresolved,
+    MapperRefTextureUnresolved,
     /// The mapping id resolved and names no live mapping.
-    Type11NoMapping { mapping_id: u32 },
+    MapperRefTextureNoMapping { mapping_id: u32 },
     /// The mapping has no latched geometry, or a zero dimension.
-    Type11Geometry {
+    MapperRefTextureGeometry {
         mapping_id: u32,
         has_geom: bool,
         width: u32,
         height: u32,
     },
     /// The mapping's format is not one Metal can render into.
-    Type11Format { mapping_id: u32, fmt: u16 },
+    MapperRefTextureFormat { mapping_id: u32, fmt: u16 },
 
-    /// The type-5 entry's descriptor bytes could not be read.
-    Type5DescRead,
-    /// The bytes were read and are not a type-5 header.
-    Type5DescDecode { len: usize },
-    /// The type-5 header names surface 0, so it wraps nothing.
-    Type5SurfaceZero,
+    /// The ref-texture entry's descriptor bytes could not be read.
+    RefTextureDescRead,
+    /// The bytes were read and are not a ref-texture header.
+    RefTextureDescDecode { len: usize },
+    /// The ref-texture header names surface 0, so it wraps nothing.
+    RefTextureSurfaceZero,
 
-    /// A mip>0 view of a type-4 surface. Colour RT materialization is level 0
+    /// A mip>0 view of a backing record. Colour RT materialization is level 0
     /// only.
-    Type4MipView { surface_id: u32, level: u32 },
+    BackingMipView { surface_id: u32, level: u32 },
     /// The surface's backing could not be resolved.
-    Type4Unresolved {
+    BackingUnresolved {
         surface_id: u32,
         live_type: Option<u8>,
     },
     /// The surface resolved and left no mapping under its id.
-    Type4NoMapping { surface_id: u32 },
+    BackingNoMapping { surface_id: u32 },
     /// The surface's mapping has no geometry, a zero dimension, or no pages.
-    Type4Geometry {
+    BackingGeometry {
         surface_id: u32,
         has_geom: bool,
         width: u32,
         height: u32,
         pages: usize,
     },
-    /// The type-4 decoder refused this surface a format — multi-plane, or a
-    /// FourCC it has no contract for. [`rt_type4_base_format`] carries the
+    /// The backing decoder refused this surface a format — multi-plane, or a
+    /// FourCC it has no contract for. [`rt_backing_base_format`] carries the
     /// argument for why no format is invented here; this is the ladder
     /// recording that it stopped there.
-    Type4BaseFormat { surface_id: u32, raw_fmt: u16 },
+    BackingBaseFormat { surface_id: u32, raw_fmt: u16 },
     /// The surface's format is not one Metal can render into.
-    Type4Format { surface_id: u32, fmt: u16 },
+    BackingFormat { surface_id: u32, fmt: u16 },
 
     /// The guest has put nothing under this ref. Expected while a task's object
     /// list is still being populated, which is why it is reported and not
@@ -546,20 +547,22 @@ impl crate::observe::Decline for RenderTargetRefusal {
             C::ViewSwizzled => "rt_view_swizzled",
             C::ViewBaseUnbound => "rt_view_base_unbound",
             C::LevelOverflow { .. } => "rt_level_overflow",
-            C::Type11MipView { .. } => "rt_type11_mip_view",
-            C::Type11Unresolved => "rt_type11_unresolved",
-            C::Type11NoMapping { .. } => "rt_type11_no_mapping",
-            C::Type11Geometry { .. } => "rt_type11_geometry",
-            C::Type11Format { .. } => "rt_type11_format",
-            C::Type5DescRead => crate::observe::ladder_slug!("rt_type5", desc_read),
-            C::Type5DescDecode { .. } => crate::observe::ladder_slug!("rt_type5", desc_decode),
-            C::Type5SurfaceZero => "rt_type5_surface_zero",
-            C::Type4MipView { .. } => "rt_type4_mip_view",
-            C::Type4Unresolved { .. } => "rt_type4_unresolved",
-            C::Type4NoMapping { .. } => "rt_type4_no_mapping",
-            C::Type4Geometry { .. } => "rt_type4_geometry",
-            C::Type4BaseFormat { .. } => "rt_type4_base_format",
-            C::Type4Format { .. } => "rt_type4_format",
+            C::MapperRefTextureMipView { .. } => "rt_mapper_ref_texture_mip_view",
+            C::MapperRefTextureUnresolved => "rt_mapper_ref_texture_unresolved",
+            C::MapperRefTextureNoMapping { .. } => "rt_mapper_ref_texture_no_mapping",
+            C::MapperRefTextureGeometry { .. } => "rt_mapper_ref_texture_geometry",
+            C::MapperRefTextureFormat { .. } => "rt_mapper_ref_texture_format",
+            C::RefTextureDescRead => crate::observe::ladder_slug!("rt_ref_texture", desc_read),
+            C::RefTextureDescDecode { .. } => {
+                crate::observe::ladder_slug!("rt_ref_texture", desc_decode)
+            }
+            C::RefTextureSurfaceZero => "rt_ref_texture_surface_zero",
+            C::BackingMipView { .. } => "rt_backing_mip_view",
+            C::BackingUnresolved { .. } => "rt_backing_unresolved",
+            C::BackingNoMapping { .. } => "rt_backing_no_mapping",
+            C::BackingGeometry { .. } => "rt_backing_geometry",
+            C::BackingBaseFormat { .. } => "rt_backing_base_format",
+            C::BackingFormat { .. } => "rt_backing_format",
             C::NoListEntry => crate::observe::ladder_slug!("rt", no_list_entry),
             C::WrongType { .. } => crate::observe::ladder_slug!("rt", wrong_type),
             C::LinearDescRead => crate::observe::ladder_slug!("rt_linear", desc_read),
@@ -584,7 +587,7 @@ impl crate::observe::Decline for RenderTargetRefusal {
         use RenderTargetCause as C;
         let mut v = vec![("base", self.base_ref.to_string())];
         match self.cause {
-            C::Type11MipView { level } | C::LinearLevelGva { level } => {
+            C::MapperRefTextureMipView { level } | C::LinearLevelGva { level } => {
                 v.push(("level", level.to_string()))
             }
             C::LevelOverflow {
@@ -594,8 +597,8 @@ impl crate::observe::Decline for RenderTargetRefusal {
                 v.push(("view_level", view_level.to_string()));
                 v.push(("attachment_level", attachment_level.to_string()));
             }
-            C::Type11NoMapping { mapping_id } => v.push(("mid", mapping_id.to_string())),
-            C::Type11Geometry {
+            C::MapperRefTextureNoMapping { mapping_id } => v.push(("mid", mapping_id.to_string())),
+            C::MapperRefTextureGeometry {
                 mapping_id,
                 has_geom,
                 width,
@@ -605,16 +608,16 @@ impl crate::observe::Decline for RenderTargetRefusal {
                 v.push(("has_geom", has_geom.to_string()));
                 v.push(("dims", format!("{width}x{height}")));
             }
-            C::Type11Format { mapping_id, fmt } => {
+            C::MapperRefTextureFormat { mapping_id, fmt } => {
                 v.push(("mid", mapping_id.to_string()));
                 v.push(("fmt", format!("{fmt:#x}")));
             }
-            C::Type5DescDecode { len } => v.push(("desc_len", len.to_string())),
-            C::Type4MipView { surface_id, level } => {
+            C::RefTextureDescDecode { len } => v.push(("desc_len", len.to_string())),
+            C::BackingMipView { surface_id, level } => {
                 v.push(("sid", surface_id.to_string()));
                 v.push(("level", level.to_string()));
             }
-            C::Type4Unresolved {
+            C::BackingUnresolved {
                 surface_id,
                 live_type,
             } => {
@@ -624,8 +627,8 @@ impl crate::observe::Decline for RenderTargetRefusal {
                     live_type.map_or_else(|| "none".to_string(), |t| t.to_string()),
                 ));
             }
-            C::Type4NoMapping { surface_id } => v.push(("sid", surface_id.to_string())),
-            C::Type4Geometry {
+            C::BackingNoMapping { surface_id } => v.push(("sid", surface_id.to_string())),
+            C::BackingGeometry {
                 surface_id,
                 has_geom,
                 width,
@@ -637,14 +640,14 @@ impl crate::observe::Decline for RenderTargetRefusal {
                 v.push(("dims", format!("{width}x{height}")));
                 v.push(("pages", pages.to_string()));
             }
-            C::Type4BaseFormat {
+            C::BackingBaseFormat {
                 surface_id,
                 raw_fmt,
             } => {
                 v.push(("sid", surface_id.to_string()));
                 v.push(("raw_fmt", format!("{raw_fmt:#x}")));
             }
-            C::Type4Format { surface_id, fmt } => {
+            C::BackingFormat { surface_id, fmt } => {
                 v.push(("sid", surface_id.to_string()));
                 v.push(("fmt", format!("{fmt:#x}")));
             }
@@ -702,9 +705,9 @@ impl crate::observe::Decline for RenderTargetRefusal {
             C::ZeroExtent { width, height } => v.push(("dims", format!("{width}x{height}"))),
             C::ViewSwizzled
             | C::ViewBaseUnbound
-            | C::Type11Unresolved
-            | C::Type5DescRead
-            | C::Type5SurfaceZero
+            | C::MapperRefTextureUnresolved
+            | C::RefTextureDescRead
+            | C::RefTextureSurfaceZero
             | C::NoListEntry
             | C::LinearDescRead => {}
         }
@@ -712,18 +715,18 @@ impl crate::observe::Decline for RenderTargetRefusal {
     }
 }
 
-/// Archive `apple_pv_gpu_lookup_render_target`: type-11 first, else type-2/3 GVA.
+/// Archive `apple_pv_gpu_lookup_render_target`: mapper-ref-texture first, else normal-texture GVA.
 ///
-/// Wallpaper/background intermediates are type-2/3 guest-VA; type-11-only resolve
+/// Wallpaper/background intermediates are normal-texture guest-VA; mapper-ref-texture-only resolve
 /// drops those passes (black wallpaper). Color RT formats are the Metal color-
 /// renderable set admitted by [`pixel_format::render_target_bpp`] (RGBA8 family,
 /// BGRA8 family, RGBA16Float) — bring-up only listed compositor BGRA8/0x73.
 ///
-/// Type-8 texture views (archive `resource_resolve_texture` view chain): resolve
+/// Texture-view texture views (archive `resource_resolve_texture` view chain): resolve
 /// to the base texture. Swizzled views are rejected as RTs (archive
 /// `resolve_texture` requires `!has_swizzle`). Level 0 only for color RT
 /// materialization (mip RT not supported). Without this, UI passes that bind a
-/// type-8 view as color attachment fail MRT (`mrt_request fail slots=[211]`) and
+/// texture-view as color attachment fail MRT (`mrt_request fail slots=[211]`) and
 /// drop entire draws (blank App Store sidebar / missing chrome labels).
 ///
 /// # An unbound ref is not a refusal
@@ -774,7 +777,7 @@ fn resolve_render_target<M: HostMemory + HostOps>(
 ) -> Result<ResolvedRenderTarget, RenderTargetRefusal> {
     use RenderTargetCause as C;
     let texture_ref = att.texture_ref;
-    // Type-8 view → base (archive resource_resolve_texture view chain).
+    // Texture-view view → base (archive resource_resolve_texture view chain).
     let (resolved_ref, view_fmt_override, view_level) =
         if let Some(view) = resolve_texture_view(state, host, task_id, texture_ref) {
             // Archive resolve_texture rejects swizzled views for linear resolve.
@@ -790,7 +793,7 @@ fn resolve_render_target<M: HostMemory + HostOps>(
     // The level the pass names is relative to the texture it names, so a pass
     // rendering into level 1 of a view whose own range starts at level 2 lands
     // on the base texture's level 3. Both halves reach every rung below as one
-    // number, which is what keeps the type-11 and type-4 rungs — neither of
+    // number, which is what keeps the mapper-ref-texture and backing rungs — neither of
     // which has a mip layout — refusing an attachment level as loudly as they
     // already refuse a view level.
     let level = view_level.checked_add(att.level).ok_or(
@@ -804,11 +807,11 @@ fn resolve_render_target<M: HostMemory + HostOps>(
         return Err(C::ViewBaseUnbound.at(resolved_ref));
     }
     // Archive lookup order is by **live** object-list type + descriptor, not a
-    // sticky cache: type-11 first, else type-2/3. Guest reuses object refs;
+    // sticky cache: mapper-ref-texture first, else normal-texture. Guest reuses object refs;
     // two failure modes for a stale `texture_to_mapping` latch:
-    // 1) live type is now type-2/3 → must not force type-11 (live residual
+    // 1) live type is now normal-texture → must not force mapper-ref-texture (live residual
     //    mrt color RT resolve fail ref=199 type=2 fmt=0x73 480x64).
-    // 2) live type is still type-11 but descriptor mapping_id changed (or a
+    // 2) live type is still mapper-ref-texture but descriptor mapping_id changed (or a
     //    recycled ref now names a different mid) → must re-read the live
     //    descriptor, not prefer the latch. Preferring latch routed dual-mid
     //    full-screen desktop composites onto only one mid (mid=3 nz=6M vs
@@ -816,27 +819,27 @@ fn resolve_render_target<M: HostMemory + HostOps>(
     let live = objects::lookup_list_entry(state, host, task_id, resolved_ref);
     let live_type = live.as_ref().map(|e| e.object_type);
     if let Some(ot) = live_type {
-        if ot != OBJECT_TYPE_IOSURFACE {
-            // Live list says not type-11 — drop any recycled-ref latch.
+        if ot != OBJECT_TYPE_MAPPER_REF_TEXTURE {
+            // Live list says not mapper-ref-texture — drop any recycled-ref latch.
             state.texture_to_mapping.remove(&(task_id, resolved_ref));
         }
     }
-    let try_type11 = live_type == Some(OBJECT_TYPE_IOSURFACE)
+    let try_mapper_ref_texture = live_type == Some(OBJECT_TYPE_MAPPER_REF_TEXTURE)
         || (live_type.is_none()
             && state
                 .texture_to_mapping
                 .contains_key(&(task_id, resolved_ref)));
-    if try_type11 {
-        // Type-11 sample windows carry planes, not mip levels — a mip>0 view
+    if try_mapper_ref_texture {
+        // Mapper-ref-texture sample windows carry planes, not mip levels — a mip>0 view
         // of an IOSurface has no contract-backed layout; fail visibly.
         if level != 0 {
-            return Err(C::Type11MipView { level }.at(resolved_ref));
+            return Err(C::MapperRefTextureMipView { level }.at(resolved_ref));
         }
-        // Live list is source of truth for mapping_id when the entry is type-11.
+        // Live list is source of truth for mapping_id when the entry is mapper-ref-texture.
         // Latch is only a fallback when the list entry is transiently missing
-        // (resolve_type11_ref refreshes the latch from the live descriptor).
-        let mapping_id = if live_type == Some(OBJECT_TYPE_IOSURFACE) {
-            objects::resolve_type11_ref(state, host, task_id, resolved_ref).or_else(|| {
+        // (resolve_mapper_ref_texture refreshes the latch from the live descriptor).
+        let mapping_id = if live_type == Some(OBJECT_TYPE_MAPPER_REF_TEXTURE) {
+            objects::resolve_mapper_ref_texture(state, host, task_id, resolved_ref).or_else(|| {
                 state
                     .texture_to_mapping
                     .get(&(task_id, resolved_ref))
@@ -847,23 +850,23 @@ fn resolve_render_target<M: HostMemory + HostOps>(
                 .texture_to_mapping
                 .get(&(task_id, resolved_ref))
                 .copied()
-                .or_else(|| objects::resolve_type11_ref(state, host, task_id, resolved_ref))
+                .or_else(|| objects::resolve_mapper_ref_texture(state, host, task_id, resolved_ref))
         }
-        .ok_or(C::Type11Unresolved.at(resolved_ref))?;
+        .ok_or(C::MapperRefTextureUnresolved.at(resolved_ref))?;
         let _ = mapper::ensure_resolved_for_scanout(state, host, mapping_id);
         // This rung is terminal either way, and both directions were already
-        // true before it said so. A live type-11 that fails geometry must not
-        // be decoded as type-2/3 — that is the sticky-latch bug above. And in
+        // true before it said so. A live mapper-ref-texture that fails geometry must not
+        // be decoded as normal-texture — that is the sticky-latch bug above. And in
         // the only other case that reaches here, `live_type` is `None`
-        // (`try_type11` admits nothing else), so every rung below ends at
+        // (`try_mapper_ref_texture` admits nothing else), so every rung below ends at
         // `NoListEntry`: falling through reported the ladder's least specific
-        // refusal for a failure the type-11 rung had already diagnosed.
+        // refusal for a failure the mapper-ref-texture rung had already diagnosed.
         let m = state
             .mappings
             .get(&mapping_id)
-            .ok_or(C::Type11NoMapping { mapping_id }.at(resolved_ref))?;
+            .ok_or(C::MapperRefTextureNoMapping { mapping_id }.at(resolved_ref))?;
         if !m.has_geom || m.width == 0 || m.height == 0 {
-            return Err(C::Type11Geometry {
+            return Err(C::MapperRefTextureGeometry {
                 mapping_id,
                 has_geom: m.has_geom,
                 width: m.width,
@@ -871,8 +874,8 @@ fn resolve_render_target<M: HostMemory + HostOps>(
             }
             .at(resolved_ref));
         }
-        // Not `rt_type4_base_format`: a type-11 mapping's format has
-        // writers other than the type-4 decoder, so 0 here can mean "not
+        // Not `rt_backing_base_format`: a mapper-ref-texture mapping's format has
+        // writers other than the backing decoder, so 0 here can mean "not
         // latched yet" rather than "refused", and BGRA8 is the display
         // contract's default for that case. See that function.
         let base_fmt = if m.format != 0 {
@@ -882,7 +885,7 @@ fn resolve_render_target<M: HostMemory + HostOps>(
         };
         let fmt = effective_view_sample_format(base_fmt, view_fmt_override).unwrap_or(base_fmt);
         if pixel_format::render_target_bpp(fmt).is_none() {
-            return Err(C::Type11Format { mapping_id, fmt }.at(resolved_ref));
+            return Err(C::MapperRefTextureFormat { mapping_id, fmt }.at(resolved_ref));
         }
         return Ok(ResolvedRenderTarget {
             mapping_id,
@@ -894,36 +897,36 @@ fn resolve_render_target<M: HostMemory + HostOps>(
             sample_count: 1,
         });
     }
-    // x86 Ventura/Tahoe type-4 surface/backing (present IOSurface). Object-list
+    // x86 Ventura/Tahoe backing record/backing (present IOSurface). Object-list
     // index == surface_id (ResourceHeap addObject type=4 objectId=getSurfaceID).
     // Without this, clear-only streams and Store writebacks never touch display
     // mids — guest pages stay empty and dual-mid thrash paints black.
-    // Type-4: object-list index is surface_id. Type-5 RefTextureHandle: surfaceID@0
-    // (allocateRefTextureHandle) — product color RTs are type-5 wrapping type-4.
-    let mut type5_view: Option<objects::Type5TextureView> = None;
-    let type4_sid = match live.as_ref() {
-        Some(e) if e.object_type == objects::OBJECT_TYPE_SURFACE => Some(resolved_ref),
+    // Backing: object-list index is surface_id. Ref-texture RefTextureHandle: surfaceID@0
+    // (allocateRefTextureHandle) — product color RTs are ref-texture wrapping backing.
+    let mut ref_texture_view: Option<objects::RefTextureView> = None;
+    let backing_sid = match live.as_ref() {
+        Some(e) if e.object_type == objects::OBJECT_TYPE_BACKING => Some(resolved_ref),
         Some(e) if e.object_type == objects::OBJECT_TYPE_REF_TEXTURE => {
             let desc = objects::read_descriptor(state, host, task_id, e)
-                .ok_or(C::Type5DescRead.at(resolved_ref))?;
-            let sid = reims_vgpu_wire::device_desc::type5_header(&desc)
-                .map_err(|_| C::Type5DescDecode { len: desc.len() }.at(resolved_ref))?
+                .ok_or(C::RefTextureDescRead.at(resolved_ref))?;
+            let sid = reims_vgpu_wire::device_desc::ref_texture_header(&desc)
+                .map_err(|_| C::RefTextureDescDecode { len: desc.len() }.at(resolved_ref))?
                 .surface_id
                 .get();
             if sid == 0 {
-                return Err(C::Type5SurfaceZero.at(resolved_ref));
+                return Err(C::RefTextureSurfaceZero.at(resolved_ref));
             }
-            type5_view = objects::decode_type5_texture_view(&desc);
+            ref_texture_view = objects::decode_ref_texture_view(&desc);
             Some(sid)
         }
         _ => None,
     };
-    if let Some(surface_id) = type4_sid {
+    if let Some(surface_id) = backing_sid {
         if level != 0 {
-            return Err(C::Type4MipView { surface_id, level }.at(resolved_ref));
+            return Err(C::BackingMipView { surface_id, level }.at(resolved_ref));
         }
-        if !objects::resolve_type4_surface(state, host, surface_id) {
-            return Err(C::Type4Unresolved {
+        if !objects::resolve_backing(state, host, surface_id) {
+            return Err(C::BackingUnresolved {
                 surface_id,
                 live_type,
             }
@@ -932,9 +935,9 @@ fn resolve_render_target<M: HostMemory + HostOps>(
         let m = state
             .mappings
             .get(&surface_id)
-            .ok_or(C::Type4NoMapping { surface_id }.at(resolved_ref))?;
+            .ok_or(C::BackingNoMapping { surface_id }.at(resolved_ref))?;
         if !m.has_geom || m.width == 0 || m.height == 0 || m.page_entries.is_empty() {
-            return Err(C::Type4Geometry {
+            return Err(C::BackingGeometry {
                 surface_id,
                 has_geom: m.has_geom,
                 width: m.width,
@@ -945,19 +948,23 @@ fn resolve_render_target<M: HostMemory + HostOps>(
         }
         let (base_w, base_h, base_raw_fmt) = (m.width, m.height, m.format);
         if live_type == Some(objects::OBJECT_TYPE_REF_TEXTURE) {
-            note_rt_type5_view(type5_view, surface_id, (base_w, base_h, base_raw_fmt));
+            note_rt_ref_texture_view(ref_texture_view, surface_id, (base_w, base_h, base_raw_fmt));
         }
-        let base_fmt = rt_type4_base_format(base_raw_fmt, surface_id).ok_or(
-            C::Type4BaseFormat {
+        let base_fmt = rt_backing_base_format(base_raw_fmt, surface_id).ok_or(
+            C::BackingBaseFormat {
                 surface_id,
                 raw_fmt: base_raw_fmt,
             }
             .at(resolved_ref),
         )?;
-        let fmt =
-            rt_type4_declared_format(base_fmt, (base_w, base_h), type5_view, view_fmt_override);
+        let fmt = rt_backing_declared_format(
+            base_fmt,
+            (base_w, base_h),
+            ref_texture_view,
+            view_fmt_override,
+        );
         if pixel_format::render_target_bpp(fmt).is_none() {
-            return Err(C::Type4Format { surface_id, fmt }.at(resolved_ref));
+            return Err(C::BackingFormat { surface_id, fmt }.at(resolved_ref));
         }
         // mapping_id = surface_id; no linear GVA.
         return Ok(ResolvedRenderTarget {
@@ -970,9 +977,10 @@ fn resolve_render_target<M: HostMemory + HostOps>(
             sample_count: 1,
         });
     }
-    // type-2/3 linear GVA (wallpaper/background layers, UI intermediate RTs).
+    // normal-texture linear GVA (wallpaper/background layers, UI intermediate RTs).
     let entry = live.ok_or(C::NoListEntry.at(resolved_ref))?;
-    if entry.object_type != OBJECT_TYPE_TEXTURE && entry.object_type != OBJECT_TYPE_TEXTURE_VARIANT
+    if entry.object_type != OBJECT_TYPE_TEXTURE
+        && entry.object_type != OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
     {
         return Err(C::WrongType {
             object_type: entry.object_type,
@@ -1172,37 +1180,37 @@ mod tests {
         );
     }
 
-    /// A type-4 colour attachment whose mapping carries the decoder's format
+    /// A backing colour attachment whose mapping carries the decoder's format
     /// refusal must be declined, and every decline must be counted.
     ///
-    /// `m.format == 0` on a type-4 mapping has exactly one writer,
-    /// `apply_type4_backing`, and it means multi-plane or unknown FourCC — a surface
+    /// `m.format == 0` on a backing mapping has exactly one writer,
+    /// `apply_backing`, and it means multi-plane or unknown FourCC — a surface
     /// that is not a single-format colour attachment. Inventing BGRA8 from it
     /// describes the wrong stride over the wrong bytes and every downstream window
     /// is built from the answer. The counter has to fire on the refusal and only on
     /// it: one that also fired on ordinary formats would answer a different question
     /// and read identically.
     #[test]
-    fn a_type4_render_target_declines_the_decoders_format_refusal() {
+    fn a_backing_render_target_declines_the_decoders_format_refusal() {
         use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
         use crate::runtime::drain::store_route_count;
 
         let before = store_route_count("rt_base_fmt_declined");
         // A format the decoder resolved is passed through untouched and uncounted.
         assert_eq!(
-            rt_type4_base_format(MTL_FORMAT_BGRA8_UNORM, 11),
+            rt_backing_base_format(MTL_FORMAT_BGRA8_UNORM, 11),
             Some(MTL_FORMAT_BGRA8_UNORM)
         );
         assert_eq!(store_route_count("rt_base_fmt_declined"), before);
         // The refusal declines, and is counted per occurrence — the fail line is
         // deduped per mapping, the counter is not.
-        assert_eq!(rt_type4_base_format(0, 11), None);
-        assert_eq!(rt_type4_base_format(0, 12), None);
-        assert_eq!(rt_type4_base_format(0, 11), None);
+        assert_eq!(rt_backing_base_format(0, 11), None);
+        assert_eq!(rt_backing_base_format(0, 12), None);
+        assert_eq!(rt_backing_base_format(0, 11), None);
         assert_eq!(store_route_count("rt_base_fmt_declined"), before + 3);
     }
 
-    /// A type-5 view's declared format reaches the colour attachment, so the
+    /// A ref-texture view's declared format reaches the colour attachment, so the
     /// hardware performs the linear-to-sRGB encode the guest asked for.
     ///
     /// This is the write half of the sRGB round trip. Metal stores `E(L)` into an
@@ -1214,15 +1222,15 @@ mod tests {
     /// The live shape is `view=300x300 fmt=0x51 base=300x300 fmt=0x50`, seen twice
     /// on a driven macos-13 boot at icon size.
     #[test]
-    fn a_type5_views_declared_format_is_what_the_colour_attachment_attaches() {
+    fn a_ref_texture_views_declared_format_is_what_the_colour_attachment_attaches() {
         use crate::contract::pixel_format::{
             MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_BGRA8_UNORM_SRGB, MTL_FORMAT_RGBA16_FLOAT,
         };
-        use crate::runtime::objects::Type5TextureView;
+        use crate::runtime::objects::RefTextureView;
 
         let extent = (300u32, 300u32);
         let view = |w, h, fmt| {
-            Some(Type5TextureView {
+            Some(RefTextureView {
                 pixel_format: fmt,
                 width: w,
                 height: h,
@@ -1233,7 +1241,7 @@ mod tests {
 
         // The defect: an sRGB view over a linear base must attach sRGB.
         assert_eq!(
-            rt_type4_declared_format(
+            rt_backing_declared_format(
                 MTL_FORMAT_BGRA8_UNORM,
                 extent,
                 view(300, 300, MTL_FORMAT_BGRA8_UNORM_SRGB),
@@ -1243,12 +1251,12 @@ mod tests {
         );
         // A surface bound without a view keeps the mapping's own format.
         assert_eq!(
-            rt_type4_declared_format(MTL_FORMAT_BGRA8_UNORM, extent, None, None),
+            rt_backing_declared_format(MTL_FORMAT_BGRA8_UNORM, extent, None, None),
             MTL_FORMAT_BGRA8_UNORM
         );
         // A view that agrees says nothing new.
         assert_eq!(
-            rt_type4_declared_format(
+            rt_backing_declared_format(
                 MTL_FORMAT_BGRA8_UNORM,
                 extent,
                 view(300, 300, MTL_FORMAT_BGRA8_UNORM),
@@ -1260,7 +1268,7 @@ mod tests {
         // takes the base mapping's geometry, so lifting the format alone would
         // attach a reinterpretation to a grid that is not its own.
         assert_eq!(
-            rt_type4_declared_format(
+            rt_backing_declared_format(
                 MTL_FORMAT_BGRA8_UNORM,
                 extent,
                 view(75, 300, MTL_FORMAT_RGBA16_FLOAT),
@@ -1271,7 +1279,7 @@ mod tests {
         // A same-extent view whose texel is a different width is not a
         // reinterpretation of one allocation, and the base format stands.
         assert_eq!(
-            rt_type4_declared_format(
+            rt_backing_declared_format(
                 MTL_FORMAT_BGRA8_UNORM,
                 extent,
                 view(300, 300, MTL_FORMAT_RGBA16_FLOAT),
@@ -1279,16 +1287,16 @@ mod tests {
             ),
             MTL_FORMAT_BGRA8_UNORM
         );
-        // A zero format is the type-5 decoder saying it has none, not a
+        // A zero format is the ref-texture decoder saying it has none, not a
         // declaration of format zero.
         assert_eq!(
-            rt_type4_declared_format(MTL_FORMAT_BGRA8_UNORM, extent, view(300, 300, 0), None),
+            rt_backing_declared_format(MTL_FORMAT_BGRA8_UNORM, extent, view(300, 300, 0), None),
             MTL_FORMAT_BGRA8_UNORM
         );
-        // A type-8 view is a further reinterpretation the guest asked for on top,
-        // so it outranks the type-5 record.
+        // A texture-view is a further reinterpretation the guest asked for on top,
+        // so it outranks the ref-texture record.
         assert_eq!(
-            rt_type4_declared_format(
+            rt_backing_declared_format(
                 MTL_FORMAT_BGRA8_UNORM,
                 extent,
                 view(300, 300, MTL_FORMAT_BGRA8_UNORM_SRGB),
@@ -1298,7 +1306,7 @@ mod tests {
         );
     }
 
-    /// A type-5 colour attachment must be scored on whether its view agrees with
+    /// A ref-texture colour attachment must be scored on whether its view agrees with
     /// the base mapping, and "no view decoded" must not read as agreement.
     ///
     /// The resolve takes geometry from the base mapping either way, so the counter
@@ -1306,13 +1314,13 @@ mod tests {
     /// undecoded record into `same` would report the ambiguous case as the healthy
     /// one, which is the failure mode that makes a census worthless.
     #[test]
-    fn a_type5_render_target_view_is_scored_against_the_base_it_resolves_through() {
+    fn a_ref_texture_render_target_view_is_scored_against_the_base_it_resolves_through() {
         use crate::runtime::drain::store_route_count;
-        use crate::runtime::objects::Type5TextureView;
+        use crate::runtime::objects::RefTextureView;
 
         let base = (64u32, 32u32, 0x50u16);
         let view = |w, h, fmt| {
-            Some(Type5TextureView {
+            Some(RefTextureView {
                 pixel_format: fmt,
                 width: w,
                 height: h,
@@ -1321,27 +1329,27 @@ mod tests {
             })
         };
         let (same0, diff0, und0) = (
-            store_route_count("rt_type5_view_same"),
-            store_route_count("rt_type5_view_differs"),
-            store_route_count("rt_type5_view_undecoded"),
+            store_route_count("rt_ref_texture_view_same"),
+            store_route_count("rt_ref_texture_view_differs"),
+            store_route_count("rt_ref_texture_view_undecoded"),
         );
 
-        note_rt_type5_view(view(64, 32, 0x50), 5, base);
-        assert_eq!(store_route_count("rt_type5_view_same"), same0 + 1);
+        note_rt_ref_texture_view(view(64, 32, 0x50), 5, base);
+        assert_eq!(store_route_count("rt_ref_texture_view_same"), same0 + 1);
 
         // The live case the contract names: a row-byte-equivalent reinterpretation
         // at a different width and format over the same bytes.
-        note_rt_type5_view(view(16, 32, 0x73), 6, base);
-        assert_eq!(store_route_count("rt_type5_view_differs"), diff0 + 1);
+        note_rt_ref_texture_view(view(16, 32, 0x73), 6, base);
+        assert_eq!(store_route_count("rt_ref_texture_view_differs"), diff0 + 1);
         // Geometry alone is not the test — a format-only view is still a different
         // view, and it is the one this resolve would silently render as BGRA8.
-        note_rt_type5_view(view(64, 32, 0x73), 7, base);
-        assert_eq!(store_route_count("rt_type5_view_differs"), diff0 + 2);
+        note_rt_ref_texture_view(view(64, 32, 0x73), 7, base);
+        assert_eq!(store_route_count("rt_ref_texture_view_differs"), diff0 + 2);
 
-        note_rt_type5_view(None, 8, base);
-        assert_eq!(store_route_count("rt_type5_view_undecoded"), und0 + 1);
+        note_rt_ref_texture_view(None, 8, base);
+        assert_eq!(store_route_count("rt_ref_texture_view_undecoded"), und0 + 1);
         assert_eq!(
-            store_route_count("rt_type5_view_same"),
+            store_route_count("rt_ref_texture_view_same"),
             same0 + 1,
             "an undecoded record must not be scored as agreement"
         );
@@ -1380,20 +1388,20 @@ mod tests {
         );
     }
 
-    /// A type-11 latch whose mapping has no geometry is reported as that, not
+    /// A mapper-ref-texture latch whose mapping has no geometry is reported as that, not
     /// as the missing object-list entry three rungs further down.
     ///
-    /// This is the terminal-rung property. The type-11 arm used to return only
+    /// This is the terminal-rung property. The mapper-ref-texture arm used to return only
     /// when the *live* list said IOSurface; a latch-only attempt that failed
-    /// geometry fell through to the type-4 and linear rungs instead. It could
+    /// geometry fell through to the backing and linear rungs instead. It could
     /// not resolve there — `live_type` is `None` in that arm by construction,
-    /// so `type4_sid` is `None` and the linear rung's first act is to unwrap
+    /// so `backing_sid` is `None` and the linear rung's first act is to unwrap
     /// the entry that is not there. The fall-through therefore changed nothing
     /// about the outcome and everything about the diagnosis: the ladder
     /// reported `no_list_entry` for a surface whose mapping it had already
     /// found and measured.
     #[test]
-    fn a_type11_latch_without_geometry_names_the_geometry_check() {
+    fn a_mapper_ref_texture_latch_without_geometry_names_the_geometry_check() {
         let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
         let host = FakeHost::new();
         let tex_ref = 0x5c2u32;
@@ -1407,7 +1415,7 @@ mod tests {
         assert!(lookup_render_target(&mut state, &host, 4, attach(tex_ref)).is_none());
         let line = cap.one("rt_resolve");
         assert!(
-            line.starts_with("rt_resolve reason=rt_type11_geometry "),
+            line.starts_with("rt_resolve reason=rt_mapper_ref_texture_geometry "),
             "the rung that found the mapping must be the one that reports: {line}"
         );
         assert!(
@@ -1430,7 +1438,7 @@ mod tests {
     ///
     /// The guest re-issues the same pass every frame, so this path is entered
     /// at draw rate. The two ad-hoc lines this ladder used to emit had no latch
-    /// at all — one of them on the type-4 rung, which a compositing workload
+    /// at all — one of them on the backing rung, which a compositing workload
     /// takes for every desktop surface.
     #[test]
     fn a_repeated_refusal_on_the_same_attachment_reports_once() {
@@ -1455,7 +1463,7 @@ mod tests {
     ///
     /// macOS 26's compositor renders a blur pyramid level by level, and until
     /// this the whole class was refused at decode as an unbindable subresource.
-    /// The rung it reaches was already here for a type-8 *view* that carries a
+    /// The rung it reaches was already here for a texture-view *view* that carries a
     /// level; what was missing was the pass's own `level` field reaching it.
     ///
     /// Every assertion names a number that differs between the two levels, so a

--- a/crates/reims-vgpu/src/runtime/draw/tests.rs
+++ b/crates/reims-vgpu/src/runtime/draw/tests.rs
@@ -54,7 +54,7 @@ fn clear_black_attachment(texture_ref: u32) -> crate::runtime::decode::render::C
 }
 
 /// The triangle every target-resolution test in this file draws: three vertices
-/// of one instance, primitive type 3, from vertex 0.
+/// of one instance, primitive generate-mipmaps texture, from vertex 0.
 ///
 /// Named because it used to be spelled `3, 1, 3, 0, 0` at four call sites — five
 /// positional `u32`s with two `3`s among them, where a transposition compiles and
@@ -138,7 +138,7 @@ fn a_small_reflected_object_stays_on_the_gather_rail_and_moves_only_its_extent()
 
 /// The sampled gather floor is one rule, and all three rails get the same answer.
 ///
-/// It was three hand-written copies and they disagreed. The type-11 arm carried
+/// It was three hand-written copies and they disagreed. The mapper-ref-texture arm carried
 /// the span term alone, so a half-float sampled surface under 64 KiB — whose CPU
 /// loader arm exists and is lossy — was declined onto that loader on that rail
 /// and admitted on the other two. `a_cost_floor_may_decline` exists precisely to
@@ -154,8 +154,8 @@ fn the_sampled_gather_floor_gives_one_verdict_to_all_three_rails() {
 
     let rails = [
         SampledFloorRail::Linear,
-        SampledFloorRail::Type11,
-        SampledFloorRail::Type5,
+        SampledFloorRail::MapperRefTexture,
+        SampledFloorRail::RefTexture,
     ];
     let under = SAMPLED_GATHER_MIN_BYTES - 1;
     let over = SAMPLED_GATHER_MIN_BYTES;
@@ -331,7 +331,7 @@ fn strided_window_extent_measures_padded_rows_and_refuses_unrepresentable_stride
     assert_eq!(strided_window_extent(64, 32, 4, 258), None);
     // Zero height has no last row to measure to.
     assert_eq!(strided_window_extent(64, 0, 4, 256), None);
-    // Single-byte texels (the type-5 NV12 luma plane) take every stride.
+    // Single-byte texels (the ref-texture NV12 luma plane) take every stride.
     assert_eq!(strided_window_extent(64, 4, 1, 64), Some((256, 0)));
     // The block-aware level form, on the geometry the gather refused for a
     // whole session: a 64x64 BC3 level is 16 rows of 16 blocks. Tight rows
@@ -377,7 +377,7 @@ fn strided_window_extent_measures_padded_rows_and_refuses_unrepresentable_stride
 
 #[test]
 #[cfg(feature = "backend-vulkan")]
-fn type11_zero_copy_declines_transient_host_mappings() {
+fn mapper_ref_texture_zero_copy_declines_transient_host_mappings() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
 
@@ -402,7 +402,7 @@ fn type11_zero_copy_declines_transient_host_mappings() {
     assert!(state.set_mapping_geom(mid, width, height, MTL_FORMAT_BGRA8_UNORM));
 
     let resource = crate::model::TaskResource::new(Default::default(), std::sync::Arc::from([]));
-    assert!(try_type11_sample_zero_copy(
+    assert!(try_mapper_ref_texture_sample_zero_copy(
         &mut state,
         &mut host,
         mid,
@@ -453,81 +453,98 @@ fn mapping_sampled_planes_reuse_one_resource_owned_import() {
         crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM_SRGB,
     ));
     crate::runtime::guest_ram::latch_import_limits(page, 1 << 30, 1 << 30);
-    let type11_witnesses = crate::runtime::drain::store_route_count("gw_rail_t11");
-    let type5_witnesses = crate::runtime::drain::store_route_count("gw_rail_t5");
-    let type11_resource =
+    let mapper_ref_texture_witnesses = crate::runtime::drain::store_route_count("gw_rail_t11");
+    let ref_texture_witnesses = crate::runtime::drain::store_route_count("gw_rail_t5");
+    let mapper_ref_texture_resource =
         crate::model::TaskResource::new(Default::default(), std::sync::Arc::from([]));
-    let type5_resource =
+    let ref_texture_resource =
         crate::model::TaskResource::new(Default::default(), std::sync::Arc::from([]));
 
-    let type11 = try_type11_sample_zero_copy(
+    let mapper_ref_texture = try_mapper_ref_texture_sample_zero_copy(
         &mut state,
         &mut host,
         mid,
         128,
         128,
-        type11_resource.lifetime_ref(),
+        mapper_ref_texture_resource.lifetime_ref(),
     )
     .expect("the mapping's color plane is sampleable");
-    let SampledSourceRequest::GuestRuns(type11, _, type11_format, _, type11_identity, ..) = type11
+    let SampledSourceRequest::GuestRuns(
+        mapper_ref_texture,
+        _,
+        mapper_ref_texture_format,
+        _,
+        mapper_ref_texture_identity,
+        ..,
+    ) = mapper_ref_texture
     else {
         panic!("the mapping stays guest-backed")
     };
-    assert_eq!(type11_format, ash::vk::Format::B8G8R8A8_SRGB);
-    assert_eq!(type11_identity, None);
+    assert_eq!(mapper_ref_texture_format, ash::vk::Format::B8G8R8A8_SRGB);
+    assert_eq!(mapper_ref_texture_identity, None);
     assert_eq!(
         crate::runtime::drain::store_route_count("gw_rail_t11"),
-        type11_witnesses,
+        mapper_ref_texture_witnesses,
         "a direct resource has no copied image whose freshness needs witnessing"
     );
-    let type11_import = type11
+    let mapper_ref_texture_import = mapper_ref_texture
         .direct_image
         .expect("stable allocation binds directly")
         .import;
 
-    let type5 = try_type5_sample_zero_copy(
+    let ref_texture = try_ref_texture_sample_zero_copy(
         &mut state,
         &mut host,
         mid,
-        objects::Type5TextureView {
+        objects::RefTextureView {
             pixel_format: MTL_FORMAT_BGRA8_UNORM,
             width: 128,
             height: 128,
             depth: 1,
             plane_index: 0,
         },
-        type5_resource.lifetime_ref(),
+        ref_texture_resource.lifetime_ref(),
     )
     .expect("the serialized plane view is sampleable");
-    let SampledSourceRequest::GuestRuns(type5, _, type5_format, _, type5_identity, ..) = type5
+    let SampledSourceRequest::GuestRuns(
+        ref_texture,
+        _,
+        ref_texture_format,
+        _,
+        ref_texture_identity,
+        ..,
+    ) = ref_texture
     else {
         panic!("the plane view stays guest-backed")
     };
-    assert_eq!(type5_format, ash::vk::Format::B8G8R8A8_UNORM);
-    assert_eq!(type5_identity, None);
+    assert_eq!(ref_texture_format, ash::vk::Format::B8G8R8A8_UNORM);
+    assert_eq!(ref_texture_identity, None);
     assert_eq!(
         crate::runtime::drain::store_route_count("gw_rail_t5"),
-        type5_witnesses,
+        ref_texture_witnesses,
         "a direct plane has no copied image whose freshness needs witnessing"
     );
-    let type5_import = type5
+    let ref_texture_import = ref_texture
         .direct_image
         .expect("stable allocation binds directly")
         .import;
     crate::runtime::guest_ram::forget_import_limits();
 
     assert_eq!(
-        type11_import.id(),
-        type5_import.id(),
+        mapper_ref_texture_import.id(),
+        ref_texture_import.id(),
         "two views of one mapping must retain the mapping's one import"
     );
-    assert!(std::sync::Arc::ptr_eq(&type11_import, &type5_import));
+    assert!(std::sync::Arc::ptr_eq(
+        &mapper_ref_texture_import,
+        &ref_texture_import
+    ));
     assert_eq!(
         state.mappings[&mid]
             .contig_import
             .as_ref()
             .map(|import| import.id()),
-        Some(type11_import.id())
+        Some(mapper_ref_texture_import.id())
     );
 }
 
@@ -561,7 +578,7 @@ fn small_mapping_sampled_plane_uses_its_direct_resource() {
     crate::runtime::guest_ram::latch_import_limits(page, 1 << 30, 1 << 30);
     let resource = crate::model::TaskResource::new(Default::default(), std::sync::Arc::from([]));
 
-    let sampled = try_type11_sample_zero_copy(
+    let sampled = try_mapper_ref_texture_sample_zero_copy(
         &mut state,
         &mut host,
         mid,
@@ -1162,7 +1179,7 @@ fn swap_rb_channels_matches_two_pass_and_preserves_tail() {
 /// the order asked for, and match `swap_rb_channels` when it is not.
 ///
 /// The no-op half is the whole point of threading the order rather than
-/// normalizing: a type-11 composite Store's readback now arrives BGRA, so this is
+/// normalizing: a mapper-ref-texture composite Store's readback now arrives BGRA, so this is
 /// the call that used to be a 776 us whole-frame pass and is now a compare. A
 /// future edit that made it exchange unconditionally would restore that cost
 /// silently — the pixels would still be right.
@@ -1204,7 +1221,7 @@ fn stage_in_buffer_read_as_ssbo_is_bound_as_storage() {
 }
 
 /// Resident GVA chain wiring: the identity is built only for GVA color0
-/// (never type-11), and its extent is color0's declared geometry — the one
+/// (never mapper-ref-texture), and its extent is color0's declared geometry — the one
 /// place a draw states what it renders into.
 #[cfg(feature = "backend-vulkan")]
 #[test]
@@ -1243,7 +1260,7 @@ fn gva_chain_identity_rules() {
     assert_eq!(
         gva_chain_identity(&req),
         None,
-        "type-11 targets never take the GVA identity"
+        "mapper-ref-texture targets never take the GVA identity"
     );
     req.colors[0].mapping_id = 0;
     req.colors[0].target_gva = 0;
@@ -1252,7 +1269,7 @@ fn gva_chain_identity_rules() {
 
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn render_chain_identity_covers_type11_and_gva_targets() {
+fn render_chain_identity_covers_mapper_ref_texture_and_gva_targets() {
     use crate::backend::vulkan::engine::TargetIdentity;
 
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -1318,7 +1335,7 @@ fn a_chained_composite_store_names_the_resident_it_loads_from() {
         ..Default::default()
     });
 
-    let unchained = type11_store_identity(&state, &req, true);
+    let unchained = mapper_ref_texture_store_identity(&state, &req, true);
     assert!(
         unchained.is_some(),
         "an unchained composite Store resolves its resident"
@@ -1326,13 +1343,13 @@ fn a_chained_composite_store_names_the_resident_it_loads_from() {
 
     req.chain_from_resident = true;
     assert_eq!(
-        type11_store_identity(&state, &req, true),
+        mapper_ref_texture_store_identity(&state, &req, true),
         unchained,
         "a chained Store must name the same resident an unchained one does — it is \
          the same attachment template, so the chain cannot move the slot"
     );
     assert_eq!(
-        type11_store_identity(&state, &req, true),
+        mapper_ref_texture_store_identity(&state, &req, true),
         render_chain_identity(&state, &req),
         "the Store identity and the LoadFromTarget identity must be one slot"
     );
@@ -1341,20 +1358,20 @@ fn a_chained_composite_store_names_the_resident_it_loads_from() {
     // separates the packet's last record from its intermediates, and an
     // intermediate has no guest Store to defer.
     assert_eq!(
-        type11_store_identity(&state, &req, false),
+        mapper_ref_texture_store_identity(&state, &req, false),
         None,
         "an intermediate record stores nothing guest-visible"
     );
     req.colors[0].store_action = crate::contract::pass_action::MTL_STORE_ACTION_DONT_CARE;
     assert_eq!(
-        type11_store_identity(&state, &req, true),
+        mapper_ref_texture_store_identity(&state, &req, true),
         None,
         "a record that discards its target has no frame to defer"
     );
     req.colors[0].store_action = MTL_STORE_ACTION_STORE;
     req.colors[0].mapping_id = 0;
     assert_eq!(
-        type11_store_identity(&state, &req, true),
+        mapper_ref_texture_store_identity(&state, &req, true),
         None,
         "a GVA target is the other rail's; this one requires a mapping"
     );
@@ -1392,8 +1409,9 @@ fn an_intermediate_record_can_still_ask_about_the_resident_it_renders_into() {
     // The query the LOAD actually asks. It takes no `writeback_guest`, so an
     // intermediate and a final record get the same answer by construction — which
     // is the property, and it is structural rather than asserted.
-    let (identity, mapping_epoch) = type11_load_currency_query(&state, &req)
-        .expect("a LOAD into a mapped type-11 surface is a candidate the resident could serve");
+    let (identity, mapping_epoch) = mapper_ref_texture_load_currency_query(&state, &req).expect(
+        "a LOAD into a mapped mapper-ref-texture surface is a candidate the resident could serve",
+    );
     assert_eq!(
         Some(identity.clone()),
         render_chain_identity(&state, &req),
@@ -1401,18 +1419,18 @@ fn an_intermediate_record_can_still_ask_about_the_resident_it_renders_into() {
     );
     assert_eq!(
         Some(identity),
-        type11_store_identity(&state, &req, true),
+        mapper_ref_texture_store_identity(&state, &req, true),
         "the Store identity is the same slot, restricted — not a different one"
     );
     assert_eq!(
         mapping_epoch,
         Some(0),
         "a freshly mapped surface has published nothing, and 0 is that value — the \
-         `is_some` guard in `type11_resident_is_current` is what keeps it from \
+         `is_some` guard in `mapper_ref_texture_resident_is_current` is what keeps it from \
          matching an unstamped slot"
     );
     assert_eq!(
-        type11_store_identity(&state, &req, false),
+        mapper_ref_texture_store_identity(&state, &req, false),
         None,
         "…while only the packet's last record may leave its frame on the resident"
     );
@@ -1421,30 +1439,30 @@ fn an_intermediate_record_can_still_ask_about_the_resident_it_renders_into() {
     // all, or the counters below it would divide all draws instead of candidates.
     req.colors[0].load_action = crate::contract::pass_action::MTL_LOAD_ACTION_CLEAR;
     assert!(
-        type11_load_currency_query(&state, &req).is_none(),
+        mapper_ref_texture_load_currency_query(&state, &req).is_none(),
         "a CLEAR has no prior content to be current"
     );
     req.colors[0].load_action = MTL_LOAD_ACTION_LOAD;
     req.colors[0].target_seed_rgba = Some(vec![0u8; 128 * 64 * 4]);
     assert!(
-        type11_load_currency_query(&state, &req).is_none(),
+        mapper_ref_texture_load_currency_query(&state, &req).is_none(),
         "an explicit seed was already selected by RT provenance"
     );
     req.colors[0].target_seed_rgba = None;
     req.colors[0].store_action = crate::contract::pass_action::MTL_STORE_ACTION_DONT_CARE;
     assert!(
-        type11_load_currency_query(&state, &req).is_none(),
+        mapper_ref_texture_load_currency_query(&state, &req).is_none(),
         "a record that discards its target renders into no resident worth naming"
     );
     req.colors[0].store_action = MTL_STORE_ACTION_STORE;
     req.colors[0].mapping_id = 0;
     assert!(
-        type11_load_currency_query(&state, &req).is_none(),
+        mapper_ref_texture_load_currency_query(&state, &req).is_none(),
         "a GVA target is the other rail's"
     );
 }
 
-/// The guest half of the type-11 seed currency test.
+/// The guest half of the mapper-ref-texture seed currency test.
 ///
 /// `surface_content_epoch` witnesses only writers inside this crate — every
 /// caller of `mark_mapping_written` is one — and a surface's pages are plain
@@ -1477,11 +1495,11 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
     }
 
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "no Store has stamped this surface, so nothing vouches for any resident"
     );
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 999),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 999),
         "a mapping this device does not know cannot be declared unwritten"
     );
 
@@ -1495,7 +1513,7 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
         .expect("mapped above")
         .guest_write_gen_at_store = stamped;
     assert!(
-        !type11_guest_wrote_since_store(&state, &host, 7),
+        !mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "nothing has written the pages since the Store, so the resident still holds them"
     );
 
@@ -1509,7 +1527,7 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
          whole rail would be unnecessary"
     );
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "the hypervisor saw the write, so the resident is stale"
     );
 
@@ -1517,7 +1535,7 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
     // report would tell the first draw of the frame the surface is dirty and
     // every later draw that it is clean.
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "the refusal must survive being read"
     );
 
@@ -1529,13 +1547,15 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
         .get_mut(&7)
         .expect("mapped above")
         .guest_write_gen_at_store = restamped;
-    assert!(!type11_guest_wrote_since_store(&state, &host, 7));
+    assert!(!mapper_ref_texture_guest_wrote_since_store(
+        &state, &host, 7
+    ));
 
     // Retiring the page list retires the token with it: a generation recorded
     // against pages the surface no longer owns vouches for nothing.
     assert!(state.unmap_surface(7));
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "a surface whose page list is gone has no vouched resident"
     );
     crate::runtime::mapper::flush_retired_views(&mut state, &mut host);
@@ -1548,7 +1568,7 @@ fn a_guest_write_since_the_store_refuses_the_resident() {
 
 /// The verdict must keep its refusals apart, because two rails now report it.
 ///
-/// [`type11_guest_wrote_since_store`] collapses everything that is not `Clean`
+/// [`mapper_ref_texture_guest_wrote_since_store`] collapses everything that is not `Clean`
 /// to `true`, which is the right answer for a gate and the wrong one for a
 /// census: "this rail was never stamped" and "the guest rewrites this surface
 /// every frame" produce the same refusal and mean opposite things. The sampled
@@ -1613,7 +1633,7 @@ fn the_guest_write_verdict_separates_its_refusals() {
 /// A page list replaced in place must not leave the token vouching for it.
 ///
 /// The lifecycle mutators retire the token eagerly, but they are not the only
-/// writers of `page_entries`: the mapper's plan adoption and the type-4 page
+/// writers of `page_entries`: the mapper's plan adoption and the backing page
 /// refresh both replace the list and bump `map_generation` without going near
 /// them, and both used to retire the contiguous view while leaving the token
 /// behind. A token that outlives its list watches pages the surface no longer
@@ -1646,9 +1666,11 @@ fn a_replaced_page_list_invalidates_the_token_it_was_built_for() {
         .get_mut(&7)
         .expect("mapped above")
         .guest_write_gen_at_store = stamped;
-    assert!(!type11_guest_wrote_since_store(&state, &host, 7));
+    assert!(!mapper_ref_texture_guest_wrote_since_store(
+        &state, &host, 7
+    ));
 
-    // Exactly what the mapper's adoption and the type-4 refresh do: swap the
+    // Exactly what the mapper's adoption and the backing refresh do: swap the
     // list and bump the generation, without touching the token.
     {
         let m = state.mappings.get_mut(&7).expect("mapped above");
@@ -1660,7 +1682,7 @@ fn a_replaced_page_list_invalidates_the_token_it_was_built_for() {
         "the point of the test is that nothing retired it"
     );
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "a token built for the old pages cannot vouch for the new ones"
     );
 
@@ -1686,11 +1708,11 @@ fn a_replaced_page_list_invalidates_the_token_it_was_built_for() {
         .guest_write_gen_at_store = restamped;
     host.guest_wrote_page(0x40 * page);
     assert!(
-        !type11_guest_wrote_since_store(&state, &host, 7),
+        !mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "the surface no longer owns that page"
     );
     host.guest_wrote_page(0x88 * page);
-    assert!(type11_guest_wrote_since_store(&state, &host, 7));
+    assert!(mapper_ref_texture_guest_wrote_since_store(&state, &host, 7));
 }
 
 /// A host with no dirty bitmap must lose the elision, not gain a wrong frame.
@@ -1721,7 +1743,7 @@ fn a_host_that_cannot_observe_guest_writes_never_vouches() {
         "the refusal belongs at registration, not at every read"
     );
     assert!(
-        type11_guest_wrote_since_store(&state, &host, 7),
+        mapper_ref_texture_guest_wrote_since_store(&state, &host, 7),
         "with no witness the pages must read as written"
     );
 }
@@ -2100,7 +2122,7 @@ fn a_mappings_declared_format_answers_for_every_mapping() {
     assert!(pixel_format::is_srgb(mapping_declared_format(
         &state, 7, None
     )));
-    // A type-8 view's format is what the guest says it is reading, so it wins
+    // A texture-view's format is what the guest says it is reading, so it wins
     // over the mapping's own — including when it takes the sRGB back off.
     assert_eq!(
         mapping_declared_format(&state, 7, Some(MTL_FORMAT_BGRA8_UNORM)),
@@ -2758,7 +2780,7 @@ fn blend_state_maps_src_alpha_one_minus() {
     assert!(translate::blend::operation(9).is_err());
 }
 
-/// qemu-shim: guest Load with unresolvable type-11 pages still encodes
+/// qemu-shim: guest Load with unresolvable mapper-ref-texture pages still encodes
 /// (archive NULL seed / Metal Clear invent) — does not drop the pass.
 #[test]
 fn mrt_draw_request_load_seed_miss_still_encodes() {
@@ -2769,7 +2791,7 @@ fn mrt_draw_request_load_seed_miss_still_encodes() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     let mut host = FakeHost::new();
     state.define_task(1, 0x1000, 2);
-    // Type-11 registered with geom but empty page table → seed read fails.
+    // Mapper-ref-texture registered with geom but empty page table → seed read fails.
     assert!(state.map_surface(9));
     assert!(state.set_mapping_geom(9, 8, 8, MTL_FORMAT_BGRA8_UNORM));
     // gen must be non-zero for Load path to attempt a snapshot (archive).
@@ -2914,11 +2936,11 @@ fn mrt_draw_request_refuses_a_resolve_destination_with_different_geometry() {
     }));
 }
 
-/// qemu-shim: type-8 view of type-11 is a valid color RT (archive
+/// qemu-shim: texture-view of mapper-ref-texture is a valid color RT (archive
 /// resource_resolve_texture view chain). Without this, App Store UI pipes
 /// that bind a view as color attachment drop the entire MRT pass.
 #[test]
-fn mrt_draw_request_type8_view_of_type11_as_color_rt() {
+fn mrt_draw_request_texture_view_view_of_mapper_ref_texture_as_color_rt() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{
@@ -2939,13 +2961,13 @@ fn mrt_draw_request_type8_view_of_type11_as_color_rt() {
     // Object list at GVA page 0; count covers live residual slot 211.
     assert!(state.set_object_list(1, 0, 256));
 
-    // Base type-11 mid 9 latched as texture ref 3.
+    // Base mapper-ref-texture mid 9 latched as texture ref 3.
     assert!(state.map_surface(9));
     assert!(state.set_mapping_geom(9, 64, 64, MTL_FORMAT_BGRA8_UNORM));
     state.mappings.get_mut(&9).unwrap().content_generation = 1;
     state.texture_to_mapping.insert((1, 3), 9);
 
-    // Type-8 view ref 211 → base 3 (identity, level 0) — live residual slot.
+    // Texture-view view ref 211 → base 3 (identity, level 0) — live residual slot.
     let view_ref = 211u32;
     let base_ref = 3u32;
     let len = TEXTURE_VIEW_MIN_RANGED;
@@ -2980,18 +3002,18 @@ fn mrt_draw_request_type8_view_of_type11_as_color_rt() {
 
     let att = clear_black_attachment(view_ref);
     let req = single_rt_draw_request(&mut state, &mut host, 12, att)
-        .expect("type-8 view of type-11 must resolve as color RT");
+        .expect("texture-view of mapper-ref-texture must resolve as color RT");
     assert_eq!(req.colors[0].mapping_id, 9);
     assert_eq!(req.colors[0].width, 64);
     assert_eq!(req.colors[0].height, 64);
     assert_eq!(req.colors[0].texture_ref, view_ref);
 }
 
-/// Archive `REIMS_VGPU_RESOURCE_RESOLVE_MAX_VIEW_CHAIN`: nested type-8 → type-8 →
-/// type-11 must collapse to the non-view base. One-hop resolve left the mid
-/// base as type-8 and dropped the MRT pass (`view_base_or_swizzle`).
+/// Archive `REIMS_VGPU_RESOURCE_RESOLVE_MAX_VIEW_CHAIN`: nested texture-view → texture-view →
+/// mapper-ref-texture must collapse to the non-view base. One-hop resolve left the mid
+/// base as texture-view and dropped the MRT pass (`view_base_or_swizzle`).
 #[test]
-fn mrt_draw_request_nested_type8_view_chain_to_type11() {
+fn mrt_draw_request_nested_texture_view_view_chain_to_mapper_ref_texture() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{
@@ -3004,7 +3026,7 @@ fn mrt_draw_request_nested_type8_view_chain_to_type11() {
     };
     use crate::runtime::host::FakeHost;
 
-    fn write_type8_view(
+    fn write_texture_view(
         host: &mut FakeHost,
         state: &DeviceState,
         view_ref: u32,
@@ -3046,19 +3068,19 @@ fn mrt_draw_request_nested_type8_view_chain_to_type11() {
     gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 8);
     assert!(state.set_object_list(1, 0, 256));
 
-    // type-11 mid 9 as texture ref 3.
+    // mapper-ref-texture mid 9 as texture ref 3.
     assert!(state.map_surface(9));
     assert!(state.set_mapping_geom(9, 64, 64, MTL_FORMAT_BGRA8_UNORM));
     state.mappings.get_mut(&9).unwrap().content_generation = 1;
     state.texture_to_mapping.insert((1, 3), 9);
 
-    // Inner view 8 → base 3 (type-11); outer view 211 → base 8 (type-8).
-    write_type8_view(&mut host, &state, 8, 3, 0x280);
-    write_type8_view(&mut host, &state, 211, 8, 0x300);
+    // Inner view 8 → base 3 (mapper-ref-texture); outer view 211 → base 8 (texture-view).
+    write_texture_view(&mut host, &state, 8, 3, 0x280);
+    write_texture_view(&mut host, &state, 211, 8, 0x300);
 
     let att = clear_black_attachment(211);
     let req = single_rt_draw_request(&mut state, &mut host, 12, att)
-        .expect("nested type-8→type-8→type-11 must resolve as color RT");
+        .expect("nested texture-view→texture-view→mapper-ref-texture must resolve as color RT");
     assert_eq!(req.colors[0].mapping_id, 9);
     assert_eq!(req.colors[0].width, 64);
     assert_eq!(req.colors[0].height, 64);
@@ -3067,7 +3089,7 @@ fn mrt_draw_request_nested_type8_view_chain_to_type11() {
 
 /// Archive resolve_texture rejects non-identity swizzle for RT resolve.
 #[test]
-fn mrt_draw_request_type8_swizzled_view_rejected_as_color_rt() {
+fn mrt_draw_request_texture_view_swizzled_view_rejected_as_color_rt() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{
@@ -3133,7 +3155,7 @@ fn mrt_draw_request_type8_swizzled_view_rejected_as_color_rt() {
             test_triangle()
         )
         .is_none(),
-        "swizzled type-8 must not resolve as color RT"
+        "swizzled texture-view must not resolve as color RT"
     );
 }
 
@@ -3315,11 +3337,11 @@ fn a_cube_texture_loads_six_faces_in_slice_order() {
     );
 }
 
-/// qemu-shim: type-2 linear RGBA16Float is a valid color RT. Stale
-/// `texture_to_mapping` from a prior type-11 at the same ref must not
+/// qemu-shim: texture linear RGBA16Float is a valid color RT. Stale
+/// `texture_to_mapping` from a prior mapper-ref-texture at the same ref must not
 /// fail-closed (live residual ref=199 type=2 fmt=0x73).
 #[test]
-fn mrt_draw_request_type2_rgba16f_as_color_rt_despite_stale_t11_latch() {
+fn mrt_draw_request_texture_rgba16f_as_color_rt_despite_stale_t11_latch() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::{MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_RGBA16_FLOAT};
     use crate::runtime::decode::resource::{
@@ -3334,12 +3356,12 @@ fn mrt_draw_request_type2_rgba16f_as_color_rt_despite_stale_t11_latch() {
     gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 16);
     assert!(state.set_object_list(1, 0, 256));
 
-    // Stale type-11 latch at ref 199 (guest recycled the ref to type-2).
+    // Stale mapper-ref-texture latch at ref 199 (guest recycled the ref to texture).
     assert!(state.map_surface(99));
     assert!(state.set_mapping_geom(99, 64, 64, MTL_FORMAT_BGRA8_UNORM));
     state.texture_to_mapping.insert((1, 199), 99);
 
-    // Live type-2 RGBA16Float 480×64 bpr=3840 (live residual shape).
+    // Live texture RGBA16Float 480×64 bpr=3840 (live residual shape).
     let tex_ref = 199u32;
     let w = 480u32;
     let h = 64u32;
@@ -3367,7 +3389,7 @@ fn mrt_draw_request_type2_rgba16f_as_color_rt_despite_stale_t11_latch() {
 
     let att = clear_black_attachment(tex_ref);
     let req = single_rt_draw_request(&mut state, &mut host, 12, att)
-        .expect("type-2 RGBA16F RT must resolve despite stale type-11 latch");
+        .expect("texture RGBA16F RT must resolve despite stale mapper-ref-texture latch");
     assert_eq!(req.colors[0].mapping_id, 0);
     assert_eq!(req.colors[0].width, w);
     assert_eq!(req.colors[0].height, h);
@@ -3380,11 +3402,11 @@ fn mrt_draw_request_type2_rgba16f_as_color_rt_despite_stale_t11_latch() {
     assert!(!state.texture_to_mapping.contains_key(&(1, tex_ref)));
 }
 
-/// Live type-11 descriptor mapping_id wins over a stale texture_to_mapping
+/// Live mapper-ref-texture descriptor mapping_id wins over a stale texture_to_mapping
 /// latch (dual-mid recycled-ref residual: full desktop Store must land on
 /// the mid named by the live descriptor, not a prior latch).
 #[test]
-fn mrt_draw_request_type11_live_mapping_overrides_stale_latch() {
+fn mrt_draw_request_mapper_ref_texture_live_mapping_overrides_stale_latch() {
     use crate::contract::endian::{st16, st32};
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
@@ -3407,7 +3429,7 @@ fn mrt_draw_request_type11_live_mapping_overrides_stale_latch() {
     let _ = host.write_gpa(root_gpa, &d[..4]);
     state.define_task(1, 0x1000, 2);
     assert!(state.set_object_list(1, 0, 8));
-    // Live type-11 at ref=1 → mapping_id=4 (descriptor first u32).
+    // Live mapper-ref-texture at ref=1 → mapping_id=4 (descriptor first u32).
     let mut entry = [0u8; 12];
     st32(&mut entry[0..], 11u32 | (0x20u32 << 8));
     entry[4..12].copy_from_slice(&0x40u64.to_le_bytes());
@@ -3428,7 +3450,7 @@ fn mrt_draw_request_type11_live_mapping_overrides_stale_latch() {
 
     let att = clear_black_attachment(1);
     let req = single_rt_draw_request(&mut state, &mut host, 12, att)
-        .expect("live type-11 RT must resolve");
+        .expect("live mapper-ref-texture RT must resolve");
     assert_eq!(
         req.colors[0].mapping_id, 4,
         "live descriptor mapping_id=4 must beat stale latch mid=3"
@@ -3438,7 +3460,7 @@ fn mrt_draw_request_type11_live_mapping_overrides_stale_latch() {
 
 /// Color RT materialization does not rematerialize non-zero view mips.
 #[test]
-fn mrt_draw_request_type8_nonzero_level_rejected_as_color_rt() {
+fn mrt_draw_request_texture_view_nonzero_level_rejected_as_color_rt() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{
@@ -3502,16 +3524,16 @@ fn mrt_draw_request_type8_nonzero_level_rejected_as_color_rt() {
             test_triangle()
         )
         .is_none(),
-        "type-8 level_base!=0 must not resolve as color RT"
+        "texture-view level_base!=0 must not resolve as color RT"
     );
 }
 
-/// Archive collapses a type-8 view's mip level into linear geometry:
-/// a level-1 view of a type-2 texture is a color RT at that level's
+/// Archive collapses a texture-view's mip level into linear geometry:
+/// a level-1 view of a texture texture is a color RT at that level's
 /// plane (offset/dims/stride from the descriptor's level record) —
 /// compositor blur/backdrop pyramids render into successive mips.
 #[test]
-fn mrt_draw_request_type8_mip_level_view_of_linear_as_color_rt() {
+fn mrt_draw_request_texture_view_mip_level_view_of_linear_as_color_rt() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     use crate::runtime::decode::resource::{
@@ -3534,7 +3556,7 @@ fn mrt_draw_request_type8_mip_level_view_of_linear_as_color_rt() {
     gva_mem::define_task_pages_arm64e(&mut host, &mut state, 4, 8);
     assert!(state.set_object_list(1, 0, 32));
 
-    // Type-2 base with 2 mips: L0 64x32 bpr 256; L1 at +0x2000, 32x16 bpr 128.
+    // Texture base with 2 mips: L0 64x32 bpr 256; L1 at +0x2000, 32x16 bpr 128.
     let base_ref = 5u32;
     let body = TEXTURE_DESC_BASE_LEN + TEXTURE_DESC_MIP_LEVEL_RECORD_LEN;
     let mut b = vec![0u8; body];
@@ -3567,7 +3589,7 @@ fn mrt_draw_request_type8_mip_level_view_of_linear_as_color_rt() {
     le[4..12].copy_from_slice(&base_desc_gva.to_le_bytes());
     write_task_gva_arm64e(&mut host, &state.tasks[1], off, &le);
 
-    // Type-8 view: level_base=1 over the type-2 base.
+    // Texture-view view: level_base=1 over the texture base.
     let view_ref = 8u32;
     let len = TEXTURE_VIEW_MIN_RANGED;
     let mut desc = vec![0u8; len];
@@ -3683,7 +3705,7 @@ fn view_format_reinterprets_bgra_storage_as_rgba() {
     assert_eq!(out, [10, 20, 30, 40]);
 }
 
-/// Regression: type-2/3 GVA Stores must walk with device page_shift (x86=12).
+/// Regression: normal-texture GVA Stores must walk with device page_shift (x86=12).
 /// Using the arm64e-default fallback made every `linux_m2v_store gva=… ok=0`
 /// on Ventura/Tahoe x86 product boots.
 #[test]
@@ -3750,11 +3772,11 @@ fn write_gva_rgba8_uses_device_page_shift_x86() {
     assert_eq!(&back[..4], &[30, 20, 10, 255]);
 }
 
-/// An encode Store of a type-2/3 GVA wallpaper layer lands in the texture_ref
+/// An encode Store of a normal-texture GVA wallpaper layer lands in the texture_ref
 /// and GVA caches and NOT in the surface_id map — three separate namespaces
 /// that happen to be keyed by the same integer.
 ///
-/// That a *sample* then reaches those bytes is `type3_sample_uses_type2_gva_cache`'s
+/// That a *sample* then reaches those bytes is `texture_gen_mips_sample_uses_texture_gva_cache`'s
 /// job: it builds the object-list entry and the descriptor the resolver needs.
 /// This fixture has neither, and the only rung that ever served it took its
 /// geometry from whichever cache entry was keyed by the ref rather than from a
@@ -4302,12 +4324,12 @@ fn a_gva_load_from_resident_draw_with_no_resident_puts_the_seed_back() {
     );
 }
 
-/// A type-5 ref is not itself a surface id. The descriptor's surface_id
+/// A ref-texture ref is not itself a surface id. The descriptor's surface_id
 /// remains authoritative even when the numeric ref collides with another
 /// live display mapping (live app-launch ref=2 -> sid=71 class).
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn type5_sample_uses_descriptor_surface_id_not_ref_collision() {
+fn ref_texture_sample_uses_descriptor_surface_id_not_ref_collision() {
     use crate::contract::endian::st32;
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::runtime::decode::resource::{list_object_entry_offset, OBJECT_LIST_ENTRY_LEN};
@@ -4340,7 +4362,7 @@ fn type5_sample_uses_descriptor_surface_id_not_ref_collision() {
     let texture_ref = 2u32;
     let surface_id = 71u32;
     let desc_gva = 0x1000u64;
-    let built = reims_vgpu_wire::device_desc::Type5Builder::new(surface_id, 0, 0, 0)
+    let built = reims_vgpu_wire::device_desc::RefTextureBuilder::new(surface_id, 0, 0, 0)
         .with_len(objects::TYPE5_MIN_LEN);
     let desc = built.bytes();
     assert!(
@@ -4386,7 +4408,7 @@ fn type5_sample_uses_descriptor_surface_id_not_ref_collision() {
 
     let (width, height, sampled_mid, sampled) =
         resolve_sampled_source(&mut state, &mut host, 1, texture_ref, None, true)
-            .expect("type-5 descriptor surface must sample");
+            .expect("ref-texture descriptor surface must sample");
     assert_eq!((width, height, sampled_mid), (4, 3, surface_id));
     let SampledSourceRequest::Bytes(sampled, _, layout, _) = sampled else {
         panic!("cache-backed fixture unexpectedly resolved a resident target");
@@ -4405,7 +4427,7 @@ fn type5_sample_uses_descriptor_surface_id_not_ref_collision() {
     let threaded_resource = objects::resolve_resource(&state, &host, 1, texture_ref).ok();
     assert!(
         threaded_resource.is_some(),
-        "type-5 fixture must expose a resource to thread"
+        "ref-texture fixture must expose a resource to thread"
     );
     let (tw, th, tmid, tsrc) = resolve_sampled_source(
         &mut state,
@@ -4447,7 +4469,7 @@ fn type5_sample_uses_descriptor_surface_id_not_ref_collision() {
 /// `next_sampled_content_generation` in the same breath as it changes the bytes.
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn type11_host_cache_rung_identity_tracks_the_cached_frame() {
+fn mapper_ref_texture_host_cache_rung_identity_tracks_the_cached_frame() {
     use crate::contract::endian::st32;
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::runtime::decode::resource::{list_object_entry_offset, OBJECT_LIST_ENTRY_LEN};
@@ -4479,7 +4501,7 @@ fn type11_host_cache_rung_identity_tracks_the_cached_frame() {
     let texture_ref = 2u32;
     let surface_id = 71u32;
     let desc_gva = 0x1000u64;
-    let built = reims_vgpu_wire::device_desc::Type5Builder::new(surface_id, 0, 0, 0)
+    let built = reims_vgpu_wire::device_desc::RefTextureBuilder::new(surface_id, 0, 0, 0)
         .with_len(objects::TYPE5_MIN_LEN);
     let desc = built.bytes();
     assert!(
@@ -4559,7 +4581,7 @@ fn type11_host_cache_rung_identity_tracks_the_cached_frame() {
     assert_eq!(
         first_id.key,
         (1u64 << 62) | surface_id as u64,
-        "bit 62 alone is the type-11 host-cache namespace"
+        "bit 62 alone is the mapper-ref-texture host-cache namespace"
     );
     let stored_gen = crate::runtime::surface_cache::get_shared_with_gen(&state, surface_id, 4, 3)
         .expect("the frame just stored must be readable")
@@ -4606,13 +4628,13 @@ fn type11_host_cache_rung_identity_tracks_the_cached_frame() {
     );
 }
 
-/// Live Safari app-launch class: the type-4 base carries an unknown
-/// 2-byte IOSurface FourCC (`LA08`) while the type-5 descriptor carries
+/// Live Safari app-launch class: the backing base carries an unknown
+/// 2-byte IOSurface FourCC (`LA08`) while the ref-texture descriptor carries
 /// the exact RG8 Metal view. Defaulting the base to BGRA asks for a
 /// 632-byte row against the wire's 320-byte row and drops the draw.
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn type5_sample_uses_serialized_rg8_view_over_unknown_surface_fourcc() {
+fn ref_texture_sample_uses_serialized_rg8_view_over_unknown_surface_fourcc() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::iosurface_pages::{
@@ -4626,7 +4648,7 @@ fn type5_sample_uses_serialized_rg8_view_over_unknown_surface_fourcc() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
     let mut host = FakeHost::new();
 
-    // One-level x86 GVA table for the object list and type-5 descriptor.
+    // One-level x86 GVA table for the object list and ref-texture descriptor.
     let dir_pfn = 2u32;
     let root_pfn = 3u32;
     let dir_gpa = (dir_pfn as u64) << PAGE_SHIFT_X86;
@@ -4653,7 +4675,7 @@ fn type5_sample_uses_serialized_rg8_view_over_unknown_surface_fourcc() {
     let height = 154u32;
     let surface_bpr = 320u32;
     let desc_gva = 0x1000u64;
-    let built = reims_vgpu_wire::device_desc::Type5Builder::new(
+    let built = reims_vgpu_wire::device_desc::RefTextureBuilder::new(
         surface_id,
         0,
         texture_ref,
@@ -4745,12 +4767,12 @@ fn type5_sample_uses_serialized_rg8_view_over_unknown_surface_fourcc() {
     );
 }
 
-/// The type-5 view memo: unchanged plane bytes reuse the converted Arc and
+/// The ref-texture view memo: unchanged plane bytes reuse the converted Arc and
 /// carry a stable content identity (engine upload skipped); a guest write
 /// to the plane is observed on the next bind and mints a new generation.
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
+fn ref_texture_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
     use crate::contract::endian::{st16, st32, st64};
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_ALLOC_SIZE, DEVICE_DESC_BPE, DEVICE_DESC_BPR, DEVICE_DESC_DIMS,
@@ -4802,7 +4824,7 @@ fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
     st32(&mut device_desc[DEVICE_DESC_BPR..], surface_bpr);
     st16(&mut device_desc[DEVICE_DESC_BPE..], 2);
     assert!(state.set_mapping_device_desc(surface_id, &device_desc));
-    let view = objects::Type5TextureView {
+    let view = objects::RefTextureView {
         pixel_format: MTL_FORMAT_RG8_UNORM,
         width,
         height,
@@ -4811,7 +4833,7 @@ fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
     };
 
     let (w1, h1, rgba1, id1, fmt1) =
-        load_type5_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
+        load_ref_texture_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
             .expect("first materialization");
     assert_eq!((w1, h1), (width, height));
     assert_eq!(
@@ -4828,11 +4850,11 @@ fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
     assert_eq!(
         id1.key,
         (1u64 << 63) | surface_id as u64,
-        "identity key namespaces type-5 content above GVA keys"
+        "identity key namespaces ref-texture content above GVA keys"
     );
 
     let (_, _, rgba2, id2, _) =
-        load_type5_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
+        load_ref_texture_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
             .expect("memo revalidation");
     assert!(
         std::sync::Arc::ptr_eq(&rgba1, &rgba2),
@@ -4843,7 +4865,7 @@ fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
     // Guest CPU writes one texel; the next bind must observe it.
     assert!(host.write_gpa(gpa0 + 6, &[0xAA, 0xBB]).is_ok());
     let (_, _, rgba3, id3, _) =
-        load_type5_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
+        load_ref_texture_view_rgba(&mut state, &mut host, 1, 248, surface_id, view)
             .expect("re-materialization after guest write");
     assert!(
         id3.generation > id2.generation,
@@ -4862,50 +4884,50 @@ fn type5_view_memo_reuses_unchanged_planes_and_invalidates_on_write() {
 
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn type5_view_materializes_only_when_base_identity_differs() {
+fn ref_texture_view_materializes_only_when_base_identity_differs() {
     use crate::contract::pixel_format::MTL_FORMAT_RG8_UNORM;
 
-    let exact = objects::Type5TextureView {
+    let exact = objects::RefTextureView {
         pixel_format: MTL_FORMAT_BGRA8_UNORM,
         width: 1920,
         height: 1080,
         depth: 1,
         plane_index: 0,
     };
-    assert!(!type5_view_requires_materialization(
+    assert!(!ref_texture_view_requires_materialization(
         true,
         1920,
         1080,
         MTL_FORMAT_BGRA8_UNORM,
         exact
     ));
-    assert!(type5_view_requires_materialization(
+    assert!(ref_texture_view_requires_materialization(
         true, 1920, 1080, 0, exact
     ));
 
-    let rg8_view = objects::Type5TextureView {
+    let rg8_view = objects::RefTextureView {
         pixel_format: MTL_FORMAT_RG8_UNORM,
         width: 158,
         height: 154,
         depth: 1,
         plane_index: 0,
     };
-    assert!(type5_view_requires_materialization(
+    assert!(ref_texture_view_requires_materialization(
         true,
         158,
         154,
         MTL_FORMAT_BGRA8_UNORM,
         rg8_view
     ));
-    assert!(type5_view_requires_materialization(
+    assert!(ref_texture_view_requires_materialization(
         false,
         158,
         154,
         MTL_FORMAT_RG8_UNORM,
         rg8_view
     ));
-    let volume = objects::Type5TextureView { depth: 2, ..exact };
-    assert!(type5_view_requires_materialization(
+    let volume = objects::RefTextureView { depth: 2, ..exact };
+    assert!(ref_texture_view_requires_materialization(
         true,
         1920,
         1080,
@@ -4993,34 +5015,34 @@ fn texture_view_decline_preserves_decode_leaf_and_chain_identity() {
     assert!(fields.contains(&("depth", "3".into())));
 }
 
-/// Every type-5 view refusal names its rail (`type5_view_`), renders
+/// Every ref-texture view refusal names its rail (`ref_texture_view_`), renders
 /// whitespace-free fields, and is distinct — the same discipline the
-/// capture and import rails took, so `grep reason=type5_view_…` stays
+/// capture and import rails took, so `grep reason=ref_texture_view_…` stays
 /// answerable against the blit rail's `t5_*` copy vocabulary next door.
 #[cfg(feature = "backend-vulkan")]
 #[test]
-fn every_type5_view_reason_is_namespaced_distinct_and_log_safe() {
+fn every_ref_texture_view_reason_is_namespaced_distinct_and_log_safe() {
     use crate::observe::Decline as _;
-    const ALL: &[Type5ViewDecline] = &[
-        Type5ViewDecline::UnsupportedDepth { depth: 0 },
-        Type5ViewDecline::Unresolved,
-        Type5ViewDecline::FormatBpp,
-        Type5ViewDecline::NoMapping,
-        Type5ViewDecline::SampleWindow {
+    const ALL: &[RefTextureViewDecline] = &[
+        RefTextureViewDecline::UnsupportedDepth { depth: 0 },
+        RefTextureViewDecline::Unresolved,
+        RefTextureViewDecline::FormatBpp,
+        RefTextureViewDecline::NoMapping,
+        RefTextureViewDecline::SampleWindow {
             base_w: 0,
             base_h: 0,
             base_fmt: 0,
             desc: None,
         },
-        Type5ViewDecline::Span {
+        RefTextureViewDecline::Span {
             pages: 0,
             page_bytes: 0,
             span_end: 0,
             bpr: 0,
         },
-        Type5ViewDecline::TightOverflow { bpp: 0 },
-        Type5ViewDecline::NativeLen { tight: 0 },
-        Type5ViewDecline::Read {
+        RefTextureViewDecline::TightOverflow { bpp: 0 },
+        RefTextureViewDecline::NativeLen { tight: 0 },
+        RefTextureViewDecline::Read {
             base_w: 0,
             base_h: 0,
             base_fmt: 0,
@@ -5029,15 +5051,15 @@ fn every_type5_view_reason_is_namespaced_distinct_and_log_safe() {
             span_end: 0,
             pages: 0,
         },
-        Type5ViewDecline::RgbaStride,
-        Type5ViewDecline::RgbaLen { stride: 0 },
-        Type5ViewDecline::Convert { row: 0, bpp: 0 },
+        RefTextureViewDecline::RgbaStride,
+        RefTextureViewDecline::RgbaLen { stride: 0 },
+        RefTextureViewDecline::Convert { row: 0, bpp: 0 },
     ];
     let mut slugs: Vec<&str> = Vec::new();
     for d in ALL {
         assert!(
-            d.slug().starts_with("type5_view_"),
-            "{} is not namespaced to the type-5 view rail",
+            d.slug().starts_with("ref_texture_view_"),
+            "{} is not namespaced to the ref-texture view rail",
             d.slug()
         );
         for (k, v) in d.fields() {
@@ -5048,7 +5070,7 @@ fn every_type5_view_reason_is_namespaced_distinct_and_log_safe() {
     slugs.sort_unstable();
     let before = slugs.len();
     slugs.dedup();
-    assert_eq!(before, slugs.len(), "duplicate Type5ViewDecline slug");
+    assert_eq!(before, slugs.len(), "duplicate RefTextureViewDecline slug");
 }
 
 /// `SampleWindow` is the only variant carrying transcribed field logic: the
@@ -5058,26 +5080,26 @@ fn every_type5_view_reason_is_namespaced_distinct_and_log_safe() {
 #[cfg(feature = "backend-vulkan")]
 #[test]
 fn sample_window_renders_the_descriptor_or_its_absence() {
-    let present = Type5ViewDecline::SampleWindow {
+    let present = RefTextureViewDecline::SampleWindow {
         base_w: 320,
         base_h: 240,
         base_fmt: 0x50,
         desc: Some((64, 64, 0x4c41_3038, 256, 4096)),
     };
     assert_eq!(
-            crate::observe::Emit::decline("type5_draw_view", &present).render(),
-            "type5_draw_view reason=type5_view_sample_window base=320x240 base_fmt=0x50 desc=64x64 desc_fmt=0x4c413038 bpr=256 alloc=4096"
+            crate::observe::Emit::decline("ref_texture_draw_view", &present).render(),
+            "ref_texture_draw_view reason=ref_texture_view_sample_window base=320x240 base_fmt=0x50 desc=64x64 desc_fmt=0x4c413038 bpr=256 alloc=4096"
         );
 
-    let missing = Type5ViewDecline::SampleWindow {
+    let missing = RefTextureViewDecline::SampleWindow {
         base_w: 320,
         base_h: 240,
         base_fmt: 0x50,
         desc: None,
     };
     assert_eq!(
-        crate::observe::Emit::decline("type5_draw_view", &missing).render(),
-        "type5_draw_view reason=type5_view_sample_window base=320x240 base_fmt=0x50 desc=missing"
+        crate::observe::Emit::decline("ref_texture_draw_view", &missing).render(),
+        "ref_texture_draw_view reason=ref_texture_view_sample_window base=320x240 base_fmt=0x50 desc=missing"
     );
 }
 
@@ -5478,7 +5500,7 @@ fn texture_ref_cache_geom_mismatch_does_not_hit_get_texture() {
     host_cache_store_rgba8(&mut state, 0, tex_ref, 1920, 1152, &full);
     // Exact geom hit
     assert!(crate::runtime::surface_cache::get_texture(&state, 0, tex_ref, 1920, 1152).is_some());
-    // Wrong geom (type-3 L0 recycle) miss
+    // Wrong geom (generate-mipmaps texture L0 recycle) miss
     assert!(crate::runtime::surface_cache::get_texture(&state, 0, tex_ref, 115, 16).is_none());
     // surface_id map must stay empty for texture_ref stores
     assert!(crate::runtime::surface_cache::get(&state, tex_ref, 1920, 1152).is_none());
@@ -6441,7 +6463,7 @@ fn a_scissored_gva_store_is_bounded_on_both_its_rails() {
     }
 }
 
-/// A type-11 sample must resolve the mapping *before* it reads its geometry.
+/// A mapper-ref-texture sample must resolve the mapping *before* it reads its geometry.
 ///
 /// A mapped surface with a live `MappingInternal` can have no latched W×H yet:
 /// that geometry lives in the guest device-surface descriptor, and
@@ -6454,7 +6476,7 @@ fn a_scissored_gva_store_is_bounded_on_both_its_rails() {
 /// `set_mapping_geom` — so this passes with the resolve first and fails with it
 /// after the geometry read.
 #[test]
-fn type11_sample_resolves_geometry_before_reading_it() {
+fn mapper_ref_texture_sample_resolves_geometry_before_reading_it() {
     use crate::contract::endian::{st32, st64};
     use crate::contract::iosurface_pages::{
         DEVICE_DESC_ALLOC_SIZE, DEVICE_DESC_BPR, DEVICE_DESC_DIMS, DEVICE_DESC_LEN,
@@ -6549,8 +6571,9 @@ fn type11_sample_resolves_geometry_before_reading_it() {
         );
     }
 
-    let (gw, gh, rgba) = load_type11_mapping_rgba(&mut state, &mut host, mid, None).expect(
-        "a mapped type-11 surface whose dims are still only in the device descriptor \
+    let (gw, gh, rgba) = load_mapper_ref_texture_mapping_rgba(&mut state, &mut host, mid, None)
+        .expect(
+        "a mapped mapper-ref-texture surface whose dims are still only in the device descriptor \
          must sample, not drop the bind",
     );
     assert_eq!((gw, gh), (w, h), "geometry must come from the resolve");
@@ -7274,8 +7297,8 @@ fn a_buffer_read_pays_the_frame_its_reference_owes_before_reading_the_pages() {
 
 /// The buffer-backed texture rail pays for its *texture* reference too.
 ///
-/// A type-8 buffer-backed texture is two contract references over one
-/// allocation — the texture object the guest binds and samples, and the type-1
+/// A texture-view buffer-backed texture is two contract references over one
+/// allocation — the texture object the guest binds and samples, and the buffer
 /// buffer that owns the storage — and a debt may be armed under either. The
 /// three sibling sampled rails all pay for the texture reference; this one made
 /// no payment at all, which is why a rendered icon or glyph atlas could stay in
@@ -7351,7 +7374,7 @@ fn a_dontcare_colour_attachment_is_still_served_its_prior_contents() {
     use crate::contract::pass_action::{
         MTL_LOAD_ACTION_CLEAR, MTL_LOAD_ACTION_DONT_CARE, MTL_LOAD_ACTION_LOAD,
     };
-    use crate::runtime::draw::vulkan::type11_load_is_a_seed_candidate;
+    use crate::runtime::draw::vulkan::mapper_ref_texture_load_is_a_seed_candidate;
 
     let mut c0 = ColorRtRequest {
         load_action: MTL_LOAD_ACTION_LOAD,
@@ -7359,13 +7382,13 @@ fn a_dontcare_colour_attachment_is_still_served_its_prior_contents() {
         ..Default::default()
     };
     assert!(
-        type11_load_is_a_seed_candidate(&c0),
+        mapper_ref_texture_load_is_a_seed_candidate(&c0),
         "a LOAD has always been a candidate"
     );
 
     c0.load_action = MTL_LOAD_ACTION_DONT_CARE;
     assert!(
-        type11_load_is_a_seed_candidate(&c0),
+        mapper_ref_texture_load_is_a_seed_candidate(&c0),
         "DontCare declares the prior contents undefined, and undefined permits \
          the prior contents — the guest redraws only its damage rect and relies \
          on the rest surviving, which is what the Metal arm gives it"
@@ -7373,7 +7396,7 @@ fn a_dontcare_colour_attachment_is_still_served_its_prior_contents() {
 
     c0.load_action = MTL_LOAD_ACTION_CLEAR;
     assert!(
-        !type11_load_is_a_seed_candidate(&c0),
+        !mapper_ref_texture_load_is_a_seed_candidate(&c0),
         "a Clear must not be served a seed: resolving one would spell the pass \
          key LOAD and silently ignore the clear the guest asked for"
     );
@@ -7384,7 +7407,7 @@ fn a_dontcare_colour_attachment_is_still_served_its_prior_contents() {
     c0.load_action = MTL_LOAD_ACTION_DONT_CARE;
     c0.target_seed_rgba = Some(vec![0u8; 4]);
     assert!(
-        !type11_load_is_a_seed_candidate(&c0),
+        !mapper_ref_texture_load_is_a_seed_candidate(&c0),
         "an explicit provenance seed still excludes the resident candidate"
     );
 }

--- a/crates/reims-vgpu/src/runtime/draw/texture_view.rs
+++ b/crates/reims-vgpu/src/runtime/draw/texture_view.rs
@@ -1,4 +1,4 @@
-//! Type-8 texture-view chain resolution and the CPU linear-texture loads that
+//! Texture-view texture-view chain resolution and the CPU linear-texture loads that
 //! consume it: swizzle application, native upload-format selection, and the
 //! tight-row RGBA/BGRA readers shared by the sample and seed paths.
 //!
@@ -10,7 +10,7 @@
 
 use super::*;
 
-/// Type-8 view resolution for sample/seed paths.
+/// Texture-view view resolution for sample/seed paths.
 #[derive(Clone, Debug)]
 pub(crate) struct ViewResolve {
     /// Non-view base texture ref after walking the view chain (archive
@@ -23,7 +23,7 @@ pub(crate) struct ViewResolve {
     pub(crate) pixel_format: Option<u16>,
 }
 
-/// A specific refusal while resolving one type-8 texture-view chain.
+/// A specific refusal while resolving one texture-view texture-view chain.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum TextureViewDecline {
     HopEntryMissing {
@@ -171,13 +171,13 @@ crate::observe::decline_display!(TextureViewDecline);
 
 impl std::error::Error for TextureViewDecline {}
 
-/// Archive `REIMS_VGPU_RESOURCE_RESOLVE_MAX_VIEW_CHAIN` — nested type-8 views collapse
+/// Archive `REIMS_VGPU_RESOURCE_RESOLVE_MAX_VIEW_CHAIN` — nested texture-views collapse
 /// to a non-view base (`apple_pv_gpu_resource_resolve_texture` chain walk).
 ///
 /// This is the decoded contract's own bound, not a budget of ours: a chain that
 /// needs a ninth hop is one the guest's own resolver would not have followed
 /// either, so refusing it is fidelity rather than a shortfall. That makes it the
-/// number **every** arm that walks a type-8 chain must use, and it is `pub(crate)`
+/// number **every** arm that walks a texture-view chain must use, and it is `pub(crate)`
 /// for exactly that reason. Two arms walk one: this module's
 /// [`resolve_texture_view_reasoned`] for the draw/sample path, and
 /// `blit_exec::resolve_texture_backing_depth` for copies. They used to disagree —
@@ -194,7 +194,7 @@ pub(crate) const MAX_TEXTURE_VIEW_CHAIN: usize = 8;
 
 /// Report a slice range the render path decodes and does not apply.
 ///
-/// [`decode_texture_view_hop_reasoned`] resolves a type-8 view to four things —
+/// [`decode_texture_view_hop_reasoned`] resolves a texture-view to four things —
 /// base ref, mip level, swizzle and format override — and the ranged forms
 /// (opcodes `0x08` and `0x1b`) carry two more that nothing on this path reads:
 /// `slice_base` and `slice_count`. `blit_exec` consumes them; the draw and
@@ -246,7 +246,7 @@ fn note_view_slice_range_dropped(
     ));
 }
 
-/// Decode one type-8 hop (does not walk nested bases).
+/// Decode one texture-view hop (does not walk nested bases).
 ///
 /// The `Result` carries a specific failure slug for the always-on fail log. No
 /// wrapper collapses it at this level: the slug travels up through
@@ -259,7 +259,7 @@ fn decode_texture_view_hop_reasoned<M: HostMemory + HostOps>(
     texture_ref: u32,
 ) -> Result<(u32, u32, Option<pixel_format::SwizzlePlan>, Option<u16>), TextureViewDecline> {
     use crate::runtime::decode::resource::{
-        decode_texture_view_descriptor, texture_type8_header, OBJECT_TYPE_TEXTURE_VIEW,
+        decode_texture_view_descriptor, texture_view_header, OBJECT_TYPE_TEXTURE_VIEW,
     };
     let (_entry, desc) = objects::resolve_descriptor(
         state,
@@ -282,7 +282,7 @@ fn decode_texture_view_hop_reasoned<M: HostMemory + HostOps>(
         }
     })?;
     // Bytes visible before decode, for the len-mismatch / bad-opcode census.
-    let (opcode, declared) = texture_type8_header(&desc).unwrap_or((0, 0));
+    let (opcode, declared) = texture_view_header(&desc).unwrap_or((0, 0));
     let view = decode_texture_view_descriptor(&desc).map_err(|reason| {
         // Dump the full wire blob for an unknown texture-view opcode: this is the
         // only signal that reveals a new serializer variant (off the hot path —
@@ -332,11 +332,11 @@ fn decode_texture_view_hop_reasoned<M: HostMemory + HostOps>(
     Ok((view.base_texture_ref, level, swizzle, pixel_format))
 }
 
-/// Resolve type-8 view to non-view base + mip + format override + swizzle.
+/// Resolve texture-view to non-view base + mip + format override + swizzle.
 ///
 /// The `Result` carries a specific failure slug (`reason=view_resolve` sub-case)
 /// for the always-on fail log; [`resolve_texture_view`] collapses it to `Option`
-/// for the hot path. Walks nested type-8 bases up to [`MAX_TEXTURE_VIEW_CHAIN`]
+/// for the hot path. Walks nested texture-view bases up to [`MAX_TEXTURE_VIEW_CHAIN`]
 /// (archive `apple_pv_gpu_resource_resolve_texture` chain). Outer-most view
 /// supplies level / format / swizzle (inner hops only extend the base ref),
 /// matching the product RT path which materializes a single selected level.
@@ -351,7 +351,8 @@ pub(crate) fn resolve_texture_view_reasoned<M: HostMemory + HostOps>(
     let (mut base, level, swizzle, pixel_format) =
         decode_texture_view_hop_reasoned(state, host, task_id, texture_ref)?;
 
-    // Collapse nested type-8 bases to a non-view texture (type-11 / type-2/3).
+    // Collapse nested texture-view bases to a non-view texture (mapper-ref-texture /
+    // normal-texture).
     let mut depth = 0u32;
     for _ in 1..MAX_TEXTURE_VIEW_CHAIN {
         let Some(entry) = objects::lookup_list_entry(state, host, task_id, base) else {
@@ -370,7 +371,7 @@ pub(crate) fn resolve_texture_view_reasoned<M: HostMemory + HostOps>(
         base = next;
     }
 
-    // Final base must not still be a type-8 view past the chain cap.
+    // Final base must not still be a texture-view past the chain cap.
     if let Some(entry) = objects::lookup_list_entry(state, host, task_id, base) {
         if entry.object_type == OBJECT_TYPE_TEXTURE_VIEW {
             return Err(TextureViewDecline::ChainOverflow { base, depth });
@@ -385,9 +386,9 @@ pub(crate) fn resolve_texture_view_reasoned<M: HostMemory + HostOps>(
     })
 }
 
-/// Resolve type-8 view to non-view base + mip + format override + swizzle.
+/// Resolve texture-view to non-view base + mip + format override + swizzle.
 ///
-/// Returns `None` if the ref is not a type-8 view, a hop is short/unsupported,
+/// Returns `None` if the ref is not a texture-view, a hop is short/unsupported,
 /// the chain exceeds the max depth without a non-view base, a base ref is zero,
 /// or swizzle selectors are malformed. See [`resolve_texture_view_reasoned`] for
 /// the specific reason on the fail path.
@@ -473,7 +474,7 @@ impl std::fmt::Display for ViewSampleRefusal {
     }
 }
 
-/// Pick the sample format for a type-8 view over base storage.
+/// Pick the sample format for a texture-view over base storage.
 ///
 /// Metal texture views require the view format to be storage-compatible with the
 /// base. Compatibility is compared as a whole [`pixel_format::BlockGeometry`] —
@@ -525,7 +526,7 @@ pub(crate) fn effective_view_sample_format_reasoned(
     Ok(sample)
 }
 
-/// Apply a type-8 view swizzle by rewriting tight RGBA8 texels. Identity plans
+/// Apply a texture-view swizzle by rewriting tight RGBA8 texels. Identity plans
 /// are no-ops. Returns `None` only if the buffer length is not a multiple of 4
 /// (corrupt load).
 ///
@@ -584,7 +585,7 @@ pub(crate) enum LinearLoadRefusal {
     DescriptorUndecodable,
     /// The descriptor carries no pixel format, so nothing names its layout.
     NoPixelFormat,
-    /// A type-8 view format that is not the same bytes-per-pixel as the base,
+    /// A texture-view format that is not the same bytes-per-pixel as the base,
     /// which would reinterpret the allocation rather than re-read it.
     ViewFormatBppMismatch { base: u16, view: u16 },
     /// The requested mip level has no address/layout in the descriptor.
@@ -978,7 +979,7 @@ fn load_linear_texture_impl<M: HostMemory + HostOps>(
         host,
         task_id,
         texture_ref,
-        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT],
+        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS],
     )
     .map_err(|rung| match rung {
         objects::LadderRung::NoListEntry => R::ObjectListMiss,

--- a/crates/reims-vgpu/src/runtime/draw/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/draw/vulkan.rs
@@ -172,13 +172,13 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
     crate::runtime::chain_phase::enter(crate::runtime::chain_phase::Phase::Prep);
     // metal2vulkan path: load MTLB → AIR → SPIR-V → internal Vulkan engine offscreen.
     let mut draw_rgba: Option<Vec<u8>> = None;
-    // Physical order of `draw_rgba`. A type-11 composite Store renders into a
+    // Physical order of `draw_rgba`. A mapper-ref-texture composite Store renders into a
     // BGRA `Surface` resident, so its readback is already in guest scanout
     // order; the pooled and GVA targets stay RGBA. Carried instead of assumed —
     // which of those a record hit depends on whether an identity resolved, and
     // that is not a condition the Store block can re-derive.
     let mut draw_bgra = false;
-    // Type-11 composite Store: the frame was written into the mapping's guest
+    // Mapper-ref-texture composite Store: the frame was written into the mapping's guest
     // pages by `store_surface_resident`, so this encode owes the caller nothing
     // further.
     let mut surface_store_armed = false;
@@ -220,7 +220,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             }
             Ok(M2vDrawSpan::ResidentGvaStore { identity }) => {
                 let _store_span = StoreCostSpan::new("gva_store_us");
-                note_type11_store_route("gva_flush");
+                note_mapper_ref_texture_store_route("gva_flush");
                 // Metal Store preserves the attachment in host GPU memory. It
                 // does not synchronize that texture into guest backing; the
                 // resource-validity protocol asks for that separately. The
@@ -230,14 +230,14 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                     crate::runtime::writeback_debt::arm_gva(state, host, req.task_id, c0, &identity)
                 });
                 if landed {
-                    note_type11_store_route("gva_resident_authoritative");
+                    note_mapper_ref_texture_store_route("gva_resident_authoritative");
                     gva_store_armed = true;
                 } else {
                     // The copying rail: read the resident the draw just
                     // rendered into and let the synchronous Store block below
                     // run exactly as it does for a Store that never skipped its
                     // readback. `read_resident_chain` fail-logs a lost resident.
-                    note_type11_store_route("gva_store_sync");
+                    note_mapper_ref_texture_store_route("gva_store_sync");
                     draw_rgba = read_resident_chain(req, &identity);
                     crate::observe::line(format!(
                         "linux_m2v_draw ok resident_gva_store pipe={} {}x{} gva={:#x} rgba={}",
@@ -271,7 +271,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                     .unwrap_or(false);
                 match (stored, c0_store) {
                     (true, Some((mid, cw, ch, fmt))) => {
-                        note_type11_store_route("surface_resident");
+                        note_mapper_ref_texture_store_route("surface_resident");
                         // The same two publishes the `Owned` rail performs at arm
                         // time, for the same reason: `dense_frame_seq` gates
                         // `present_unbacked`, and a route that skipped it would
@@ -294,7 +294,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                         // a Store that never skipped its readback. This pays the
                         // readback the rail exists to avoid, which is the point —
                         // the fallback is a cost, never a lost frame.
-                        note_type11_store_route("surface_resident_sync");
+                        note_mapper_ref_texture_store_route("surface_resident_sync");
                         draw_rgba = read_resident_chain(req, &identity);
                         crate::observe::line(format!(
                             "linux_m2v_draw ok resident_surface_store_sync_fallback pipe={} {}x{} mid={} rgba={}",
@@ -356,7 +356,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
         return (EncodeStatus::Ok, None);
     }
 
-    // Deferred type-11 composite Store: the window names the pinned resident and
+    // Deferred mapper-ref-texture composite Store: the window names the pinned resident and
     // the guest write lands on first access. `None`, not the frame, for the same
     // reason the `Owned` route returns `None` — `writeback_guest` is granted only
     // to the last record of a packet, so there is no record N+1 to seed.
@@ -364,7 +364,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
         return (EncodeStatus::Ok, None);
     }
 
-    // A type-11 composite Store reaches the guest only through the CPU writeback
+    // A mapper-ref-texture composite Store reaches the guest only through the CPU writeback
     // below. The DMA rail that used to short-circuit it here — a resident BGRA
     // target landed straight in the mapping's guest pages through an imported
     // host pointer — is gone, because a pointer the GPU can read is one it can
@@ -373,11 +373,11 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
     // Taken, not borrowed. Every exit from this block returns the frame, and
     // borrowing forced each of them to `rgba.clone()` a whole framebuffer — 8 MB
     // at 1080p, at the 28-111 Stores/s `store_routes` measures, on the drain
-    // worker `drain_duty` shows at duty 0.93-0.99. The deferred type-11 arm is
+    // worker `drain_duty` shows at duty 0.93-0.99. The deferred mapper-ref-texture arm is
     // the hot one and it cloned purely to hand back the buffer it already owned.
     if let Some(mut rgba) = draw_rgba.take() {
         // Intermediate multi-draw GVA records: return color0 for chaining without
-        // guest Store (archive store plan). Resident type-11 intermediates
+        // guest Store (archive store plan). Resident mapper-ref-texture intermediates
         // returned above without materializing CPU pixels.
         if !writeback_guest {
             // A chain value seeds the next record, and `DrawRequest` states a
@@ -391,7 +391,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             // and producing them is an O(w*h) pass over a whole framebuffer
             // readback — 2 073 600 pixels per Store at 1080p, at the 28-111
             // Stores/s `store_routes` measures under load. Computing it here
-            // paid that on every route, including the type-11 one whose only
+            // paid that on every route, including the mapper-ref-texture one whose only
             // consumer is a `observe::line` a normal boot discards. Each arm
             // now scans only when it is about to write a line.
             // A free function, not a closure over `rgba`: the deferred arm below
@@ -404,7 +404,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
             }
             let ok = if c0.mapping_id != 0 {
                 // Unconditional. This used to be `if
-                // type11_cpu_store_fallback_allowed(import_allowed)`, where
+                // mapper_ref_texture_cpu_store_fallback_allowed(import_allowed)`, where
                 // `import_allowed` asked whether the device could import a host
                 // pointer over the mapping's guest pages; when it could, the
                 // draw took the import rail and landing here was a fail-closed
@@ -412,7 +412,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                 // invariant. There is no invariant left to preserve, and the
                 // else arm was a refusal for a rail that cannot be chosen.
                 {
-                    // Brackets the whole type-11 arm, into the same per-second
+                    // Brackets the whole mapper-ref-texture arm, into the same per-second
                     // window it divides into. `draw_phase` stops at the engine
                     // boundary, so this arm — the cache publish, the window arm,
                     // the guest scatter — is the bulk of the ~245 ms/s (28 % of
@@ -430,7 +430,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                         let _span = StoreCostSpan::new("t11_convert_us");
                         reorder_rb_in_place(&mut bgra, draw_bgra, true);
                     }
-                    note_type11_store_route("cpu_portability");
+                    note_mapper_ref_texture_store_route("cpu_portability");
                     // `write_bgra8`, not `write_rgba8_image_changed`: the frame is
                     // already in guest scanout order, and that entry point would
                     // have to exchange every row back to read it. Both share the
@@ -476,7 +476,13 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                             );
                         }
                         if let Some(epoch) = sync_epoch {
-                            stamp_type11_resident(state, host, req, writeback_guest, epoch);
+                            stamp_mapper_ref_texture_resident(
+                                state,
+                                host,
+                                req,
+                                writeback_guest,
+                                epoch,
+                            );
                         }
                         crate::observe::when_verbose(|| {
                             // Order-independent: both fields reduce over the three
@@ -523,7 +529,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                 }
             } else if c0.target_gva != 0 {
                 // What this Store would cost if it were served the way the
-                // type-11 surface Store is served.
+                // mapper-ref-texture surface Store is served.
                 //
                 // That rail lands its frame with `copy_target_to_guest_pages` —
                 // the GPU writes the guest's pages and no byte crosses host
@@ -576,7 +582,7 @@ pub fn encode_draw_chain<M: HostMemory + HostOps>(
                     sync_store_pages.as_ref().map(|p| p.membership()),
                 )
                 .is_ok();
-                // Discrete-GPU rail: type-2/3 encode into **texture_ref** + **GVA**
+                // Discrete-GPU rail: normal-texture encode into **texture_ref** + **GVA**
                 // host caches (not surface_id mid map — list ids collide with
                 // present mids;). Sample prefers GVA key then
                 // texture_ref with live descriptor geom.
@@ -792,7 +798,7 @@ pub(super) enum SampledSourceRequest {
     /// view swizzle: this rail binds guest bytes untouched, so a format whose
     /// Metal channels do not sit identically on the Vulkan format carrying them
     /// needs that difference expressed on the image view. It is composed with
-    /// the type-8 view swizzle at the push site. Identity for every format but
+    /// the texture-view swizzle at the push site. Identity for every format but
     /// `A8Unorm`.
     GuestRuns(
         crate::backend::vulkan::engine::GuestRunSource,
@@ -819,9 +825,9 @@ pub(super) enum SampledSourceRequest {
 /// | bit 63 | bit 62 | producer | low bits |
 /// |---|---|---|---|
 /// | 0 | 0 | guest linear | the texture's authoritative GVA (`host_gva_surfaces`) |
-/// | 1 | 0 | type-5 view | `plane_index << 32 \| mapping_id` |
-/// | 0 | 1 | type-11 host cache | `mapping_id` (`host_surfaces`) |
-/// | 1 | 1 | type-11 guest memo | `mapping_id` (`type11_memo`) |
+/// | 1 | 0 | ref-texture view | `plane_index << 32 \| mapping_id` |
+/// | 0 | 1 | mapper-ref-texture host cache | `mapping_id` (`host_surfaces`) |
+/// | 1 | 1 | mapper-ref-texture guest memo | `mapping_id` (`mapper_ref_texture_memo`) |
 ///
 /// GVAs are well under 2^62, so the unflagged row cannot collide with a flagged
 /// one. `generation` comes from
@@ -850,7 +856,7 @@ impl From<crate::runtime::gather_witness::GatheredIdentity> for LinearSampleIden
     }
 }
 
-type LoadedType5View = (
+type LoadedRefTextureView = (
     u32,
     u32,
     std::sync::Arc<Vec<u8>>,
@@ -945,7 +951,7 @@ pub(super) fn fragment_attachment_alias_sample<'a>(
 ///
 /// Four rails resolve a texture ref through the second rung of the object-list
 /// ladder — `mipmap`, `draw::texture_view` and `compute_exec` name
-/// `[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT]` to
+/// `[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS]` to
 /// [`objects::resolve_descriptor`], and `draw::render_target` writes the pair
 /// out — and the two sampled-path sites in this file did not. They went
 /// `lookup_list_entry` -> `read_descriptor` -> `decode_texture_descriptor`, so
@@ -975,8 +981,11 @@ pub(super) fn sampled_texture_descriptor<M: HostMemory>(
 )> {
     let resource = objects::resolve_resource(state, host, task_id, texture_ref).ok()?;
     let entry = resource.entry;
-    use crate::runtime::decode::resource::{OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT};
-    if entry.object_type != OBJECT_TYPE_TEXTURE && entry.object_type != OBJECT_TYPE_TEXTURE_VARIANT
+    use crate::runtime::decode::resource::{
+        OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
+    };
+    if entry.object_type != OBJECT_TYPE_TEXTURE
+        && entry.object_type != OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
     {
         let slug = crate::observe::ladder_slug!("draw_sampled_texture", wrong_type);
         if degrade_log_first(texture_ref, slug) {
@@ -998,9 +1007,9 @@ pub(super) fn sampled_texture_descriptor<M: HostMemory>(
 /// resolver the engine draw path uses. Distinct from [`load_sampled_rgba`],
 /// which is the Metal-path resolver and always materializes RGBA8 bytes.
 ///
-/// # The type-11 ladder is measured, and every rung carries load
+/// # The mapper-ref-texture ladder is measured, and every rung carries load
 ///
-/// Four rungs offer the same type-11 surface, and the obvious reading is that
+/// Four rungs offer the same mapper-ref-texture surface, and the obvious reading is that
 /// three of them are redundant with the first. They are not. A DRIVEN x86/Vulkan
 /// session — four Safari page loads, each scrolled six pages and then dragged by
 /// its title bar — split as:
@@ -1114,7 +1123,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
         return None;
     }
 
-    // Opcode-9 buffer-backed texture (type-8): the sampled bytes are an MTLBuffer's
+    // Opcode-9 buffer-backed texture (texture-view): the sampled bytes are an MTLBuffer's
     // guest storage, not a view over another texture. Resolve it directly before
     // the view/surface paths (which would mis-decode the opcode-9 descriptor).
     // `resource` (when supplied by the caller) serves every classification and
@@ -1144,73 +1153,73 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
     // decided by the entry's `object_type`, and the cases below are distinct
     // values of that single u8 field, so they cannot both apply:
     //
-    //   type-5 RefTextureHandle — carries the type-4 surface id in its
+    //   ref-texture RefTextureHandle — carries the backing record id in its
     //                             descriptor, alongside the Metal texture view
-    //   type-4 Surface         — the ref *is* the surface id
-    //   type-11 IOSurface      — resolves to the mapping id it was created on
+    //   backing Surface         — the ref *is* the surface id
+    //   mapper-ref-texture IOSurface      — resolves to the mapping id it was created on
     //
-    // The retained resource already carries the total typed decode. Type 11 can
+    // The retained resource already carries the total typed decode. Mapper-ref-texture can
     // therefore fill the slot directly from that object rather than looking up
     // and decoding the same reference a second time. It returns `None` for every
     // other type, so it can only fill a slot the classification above left empty.
     // Hence an `Option`, not a list of candidates to choose between.
     let mut is_linear_tex = false;
-    let mut is_type5 = false;
-    let mut type5_view: Option<objects::Type5TextureView> = None;
+    let mut is_ref_texture = false;
+    let mut ref_texture_view: Option<objects::RefTextureView> = None;
     let mut surface: Option<u32> = None;
     let resolved_resource =
         resource.or_else(|| objects::resolve_resource(state, host, task_id, texture_ref).ok());
     if let Some(resource) = resolved_resource.as_ref() {
         let entry = resource.entry;
         if entry.object_type == objects::OBJECT_TYPE_REF_TEXTURE {
-            is_type5 = true;
+            is_ref_texture = true;
             let desc = &resource.descriptor;
-            if let Ok(t5) = reims_vgpu_wire::device_desc::type5_header(desc) {
+            if let Ok(t5) = reims_vgpu_wire::device_desc::ref_texture_header(desc) {
                 let sid = t5.surface_id.get();
                 if sid != 0 {
-                    type5_view = objects::decode_type5_texture_view(desc);
+                    ref_texture_view = objects::decode_ref_texture_view(desc);
                     surface = Some(sid);
                 }
             }
         }
-        if entry.object_type == objects::OBJECT_TYPE_SURFACE {
+        if entry.object_type == objects::OBJECT_TYPE_BACKING {
             surface = Some(texture_ref);
         }
         if entry.object_type == OBJECT_TYPE_TEXTURE
-            || entry.object_type == OBJECT_TYPE_TEXTURE_VARIANT
+            || entry.object_type == OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
         {
             is_linear_tex = true;
         }
     }
-    if !is_type5 {
+    if !is_ref_texture {
         // Runs for the linear and unclassified types too, not only for the
-        // type-11 hit it can return: the resolve records the ref as live in the
+        // mapper-ref-texture hit it can return: the resolve records the ref as live in the
         // task's object set and reports a typed failure when the descriptor is
         // unreadable. Both are wanted for any ref a draw sampled.
         surface = surface.or_else(|| {
             resolved_resource.as_ref().and_then(|resource| {
-                objects::resolve_type11_resource(state, task_id, texture_ref, resource)
+                objects::resolve_mapper_ref_texture_resource(state, task_id, texture_ref, resource)
             })
         });
     }
 
     if let Some(mid) = surface {
-        // Ensure type-4 pages exist for this surface id.
+        // Ensure backing pages exist for this surface id.
         let _ = objects::ensure_surface_for_texture_bind(state, host, mid);
-        // A type-5 serialized record is the exact Metal texture view over the
+        // A ref-texture serialized record is the exact Metal texture view over the
         // IOSurface bytes. Materialize it only when it differs from (or cannot
         // be inferred from) the base mapping. Exact base views keep the fast
         // resident/cache path below; an unknown 2-B/texel base FourCC exposed
         // as RG8 must instead use the serialized view's native interpretation.
-        // `type5_view` is set only on the branch that also set `surface` to that
+        // `ref_texture_view` is set only on the branch that also set `surface` to that
         // view's own surface id, so reaching here with a view in hand already
         // means `mid` is the surface it describes.
-        if let Some(view) = type5_view {
+        if let Some(view) = ref_texture_view {
             let needs_materialization = state
                 .mappings
                 .get(&mid)
                 .map(|m| {
-                    type5_view_requires_materialization(
+                    ref_texture_view_requires_materialization(
                         m.has_geom, m.width, m.height, m.format, view,
                     )
                 })
@@ -1224,7 +1233,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                 if let Some(bpp) = crate::contract::pixel_format::bytes_per_pixel(view.pixel_format)
                 {
                     if let Some((base_off, bpr, _)) = state.mappings.get(&mid).and_then(|m| {
-                        crate::runtime::mapping_write::type5_sample_window(
+                        crate::runtime::mapping_write::ref_texture_sample_window(
                             m,
                             view.plane_index,
                             view.width,
@@ -1237,7 +1246,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                             &*host,
                             mid,
                             texture_ref,
-                            "type5_view",
+                            "ref_texture_view",
                             crate::runtime::scanout::SampledFieldWindow {
                                 width: view.width,
                                 height: view.height,
@@ -1254,7 +1263,13 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                 // RGBA8). This bypasses the ~1.5 MB/plane/frame CPU read +
                 // upload the CPU loader below would pay every decoded frame.
                 if let Some(src) = resolved_resource.as_ref().and_then(|resource| {
-                    try_type5_sample_zero_copy(state, host, mid, view, resource.lifetime_ref())
+                    try_ref_texture_sample_zero_copy(
+                        state,
+                        host,
+                        mid,
+                        view,
+                        resource.lifetime_ref(),
+                    )
                 }) {
                     // Success path: a healthy video decodes ~2 planes/frame,
                     // so this fires per-bind (~99k lines/boot). The aggregate
@@ -1263,13 +1278,13 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                     // for deep debugging behind REIMS_VGPU_DRAW_LOG (observe::line)
                     // rather than flooding the always-on fail sink.
                     crate::observe::line(format!(
-                        "type5_view_zc ref={texture_ref} sid={mid} view={}x{} fmt={:#x} plane={}",
+                        "ref_texture_view_zc ref={texture_ref} sid={mid} view={}x{} fmt={:#x} plane={}",
                         view.width, view.height, view.pixel_format, view.plane_index
                     ));
                     return Some((view.width, view.height, mid, src));
                 }
                 let (w, h, rgba, identity, byte_format) =
-                    load_type5_view_rgba(state, host, task_id, texture_ref, mid, view)?;
+                    load_ref_texture_view_rgba(state, host, task_id, texture_ref, mid, view)?;
                 return Some((
                     w,
                     h,
@@ -1380,11 +1395,11 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
 
                 // A ready resident target is authoritative after a product
                 // Store — but only while nothing has replaced the bytes it is a
-                // copy of. A type-11 surface's pages are plain guest RAM and the
+                // copy of. A mapper-ref-texture surface's pages are plain guest RAM and the
                 // guest CPU stores into them with no device operation, so a
                 // resident produced for one tenant of the surface keeps claiming
                 // to hold its pixels after the guest has painted different ones
-                // there. This is the same question `type11_guest_wrote_since_store`
+                // there. This is the same question `mapper_ref_texture_guest_wrote_since_store`
                 // asks before the attachment LOAD elision reuses a resident, and
                 // the same one the host-cache rung below asks before serving its
                 // copy. This rung asked neither, and it is the largest of the
@@ -1411,10 +1426,10 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                 // merge, so borrowing `_refused` would report a repaint that did
                 // not happen and run a merge for it.
                 if resident_ready && !guest_replaced && !may_bind_resident {
-                    note_type11_sample_rung("t11rung_resident_swizzled", guest_write);
+                    note_mapper_ref_texture_sample_rung("t11rung_resident_swizzled", guest_write);
                 } else if resident_ready {
                     if !guest_replaced {
-                        note_type11_sample_rung("t11rung_resident", guest_write);
+                        note_mapper_ref_texture_sample_rung("t11rung_resident", guest_write);
                         let format = resident_id.resident_format();
                         return Some((
                             w,
@@ -1423,7 +1438,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                             SampledSourceRequest::Target(resident_id, format),
                         ));
                     }
-                    note_type11_sample_rung("t11rung_resident_refused", guest_write);
+                    note_mapper_ref_texture_sample_rung("t11rung_resident_refused", guest_write);
                     match guest_owned {
                         Some(ranges) => {
                             // The merge is what makes falling through sound: it
@@ -1493,9 +1508,9 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                 // is nothing left to merge from — the image is destroyed — yet
                 // it takes this fall-through with no merge and no refusal.
                 //
-                // For most surfaces that is correct: a type-11 surface's pages
+                // For most surfaces that is correct: a mapper-ref-texture surface's pages
                 // are its content, the flush rails write them, and reading them
-                // back is what `resolve_type11_load_seed` already calls "a cache
+                // back is what `resolve_mapper_ref_texture_load_seed` already calls "a cache
                 // miss is a reason to read them".
                 //
                 // # The unsound case this line was added to count is closed
@@ -1573,7 +1588,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                     .flatten()
                 {
                     // Uploaded in the order the cache already holds. This rung's
-                    // bytes are BGRA8 by construction — it is a type-4 scanout
+                    // bytes are BGRA8 by construction — it is a backing scanout
                     // cache — and `B8G8R8A8_UNORM` is a Vulkan-mandatory sampled
                     // format with linear filtering, so declaring the layout costs
                     // nothing and the hardware reads the channels the guest
@@ -1605,8 +1620,8 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                         key: (1u64 << 62) | mid as u64,
                         generation: host_gen,
                     });
-                    note_type11_sample_rung("t11rung_host_cache", guest_write);
-                    // BGRA8 by construction — it is a type-4 scanout cache — but
+                    note_mapper_ref_texture_sample_rung("t11rung_host_cache", guest_write);
+                    // BGRA8 by construction — it is a backing scanout cache — but
                     // the *values* in it are the surface's, and this cache is
                     // filled from a writeback that reorders channels and decodes
                     // nothing. So the transfer function is the mapping's declared
@@ -1630,19 +1645,28 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                 // the guest has written over — so the gather always runs and the
                 // guest bytes are taken unconditionally. Declining the gather is
                 // expected control flow — the CPU byte loader below serves the
-                // same pixels — so it stays quiet, like the type-2/3 rail's.
+                // same pixels — so it stays quiet, like the normal-texture rail's.
                 if let Some(src) = resolved_resource.as_ref().and_then(|resource| {
-                    try_type11_sample_zero_copy(state, host, mid, w, h, resource.lifetime_ref())
+                    try_mapper_ref_texture_sample_zero_copy(
+                        state,
+                        host,
+                        mid,
+                        w,
+                        h,
+                        resource.lifetime_ref(),
+                    )
                 }) {
-                    note_type11_sample_rung("t11rung_zero_copy", guest_write);
+                    note_mapper_ref_texture_sample_rung("t11rung_zero_copy", guest_write);
                     return Some((w, h, mid, src));
                 }
                 // The memo skips the convert/alloc on unchanged content and
                 // returns a content identity so the engine skips re-hash+upload;
                 // its census (T11Memo hit / T11Guest fill) is emitted internally.
                 let memo_source = crate::runtime::draw::mapping_declared_format(state, mid, None);
-                if let Some((rgba, identity)) = load_type11_rgba_memoized(state, host, mid) {
-                    note_type11_sample_rung("t11rung_guest_memo", guest_write);
+                if let Some((rgba, identity)) =
+                    load_mapper_ref_texture_rgba_memoized(state, host, mid)
+                {
+                    note_mapper_ref_texture_sample_rung("t11rung_guest_memo", guest_write);
                     return Some((
                         w,
                         h,
@@ -1663,7 +1687,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
                     // (mid, geometry) so a steady repeat stays at one line.
                     use std::collections::HashSet;
                     use std::sync::Mutex;
-                    note_type11_sample_rung("t11rung_miss", guest_write);
+                    note_mapper_ref_texture_sample_rung("t11rung_miss", guest_write);
                     static SEEN: Mutex<Option<HashSet<(u32, u32, u32)>>> = Mutex::new(None);
                     let mut guard = SEEN.lock().unwrap_or_else(|e| e.into_inner());
                     if guard.get_or_insert_with(HashSet::new).insert((mid, w, h)) {
@@ -1677,7 +1701,7 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
         }
     }
 
-    // Type-2/3: GVA-keyed encode, then texture_ref with **descriptor** geom match.
+    // normal-texture: GVA-keyed encode, then texture_ref with **descriptor** geom match.
     if is_linear_tex {
         // Zero-copy gather for large Vulkan-native linear textures: replaces
         // the CPU host-cache/memo byte paths below for eligible formats (the
@@ -1792,9 +1816,9 @@ pub(super) fn resolve_sampled_source<M: HostMemory + HostOps>(
 fn resource_type_owns_surface_resident(object_type: u8) -> bool {
     matches!(
         object_type,
-        objects::OBJECT_TYPE_SURFACE
+        objects::OBJECT_TYPE_BACKING
             | objects::OBJECT_TYPE_REF_TEXTURE
-            | crate::runtime::decode::resource::OBJECT_TYPE_IOSURFACE
+            | crate::runtime::decode::resource::OBJECT_TYPE_MAPPER_REF_TEXTURE
     )
 }
 
@@ -1809,7 +1833,7 @@ fn resource_type_owns_gva_resident(object_type: u8) -> bool {
     matches!(
         object_type,
         crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE
-            | crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_VARIANT
+            | crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS
     )
 }
 
@@ -1820,16 +1844,16 @@ mod resource_resident_ownership_tests {
     #[test]
     fn every_surface_texture_construction_form_owns_its_resident() {
         for object_type in [
-            objects::OBJECT_TYPE_SURFACE,
+            objects::OBJECT_TYPE_BACKING,
             objects::OBJECT_TYPE_REF_TEXTURE,
-            crate::runtime::decode::resource::OBJECT_TYPE_IOSURFACE,
+            crate::runtime::decode::resource::OBJECT_TYPE_MAPPER_REF_TEXTURE,
         ] {
             assert!(resource_type_owns_surface_resident(object_type));
         }
         for object_type in [
             crate::runtime::decode::resource::OBJECT_TYPE_BUFFER,
             crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE,
-            crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_VARIANT,
+            crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
         ] {
             assert!(!resource_type_owns_surface_resident(object_type));
         }
@@ -1839,14 +1863,14 @@ mod resource_resident_ownership_tests {
     fn linear_texture_construction_forms_own_their_gva_resident() {
         for object_type in [
             crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE,
-            crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_VARIANT,
+            crate::runtime::decode::resource::OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
         ] {
             assert!(resource_type_owns_gva_resident(object_type));
         }
         for object_type in [
-            objects::OBJECT_TYPE_SURFACE,
+            objects::OBJECT_TYPE_BACKING,
             objects::OBJECT_TYPE_REF_TEXTURE,
-            crate::runtime::decode::resource::OBJECT_TYPE_IOSURFACE,
+            crate::runtime::decode::resource::OBJECT_TYPE_MAPPER_REF_TEXTURE,
             crate::runtime::decode::resource::OBJECT_TYPE_BUFFER,
         ] {
             assert!(!resource_type_owns_gva_resident(object_type));
@@ -1855,12 +1879,12 @@ mod resource_resident_ownership_tests {
 }
 
 #[inline]
-pub(super) fn type5_view_requires_materialization(
+pub(super) fn ref_texture_view_requires_materialization(
     base_has_geom: bool,
     base_width: u32,
     base_height: u32,
     base_format: u16,
-    view: objects::Type5TextureView,
+    view: objects::RefTextureView,
 ) -> bool {
     !base_has_geom
         || view.depth != 1
@@ -1874,20 +1898,20 @@ pub(super) fn type5_view_requires_materialization(
 /// for diagnosis: `(width, height, pixel_format, bytes_per_row, alloc_size)`.
 type SampleWindowDesc = (u32, u32, u32, u32, u32);
 
-/// Why the type-5 serialized-view loader refused to materialize a plane.
+/// Why the ref-texture serialized-view loader refused to materialize a plane.
 ///
-/// # Why these slugs are prefixed `type5_view_`
+/// # Why these slugs are prefixed `ref_texture_view_`
 ///
-/// The blit rail's `BlitStatus` already owns a `t5_*` vocabulary for the type-5
+/// The blit rail's `BlitStatus` already owns a `t5_*` vocabulary for the ref-texture
 /// *copy* path (`t5_no_mapping`, `t5_sample_window`, `t5_fmt_bpp`,
 /// `t5_unmapped`), and four of this loader's checks are conceptually the same
 /// words. A bare `no_mapping` was in fact one of three claimants — console
 /// capture, guest-page import and this loader — that the last present-rail
-/// migration recorded as still sharing the word. The `type5_view_` prefix keeps
-/// `grep reason=type5_view_…` answerable against the copy path that shares the
+/// migration recorded as still sharing the word. The `ref_texture_view_` prefix keeps
+/// `grep reason=ref_texture_view_…` answerable against the copy path that shares the
 /// surface.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum Type5ViewDecline {
+pub(super) enum RefTextureViewDecline {
     /// The serialized view is volumetric; only `depth == 1` planes materialize.
     UnsupportedDepth { depth: u32 },
     /// The mapping's page table is not resident for scanout.
@@ -1935,21 +1959,21 @@ pub(super) enum Type5ViewDecline {
     Convert { row: usize, bpp: u32 },
 }
 
-impl crate::observe::Decline for Type5ViewDecline {
+impl crate::observe::Decline for RefTextureViewDecline {
     fn slug(&self) -> &'static str {
         match self {
-            Self::UnsupportedDepth { .. } => "type5_view_unsupported_depth",
-            Self::Unresolved => "type5_view_unresolved",
-            Self::FormatBpp => "type5_view_format_bpp",
-            Self::NoMapping => "type5_view_no_mapping",
-            Self::SampleWindow { .. } => "type5_view_sample_window",
-            Self::Span { .. } => "type5_view_span",
-            Self::TightOverflow { .. } => "type5_view_tight_overflow",
-            Self::NativeLen { .. } => "type5_view_native_len",
-            Self::Read { .. } => "type5_view_read",
-            Self::RgbaStride => "type5_view_rgba_stride",
-            Self::RgbaLen { .. } => "type5_view_rgba_len",
-            Self::Convert { .. } => "type5_view_convert",
+            Self::UnsupportedDepth { .. } => "ref_texture_view_unsupported_depth",
+            Self::Unresolved => "ref_texture_view_unresolved",
+            Self::FormatBpp => "ref_texture_view_format_bpp",
+            Self::NoMapping => "ref_texture_view_no_mapping",
+            Self::SampleWindow { .. } => "ref_texture_view_sample_window",
+            Self::Span { .. } => "ref_texture_view_span",
+            Self::TightOverflow { .. } => "ref_texture_view_tight_overflow",
+            Self::NativeLen { .. } => "ref_texture_view_native_len",
+            Self::Read { .. } => "ref_texture_view_read",
+            Self::RgbaStride => "ref_texture_view_rgba_stride",
+            Self::RgbaLen { .. } => "ref_texture_view_rgba_len",
+            Self::Convert { .. } => "ref_texture_view_convert",
         }
     }
 
@@ -2015,7 +2039,7 @@ impl crate::observe::Decline for Type5ViewDecline {
     }
 }
 
-/// Why a type-11 attachment `LOAD` could not be seeded with the surface's own
+/// Why a mapper-ref-texture attachment `LOAD` could not be seeded with the surface's own
 /// prior contents.
 ///
 /// This is not a degradation the caller absorbs. `exec` resolves the pass load
@@ -2034,7 +2058,7 @@ impl crate::observe::Decline for Type5ViewDecline {
 /// existed: **121 distinct (mapping, geometry) wipes** in ~170 s, four of them at
 /// the full 1920x1080 composite extent, against 0 in the idle phase.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Type11SeedDecline {
+enum MapperRefTextureSeedDecline {
     /// The cache holds no entry for this mapping id and the mapping's own pages
     /// could not be read at the requested extent either.
     ///
@@ -2053,7 +2077,7 @@ enum Type11SeedDecline {
     /// `NoEntry` would hide which one a future boot hit.
     GeomMismatch { have_w: u32, have_h: u32 },
     /// An entry exists at exactly this geometry but its bytes were ceded to the
-    /// pinned resident of a deferred type-11 Store that skipped its readback
+    /// pinned resident of a deferred mapper-ref-texture Store that skipped its readback
     /// (`surface_cache::cede_surface_to_resident`).
     ///
     /// Distinct from [`Self::GeomMismatch`] because the geometries *match* — folding
@@ -2066,12 +2090,12 @@ enum Type11SeedDecline {
     CededToResident,
 }
 
-impl crate::observe::Decline for Type11SeedDecline {
+impl crate::observe::Decline for MapperRefTextureSeedDecline {
     fn slug(&self) -> &'static str {
         match self {
-            Self::NoEntry => "type11_seed_cache_absent",
-            Self::GeomMismatch { .. } => "type11_seed_cache_geom",
-            Self::CededToResident => "type11_seed_cache_ceded",
+            Self::NoEntry => "mapper_ref_texture_seed_cache_absent",
+            Self::GeomMismatch { .. } => "mapper_ref_texture_seed_cache_geom",
+            Self::CededToResident => "mapper_ref_texture_seed_cache_ceded",
         }
     }
 
@@ -2083,19 +2107,19 @@ impl crate::observe::Decline for Type11SeedDecline {
     }
 }
 
-/// Which rung of the type-11 `LOAD` seed ladder produced the attachment's prior
+/// Which rung of the mapper-ref-texture `LOAD` seed ladder produced the attachment's prior
 /// contents.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Type11SeedRung {
+enum MapperRefTextureSeedRung {
     /// The host render cache held this mapping at exactly this geometry.
     Cache,
     /// The cache missed and the surface's own guest IOSurface pages were read.
     GuestPages,
 }
 
-/// A type-11 attachment's prior contents, kept in the representation of the
+/// A mapper-ref-texture attachment's prior contents, kept in the representation of the
 /// freshest rung that supplied them.
-enum Type11LoadSeed {
+enum MapperRefTextureLoadSeed {
     /// Host-owned bytes from the render cache, or the universal converted
     /// fallback when the native guest-page view cannot be described.
     Host(
@@ -2107,7 +2131,7 @@ enum Type11LoadSeed {
     Guest(crate::backend::vulkan::engine::GuestTargetSeed),
 }
 
-impl Type11SeedRung {
+impl MapperRefTextureSeedRung {
     fn name(self) -> &'static str {
         match self {
             Self::Cache => "cache_hit",
@@ -2116,7 +2140,7 @@ impl Type11SeedRung {
     }
 }
 
-/// Report which way the type-11 `LOAD` seed branch went, once per
+/// Report which way the mapper-ref-texture `LOAD` seed branch went, once per
 /// `(mapping, requested geometry, outcome)`.
 ///
 /// Every outcome reports, because a zero on the miss arm has to be readable. A
@@ -2134,12 +2158,12 @@ impl Type11SeedRung {
 /// The mapping's own latched geometry and generation ride along on every arm:
 /// `want == mapgeom` is the condition under which the guest-pages rung can serve
 /// at all, so the pair says whether a miss was recoverable.
-fn note_type11_load_seed(
+fn note_mapper_ref_texture_load_seed(
     state: &DeviceState,
     mapping_id: u32,
     w: u32,
     h: u32,
-    served: Option<Type11SeedRung>,
+    served: Option<MapperRefTextureSeedRung>,
 ) {
     let (map_w, map_h, map_gen) = state
         .mappings
@@ -2153,17 +2177,17 @@ fn note_type11_load_seed(
     // sits on a branch the census measures at 28-111 entries a second.
     let outcome_bits = match served {
         None => 0u64,
-        Some(Type11SeedRung::Cache) => 1,
-        Some(Type11SeedRung::GuestPages) => 2,
+        Some(MapperRefTextureSeedRung::Cache) => 1,
+        Some(MapperRefTextureSeedRung::GuestPages) => 2,
     };
     let disc =
         (u64::from(mapping_id) << 40) | (u64::from(w) << 20) | u64::from(h) | (outcome_bits << 62);
     if let Some(rung) = served {
-        if !crate::observe::first_sight("type11_load_seed_served", disc) {
+        if !crate::observe::first_sight("mapper_ref_texture_load_seed_served", disc) {
             return;
         }
         crate::observe::off(format!(
-            "type11_load_seed outcome={} mid={mapping_id} want={w}x{h} \
+            "mapper_ref_texture_load_seed outcome={} mid={mapping_id} want={w}x{h} \
              mapgeom={map_w}x{map_h} mapgen={map_gen} hostgen={host_gen}",
             rung.name()
         ));
@@ -2175,15 +2199,15 @@ fn note_type11_load_seed(
                 state, mapping_id, w, h,
             ) =>
         {
-            Type11SeedDecline::CededToResident
+            MapperRefTextureSeedDecline::CededToResident
         }
-        Some((have_w, have_h)) => Type11SeedDecline::GeomMismatch { have_w, have_h },
-        None => Type11SeedDecline::NoEntry,
+        Some((have_w, have_h)) => MapperRefTextureSeedDecline::GeomMismatch { have_w, have_h },
+        None => MapperRefTextureSeedDecline::NoEntry,
     };
     if !crate::observe::first_sight(crate::observe::Decline::slug(&d), disc) {
         return;
     }
-    crate::observe::Emit::decline("type11_load_seed", &d)
+    crate::observe::Emit::decline("mapper_ref_texture_load_seed", &d)
         .field("mid", mapping_id)
         .field("want", format!("{w}x{h}"))
         .field("mapgeom", format!("{map_w}x{map_h}"))
@@ -2192,7 +2216,7 @@ fn note_type11_load_seed(
         .fail();
 }
 
-/// The prior contents of a type-11 attachment under `MTL_LOAD_ACTION_LOAD`,
+/// The prior contents of a mapper-ref-texture attachment under `MTL_LOAD_ACTION_LOAD`,
 /// with the byte order they are in.
 ///
 /// Two rungs, in freshness order:
@@ -2203,7 +2227,7 @@ fn note_type11_load_seed(
 ///    the R/B exchange rides the engine's single copy into mapped staging rather
 ///    than materializing a converted frame here.
 /// 2. **The surface's own guest IOSurface pages.** The cache is an accelerator,
-///    not the surface. What a type-11 attachment *contains* is its pages, so a
+///    not the surface. What a mapper-ref-texture attachment *contains* is its pages, so a
 ///    cache miss is a reason to read them — not a reason to drop the guest's
 ///    LOAD. Without this rung the pass began with `LoadOp::CLEAR` against the
 ///    hardcoded `[0,0,0,0]` primary clear and the matching Store published that
@@ -2217,12 +2241,12 @@ fn note_type11_load_seed(
 /// before recording the copy. Any writeback debt is paid before the page view is
 /// built, so it observes this device's latest Store rather than pre-Store bytes.
 ///
-/// The sibling Metal path already had rung 2: type-11 `seed_color_load` falls
+/// The sibling Metal path already had rung 2: mapper-ref-texture `seed_color_load` falls
 /// through to the same reader via `load_sampled_rgba_static`. Only the Vulkan arm
 /// stopped at the cache.
 ///
 /// `None` means the guest's LOAD could not be honoured at all, and
-/// [`note_type11_load_seed`] has already said which check refused.
+/// [`note_mapper_ref_texture_load_seed`] has already said which check refused.
 /// Band how long after pressure recovery the guest wanted the resident again.
 /// The fixed reference interval keeps existing census buckets comparable; it
 /// has no role in deciding whether the resident remains alive.
@@ -2259,7 +2283,7 @@ fn stage_uses_sampled_band(textures: &[TextureBind], samplers: &[SamplerBind]) -
     textures.iter().any(|t| t.texture_ref != 0) || samplers.iter().any(|s| s.sampler_ref != 0)
 }
 
-fn try_type11_target_guest_seed<M: HostMemory + HostOps>(
+fn try_mapper_ref_texture_target_guest_seed<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mapping_id: u32,
@@ -2268,7 +2292,7 @@ fn try_type11_target_guest_seed<M: HostMemory + HostOps>(
     target_format: ash::vk::Format,
 ) -> Option<crate::backend::vulkan::engine::GuestTargetSeed> {
     use crate::backend::vulkan::engine::{GuestRunSource, GuestTargetSeed};
-    use crate::runtime::mapping_write::type11_sample_window;
+    use crate::runtime::mapping_write::mapper_ref_texture_sample_window;
 
     if w == 0 || h == 0 || !mapper::ensure_resolved_for_scanout(state, host, mapping_id) {
         return None;
@@ -2289,7 +2313,7 @@ fn try_type11_target_guest_seed<M: HostMemory + HostOps>(
             mapping.format
         };
         let layout = pixel_format::store_texel_order(format)?;
-        let (base_off, bpr, _) = type11_sample_window(mapping, w, h, format)?;
+        let (base_off, bpr, _) = mapper_ref_texture_sample_window(mapping, w, h, format)?;
         (base_off, u64::from(bpr), layout)
     };
     let source_format = translate::pixel::vk_texel_layout(layout);
@@ -2318,14 +2342,14 @@ fn try_type11_target_guest_seed<M: HostMemory + HostOps>(
     })
 }
 
-fn resolve_type11_load_seed<M: HostMemory + HostOps>(
+fn resolve_mapper_ref_texture_load_seed<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mapping_id: u32,
     w: u32,
     h: u32,
     target_format: ash::vk::Format,
-) -> Option<Type11LoadSeed> {
+) -> Option<MapperRefTextureLoadSeed> {
     use crate::backend::vulkan::engine::SeedOrder;
     // The cache is the other host-side copy of these pages, and it sits above
     // the only rung that reads the pages themselves — so a stale hit here is
@@ -2336,12 +2360,12 @@ fn resolve_type11_load_seed<M: HostMemory + HostOps>(
     // it did is the page list walked to say whether it wrote the *pixels*.
     //
     // Without it this rung served exactly the frame the elision gate two frames
-    // up had just refused. The caller computes `type11_guest_wrote_since_store`
+    // up had just refused. The caller computes `mapper_ref_texture_guest_wrote_since_store`
     // to decide whether the resident may carry the chain, declines when it says
     // written, and then arrived here to be handed the same stale bytes out of
     // the host cache. The pass composites onto them and its Store publishes
     // them back over the guest's pages, which is the fixpoint this file's own
-    // note above `type11_load_currency_query` calls "renders correctly for a few
+    // note above `mapper_ref_texture_load_currency_query` calls "renders correctly for a few
     // frames then stays corrupted".
     let guest_write = mapping_guest_write_verdict(state, host, mapping_id);
     let site = guest_wrote_allocation(guest_write)
@@ -2355,48 +2379,56 @@ fn resolve_type11_load_seed<M: HostMemory + HostOps>(
         .flatten();
     let served = if let Some(bgra) = cached {
         Some((
-            Type11LoadSeed::Host(bgra, SeedOrder::Bgra8),
-            Type11SeedRung::Cache,
+            MapperRefTextureLoadSeed::Host(bgra, SeedOrder::Bgra8),
+            MapperRefTextureSeedRung::Cache,
         ))
     } else {
-        try_type11_target_guest_seed(state, host, mapping_id, w, h, target_format)
-            .map(|seed| (Type11LoadSeed::Guest(seed), Type11SeedRung::GuestPages))
+        try_mapper_ref_texture_target_guest_seed(state, host, mapping_id, w, h, target_format)
+            .map(|seed| {
+                (
+                    MapperRefTextureLoadSeed::Guest(seed),
+                    MapperRefTextureSeedRung::GuestPages,
+                )
+            })
             .or_else(|| {
-                load_type11_mapping_rgba(state, host, mapping_id, None)
+                load_mapper_ref_texture_mapping_rgba(state, host, mapping_id, None)
                     .map(|(_, _, r)| r)
                     .filter(|rgba| rgba.len() == (w as usize) * (h as usize) * 4)
                     .map(|rgba| {
                         (
-                            Type11LoadSeed::Host(std::sync::Arc::new(rgba), SeedOrder::Rgba8),
-                            Type11SeedRung::GuestPages,
+                            MapperRefTextureLoadSeed::Host(
+                                std::sync::Arc::new(rgba),
+                                SeedOrder::Rgba8,
+                            ),
+                            MapperRefTextureSeedRung::GuestPages,
                         )
                     })
             })
     };
-    note_type11_load_seed(state, mapping_id, w, h, served.as_ref().map(|s| s.1));
+    note_mapper_ref_texture_load_seed(state, mapping_id, w, h, served.as_ref().map(|s| s.1));
     served.map(|(seed, _)| seed)
 }
 
-/// Materialize the exact serialized Metal view carried by a type-5 object.
+/// Materialize the exact serialized Metal view carried by a ref-texture object.
 ///
-/// The underlying type-4 FourCC is allocation metadata, not necessarily the
+/// The underlying backing FourCC is allocation metadata, not necessarily the
 /// sampled Metal format. The view's format/geometry define the native row
-/// interpretation; the type-4 device descriptor supplies its base/BPR/span.
-/// Materialize a type-5 serialized texture view through the byte-exact
+/// interpretation; the backing device descriptor supplies its base/BPR/span.
+/// Materialize a ref-texture serialized texture view through the byte-exact
 /// revalidated memo (same contract as [`load_linear_guest_memoized`]): every
 /// bind re-reads the native plane window so a guest write is always observed;
 /// conversion, allocation, and — via the returned content identity — the
 /// engine upload are skipped when the bytes are unchanged.
-pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
+pub(super) fn load_ref_texture_view_rgba<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     task_id: u32,
     texture_ref: u32,
     mapping_id: u32,
-    view: objects::Type5TextureView,
-) -> Option<LoadedType5View> {
-    let fail = |d: Type5ViewDecline| -> Option<LoadedType5View> {
-        crate::observe::Emit::decline("type5_draw_view", &d)
+    view: objects::RefTextureView,
+) -> Option<LoadedRefTextureView> {
+    let fail = |d: RefTextureViewDecline| -> Option<LoadedRefTextureView> {
+        crate::observe::Emit::decline("ref_texture_draw_view", &d)
             .field("task", task_id)
             .field("ref", texture_ref)
             .field("sid", mapping_id)
@@ -2407,19 +2439,19 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
     };
 
     if view.depth != 1 {
-        return fail(Type5ViewDecline::UnsupportedDepth { depth: view.depth });
+        return fail(RefTextureViewDecline::UnsupportedDepth { depth: view.depth });
     }
     if !mapper::ensure_resolved_for_scanout(state, host, mapping_id) {
-        return fail(Type5ViewDecline::Unresolved);
+        return fail(RefTextureViewDecline::Unresolved);
     }
     let Some(bpp) = pixel_format::bytes_per_pixel(view.pixel_format) else {
-        return fail(Type5ViewDecline::FormatBpp);
+        return fail(RefTextureViewDecline::FormatBpp);
     };
     let (base_off, surface_bpr, span_end, pages_n, base_w, base_h, base_fmt, map_gen) = {
         let Some(m) = state.mappings.get(&mapping_id) else {
-            return fail(Type5ViewDecline::NoMapping);
+            return fail(RefTextureViewDecline::NoMapping);
         };
-        let Some((base_off, surface_bpr, span_end)) = mapping_write::type5_sample_window(
+        let Some((base_off, surface_bpr, span_end)) = mapping_write::ref_texture_sample_window(
             m,
             view.plane_index,
             view.width,
@@ -2436,7 +2468,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
                         d.alloc_size,
                     )
                 });
-            return fail(Type5ViewDecline::SampleWindow {
+            return fail(RefTextureViewDecline::SampleWindow {
                 base_w: m.width,
                 base_h: m.height,
                 base_fmt: m.format,
@@ -2456,7 +2488,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
     };
     let page_bytes = (pages_n as u64).saturating_mul(1u64 << state.page_shift);
     if page_bytes < span_end {
-        return fail(Type5ViewDecline::Span {
+        return fail(RefTextureViewDecline::Span {
             pages: pages_n,
             page_bytes,
             span_end,
@@ -2464,13 +2496,13 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
         });
     }
     let Some(tight) = view.width.checked_mul(bpp) else {
-        return fail(Type5ViewDecline::TightOverflow { bpp });
+        return fail(RefTextureViewDecline::TightOverflow { bpp });
     };
     let Some(native_len) = (tight as u64)
         .checked_mul(view.height as u64)
         .and_then(host_alloc_len)
     else {
-        return fail(Type5ViewDecline::NativeLen { tight });
+        return fail(RefTextureViewDecline::NativeLen { tight });
     };
     let mut native = vec![0u8; native_len];
     if !mapping_write::read_rect_raw_at(
@@ -2492,7 +2524,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
         &mut native,
         tight,
     ) {
-        return fail(Type5ViewDecline::Read {
+        return fail(RefTextureViewDecline::Read {
             base_w,
             base_h,
             base_fmt,
@@ -2502,7 +2534,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
             pages: pages_n,
         });
     }
-    // Identity key namespace: bit 63 marks type-5 view content (guest linear
+    // Identity key namespace: bit 63 marks ref-texture view content (guest linear
     // identities use the raw sampled GVA as key). Every producer draws its
     // generation from `DeviceState::next_sampled_content_generation`, so a
     // (key, generation) pair cannot alias content even on a key collision.
@@ -2527,8 +2559,8 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
     // The half-float colour pair is deliberately **not** here yet. It belongs
     // by the same argument the linear rails took — `texel_to_rgba8`'s arm for
     // it clamps to `[0, 1]` and quantizes to 256 levels — but nothing has ever
-    // measured a type-5 view arriving in one, and this rail is the video-plane
-    // rail. `type5_view_narrowed` below is the measurement; add the arm when it
+    // measured a ref-texture view arriving in one, and this rail is the video-plane
+    // rail. `ref_texture_view_narrowed` below is the measurement; add the arm when it
     // fires, not before.
     //
     // The packed 32-bit colour formats take the native rail for the same
@@ -2552,10 +2584,10 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
         view.pixel_format,
     );
     let ok_line = |generation_source: &str, rgba: &[u8]| {
-        // Per-draw success echo — fires on EVERY type-5 plane bind (thousands/sec
+        // Per-draw success echo — fires on EVERY ref-texture plane bind (thousands/sec
         // under video → ~36k lines/boot, 61% of the fail log), burying real
         // failures. The always-on health signal is the `sampled_branch_census`
-        // aggregate (Type5View / T5Memo, noted on both paths below), so this
+        // aggregate (RefTextureView / T5Memo, noted on both paths below), so this
         // per-bind detail — and its O(w*h) `rgba_rgb_stats` scan — is diagnostic
         // only: hand both to the sink so a normal boot stays uncluttered and
         // this path never holds the answer to whether the sink is open.
@@ -2563,14 +2595,14 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
             let s = crate::observe::rgba_rgb_stats(rgba);
             let (nz, max) = (s.rgb_nz, s.max_rgb);
             crate::observe::line(format!(
-            "type5_draw_view ok task={task_id} ref={texture_ref} sid={mapping_id} map_gen={map_gen} view={}x{} fmt={:#x} bpp={bpp} base={base_w}x{base_h} base_fmt={base_fmt:#x} off={base_off} bpr={surface_bpr} span_end={span_end} src={generation_source} rgb_nz={nz} max_rgb={max}",
+            "ref_texture_draw_view ok task={task_id} ref={texture_ref} sid={mapping_id} map_gen={map_gen} view={}x{} fmt={:#x} bpp={bpp} base={base_w}x{base_h} base_fmt={base_fmt:#x} off={base_off} bpr={surface_bpr} span_end={span_end} src={generation_source} rgb_nz={nz} max_rgb={max}",
             view.width,
             view.height,
             view.pixel_format,
         ));
         });
     };
-    if let Some(m) = state.type5_view_memo.get_touch(&memo_key) {
+    if let Some(m) = state.ref_texture_view_memo.get_touch(&memo_key) {
         // Vec equality is length + byte memcmp with early exit on change.
         if m.native == native {
             let rgba = m.rgba.clone();
@@ -2593,13 +2625,13 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
     // memcmp key and the upload payload).
     let rgba: std::sync::Arc<Vec<u8>> = if byte_format.layout() == TexelLayout::Rgba8 {
         let Some(rgba_stride) = view.width.checked_mul(RGBA8_BPP) else {
-            return fail(Type5ViewDecline::RgbaStride);
+            return fail(RefTextureViewDecline::RgbaStride);
         };
         let Some(rgba_len) = (rgba_stride as u64)
             .checked_mul(view.height as u64)
             .and_then(host_alloc_len)
         else {
-            return fail(Type5ViewDecline::RgbaLen {
+            return fail(RefTextureViewDecline::RgbaLen {
                 stride: rgba_stride,
             });
         };
@@ -2607,9 +2639,9 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
         // The third CPU convert in this crate, and the third that said nothing
         // when it lost precision. `byte_format`'s table above names the video
         // plane formats natively and folds everything else here, so a half-float
-        // type-5 view is quantized on the same terms the linear rails were.
+        // ref-texture view is quantized on the same terms the linear rails were.
         crate::runtime::draw::note_sampled_narrowing(
-            "type5_view_narrowed",
+            "ref_texture_view_narrowed",
             texture_ref,
             view.pixel_format,
             view.width,
@@ -2624,7 +2656,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
                 view.width,
                 &mut rgba[dst_off..dst_off + rgba_stride as usize],
             ) {
-                return fail(Type5ViewDecline::Convert { row: y, bpp });
+                return fail(RefTextureViewDecline::Convert { row: y, bpp });
             }
         }
         std::sync::Arc::new(rgba)
@@ -2634,12 +2666,12 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
     let generation = state.next_sampled_content_generation();
     ok_line("fill", &rgba);
     let entry_bytes = native.len() + rgba.len();
-    state.type5_view_memo.insert(
+    state.ref_texture_view_memo.insert(
         memo_key,
         crate::model::GuestLinearMemo {
             native,
             rgba: rgba.clone(),
-            // The type-5 view path re-derives this from the view's own pixel
+            // The ref-texture view path re-derives this from the view's own pixel
             // format on every call, hit or miss, so storing it is a statement of
             // what the bytes are rather than the source anything reads.
             layout: byte_format.layout(),
@@ -2664,7 +2696,7 @@ pub(super) fn load_type5_view_rgba<M: HostMemory + HostOps>(
 /// threshold only — never a correctness gate and never a gate on a direct
 /// buffer-backed image.
 ///
-/// Set to 64 KiB from a video-playback census: after the type-5 plane rail
+/// Set to 64 KiB from a video-playback census: after the ref-texture plane rail
 /// landed, the whole remaining CPU copy under video was `t11_guest`
 /// (~226 MB/session), and 100% of those declines were the floor —
 /// per-frame-changing composite surfaces clustered at ~236 KiB, just under the
@@ -2689,10 +2721,10 @@ pub(super) const SAMPLED_GATHER_MIN_BYTES: u64 = 64 * 1024;
 pub(super) enum SampledFloorRail {
     /// A linear texture addressed through task-local GVA space.
     Linear,
-    /// A type-11 surface plane addressed through a mapping.
-    Type11,
-    /// A serialized type-5 surface view addressed through a mapping.
-    Type5,
+    /// A mapper-ref-texture surface plane addressed through a mapping.
+    MapperRefTexture,
+    /// A serialized ref-texture surface view addressed through a mapping.
+    RefTexture,
 }
 
 /// The only application of [`SAMPLED_GATHER_MIN_BYTES`], for all three sampled
@@ -2707,7 +2739,7 @@ pub(super) enum SampledFloorRail {
 /// reaches the shader quantized.
 ///
 /// Written once here because it was written three times by hand and the three
-/// did not agree: the type-11 arm carried the span term alone, so every
+/// did not agree: the mapper-ref-texture arm carried the span term alone, so every
 /// half-float sampled surface under 64 KiB on that rail was declined onto the
 /// very loader `a_cost_floor_may_decline` was added to keep it away from. The
 /// two mapping rails also declined silently — no record at all — while the
@@ -2728,12 +2760,12 @@ pub(super) fn sampled_gather_floor_admits(
         (SampledFloorRail::Linear, s) if s < 4 * 1024 => "zc_lin_below_floor_lt4k",
         (SampledFloorRail::Linear, s) if s < 16 * 1024 => "zc_lin_below_floor_lt16k",
         (SampledFloorRail::Linear, _) => "zc_lin_below_floor_lt64k",
-        (SampledFloorRail::Type11, s) if s < 4 * 1024 => "zc_t11_below_floor_lt4k",
-        (SampledFloorRail::Type11, s) if s < 16 * 1024 => "zc_t11_below_floor_lt16k",
-        (SampledFloorRail::Type11, _) => "zc_t11_below_floor_lt64k",
-        (SampledFloorRail::Type5, s) if s < 4 * 1024 => "zc_t5_below_floor_lt4k",
-        (SampledFloorRail::Type5, s) if s < 16 * 1024 => "zc_t5_below_floor_lt16k",
-        (SampledFloorRail::Type5, _) => "zc_t5_below_floor_lt64k",
+        (SampledFloorRail::MapperRefTexture, s) if s < 4 * 1024 => "zc_t11_below_floor_lt4k",
+        (SampledFloorRail::MapperRefTexture, s) if s < 16 * 1024 => "zc_t11_below_floor_lt16k",
+        (SampledFloorRail::MapperRefTexture, _) => "zc_t11_below_floor_lt64k",
+        (SampledFloorRail::RefTexture, s) if s < 4 * 1024 => "zc_t5_below_floor_lt4k",
+        (SampledFloorRail::RefTexture, s) if s < 16 * 1024 => "zc_t5_below_floor_lt16k",
+        (SampledFloorRail::RefTexture, _) => "zc_t5_below_floor_lt64k",
     });
     false
 }
@@ -3423,7 +3455,7 @@ pub(super) fn strided_window_extent(w: u32, h: u32, bpp: u64, bpr: u64) -> Optio
 /// block width. An uncompressed block is 1x1, for which every expression below
 /// reduces to exactly what [`strided_window_extent`] computes; that helper
 /// keeps its texel spelling because its other callers are rails a compressed
-/// format cannot reach (type-11/type-5 surfaces, whose formats have a
+/// format cannot reach (mapper-ref-texture/ref-texture surfaces, whose formats have a
 /// bytes-per-texel by construction).
 ///
 /// This is the arithmetic that kept BC textures off the zero-copy gather:
@@ -3462,8 +3494,8 @@ pub(super) fn strided_level_extent(
 /// window's own page list beside the runs, for the same reason
 /// [`task_gva_guest_run_window`] does.
 ///
-/// Shared by the type-11 attachment seed and the type-11/type-5 sampled rails,
-/// which reach the same pages through different window math.
+/// Shared by the mapper-ref-texture attachment seed and the mapper-ref-texture/ref-texture sampled
+/// rails, which reach the same pages through different window math.
 ///
 /// # No settle, for the reason its linear twin already states
 ///
@@ -3502,7 +3534,7 @@ fn mapping_window_guest_runs<M: HostMemory + HostOps>(
     Some((window.to_vec(), runs))
 }
 
-/// Zero-copy draw-time buffer bind: resolve a type-1 buffer object's backing
+/// Zero-copy draw-time buffer bind: resolve a buffer object's backing
 /// span (from `offset`) to guest-RAM runs and hand the engine a
 /// [`engine::BufferContent::GuestRuns`] — the GPU gathers the bytes from
 /// imported guest RAM inside the draw's own CB. Replaces the per-draw CPU
@@ -4391,7 +4423,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
     // still lost, so the census records it rather than letting the fold be
     // silent.
     // **Every layout `sampled_pixels` returns is admitted**, which is the same
-    // rule `try_type5_sample_zero_copy` states and applies: that function is
+    // rule `try_ref_texture_sample_zero_copy` states and applies: that function is
     // the answer to "which guest bytes sample byte-identically through the
     // matching Vulkan image", and a layout it hands back has already passed
     // the identity-components test inside it. The engine creates the image
@@ -4400,7 +4432,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
     //
     // This rail used to narrow that set again, to four-byte colour plus the
     // single-channel floats, on the stated grounds that "R8/Rg8 video planes
-    // keep their existing CPU/type-5 rails". The premise was that R8 and Rg8
+    // keep their existing CPU/ref-texture rails". The premise was that R8 and Rg8
     // only ever arrive as video; they do not. A Safari window drag with no
     // video playing produced 37 704 `Rg8` binds, 49 % of every linear sampled
     // bind in the boot, and each one fell to `load_linear_guest_memoized`'s
@@ -4423,7 +4455,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
     //
     // The plan beside the layout is the format's own channel mapping — identity
     // for all but `A8Unorm`, whose byte rides in `R8_UNORM`. It is composed with
-    // the guest's type-8 view swizzle where the image view is built, so this
+    // the guest's texture-view swizzle where the image view is built, so this
     // rail no longer has to refuse a format for having one.
     let (native, sampled_vk_format, native_components) =
         match translate::pixel::sampled_pixels(declared_format) {
@@ -4511,7 +4543,7 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
     // writeback ahead of this gather, and a CPU fence wait buys an ordering that
     // holds without it.
     //
-    // `try_type11_sample_zero_copy` and `try_type5_sample_zero_copy` are the two
+    // `try_mapper_ref_texture_sample_zero_copy` and `try_ref_texture_sample_zero_copy` are the two
     // rails that were already written this way, and this one is now consistent
     // with them.
     //
@@ -4705,14 +4737,14 @@ pub(super) fn try_linear_sample_zero_copy<M: HostMemory + HostOps>(
     ))
 }
 
-/// Zero-copy rail for type-11 mapping-backed sampled binds. Eligible when
+/// Zero-copy rail for mapper-ref-texture mapping-backed sampled binds. Eligible when
 /// the mapping's raw bytes sample byte-identically through a native UNORM
 /// image (BGRA8/RGBA8 families — the CPU loader's `texel_to_rgba8` is a
 /// byte pass-through/swizzle for exactly these) and the caller established
 /// the resident is not authoritative. Mirrors `paint_mapping`'s window math
-/// (`type11_sample_window`) and its flush-on-access rule; any gate miss
+/// (`mapper_ref_texture_sample_window`) and its flush-on-access rule; any gate miss
 /// falls back to the CPU byte path.
-pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
+pub(super) fn try_mapper_ref_texture_sample_zero_copy<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mid: u32,
@@ -4721,7 +4753,7 @@ pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
     owner: crate::model::TaskResourceLifetimeRef,
 ) -> Option<SampledSourceRequest> {
     use crate::backend::vulkan::engine;
-    use crate::runtime::mapping_write::type11_sample_window;
+    use crate::runtime::mapping_write::mapper_ref_texture_sample_window;
     if w == 0 || h == 0 {
         return None;
     }
@@ -4751,10 +4783,10 @@ pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
             _ => return None,
         };
         let sampled_vk_format = translate::pixel::translate(format).ok()?.vk;
-        let (base_off, bpr_u32, _span_end) = type11_sample_window(m, w, h, format)?;
+        let (base_off, bpr_u32, _span_end) = mapper_ref_texture_sample_window(m, w, h, format)?;
         (native, sampled_vk_format, base_off, bpr_u32 as u64)
     };
-    // From the layout the translation chose, as the type-5 rail does, so the
+    // From the layout the translation chose, as the ref-texture rail does, so the
     // texel size cannot disagree with the image the engine creates. The
     // `is_four_byte_color` gate above already fixes it at four.
     let (span, row_length_texels) =
@@ -4803,7 +4835,7 @@ pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
             pixel_format::swizzle_identity(),
         ));
     }
-    if !sampled_gather_floor_admits(SampledFloorRail::Type11, native, span) {
+    if !sampled_gather_floor_admits(SampledFloorRail::MapperRefTexture, native, span) {
         return None;
     }
     let (gpas, runs) = mapping_window_guest_runs(state, host, mid, base_off, span)?;
@@ -4811,7 +4843,7 @@ pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
     let seen = crate::runtime::gather_witness::note_gather(
         state,
         host,
-        crate::runtime::gather_witness::GatherRail::Type11,
+        crate::runtime::gather_witness::GatherRail::MapperRefTexture,
         crate::runtime::gather_witness::GatherKey::Mapping { mid, base_off },
         crate::runtime::gather_witness::GatherWindow {
             gpas: &gpas,
@@ -4840,24 +4872,24 @@ pub(super) fn try_type11_sample_zero_copy<M: HostMemory + HostOps>(
     ))
 }
 
-/// Zero-copy rail for a type-5 serialized IOSurface plane view — the video
+/// Zero-copy rail for a ref-texture serialized IOSurface plane view — the video
 /// hot path. VideoToolbox decodes to NV12 (Y = R8, CbCr = RG8; also
-/// BGRA8/RGBA8 surfaces), sampled through the type-5 view path whose CPU
-/// loader (`load_type5_view_rgba`) read + uploaded ~1.5 MB per plane per
+/// BGRA8/RGBA8 surfaces), sampled through the ref-texture view path whose CPU
+/// loader (`load_ref_texture_view_rgba`) read + uploaded ~1.5 MB per plane per
 /// decoded frame (census `t5_view`). This gathers the plane's guest pages
 /// directly in the draw CB so the decoded frame never materializes CPU bytes.
-/// Mirrors `try_type11_sample_zero_copy`'s page coalescing over the plane
-/// window from `type5_sample_window` (which carries the wire plane index +
+/// Mirrors `try_mapper_ref_texture_sample_zero_copy`'s page coalescing over the plane
+/// window from `ref_texture_sample_window` (which carries the wire plane index +
 /// biplanar offset); any gate miss falls back to the CPU byte path.
-pub(super) fn try_type5_sample_zero_copy<M: HostMemory + HostOps>(
+pub(super) fn try_ref_texture_sample_zero_copy<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mid: u32,
-    view: objects::Type5TextureView,
+    view: objects::RefTextureView,
     owner: crate::model::TaskResourceLifetimeRef,
 ) -> Option<SampledSourceRequest> {
     use crate::backend::vulkan::engine;
-    use crate::runtime::mapping_write::type5_sample_window;
+    use crate::runtime::mapping_write::ref_texture_sample_window;
     let (w, h) = (view.width, view.height);
     if w == 0 || h == 0 || view.depth != 1 {
         return None;
@@ -4878,7 +4910,7 @@ pub(super) fn try_type5_sample_zero_copy<M: HostMemory + HostOps>(
         // never disagree with the image the engine creates.
         // A multiplanar view's planes are the video luma/chroma formats, all of
         // which sit identically on their Vulkan spellings. Required rather than
-        // assumed, for the reason the type-11 rail states.
+        // assumed, for the reason the mapper-ref-texture rail states.
         let (native, bpp) = match translate::pixel::sampled_pixels(view.pixel_format) {
             Ok((layout, _decline, components)) => {
                 if !pixel_format::swizzle_is_identity(&components) {
@@ -4890,16 +4922,16 @@ pub(super) fn try_type5_sample_zero_copy<M: HostMemory + HostOps>(
             Err(_) => return None,
         };
         let (base_off, bpr_u32, _span_end) =
-            type5_sample_window(m, view.plane_index, w, h, view.pixel_format)?;
+            ref_texture_sample_window(m, view.plane_index, w, h, view.pixel_format)?;
         let sampled_vk_format = translate::pixel::translate(view.pixel_format).ok()?.vk;
         (native, sampled_vk_format, bpp, base_off, bpr_u32 as u64)
     };
     let (span, row_length_texels) = strided_window_extent(w, h, bpp as u64, bpr)?;
     // Same rule as the linear rail's floor: a cost threshold may only turn a
-    // plane away onto a CPU arm that produces the same pixels. The type-11 rail
+    // plane away onto a CPU arm that produces the same pixels. The mapper-ref-texture rail
     // needs no such qualifier because `is_four_byte_color` already fixes what
     // reaches its floor; this one admits every layout the translation names.
-    // The owed frame, for the reason `try_type11_sample_zero_copy` states: a
+    // The owed frame, for the reason `try_mapper_ref_texture_sample_zero_copy` states: a
     // debt is not a submitted writeback and queue order cannot order it.
     crate::runtime::writeback_debt::pay_for_mapping(state, host, mid);
     if let Some(source) = mapped_sampled_source(
@@ -4930,7 +4962,7 @@ pub(super) fn try_type5_sample_zero_copy<M: HostMemory + HostOps>(
             pixel_format::swizzle_identity(),
         ));
     }
-    if !sampled_gather_floor_admits(SampledFloorRail::Type5, native, span) {
+    if !sampled_gather_floor_admits(SampledFloorRail::RefTexture, native, span) {
         return None;
     }
     let (gpas, runs) = mapping_window_guest_runs(state, host, mid, base_off, span)?;
@@ -4938,7 +4970,7 @@ pub(super) fn try_type5_sample_zero_copy<M: HostMemory + HostOps>(
     let seen = crate::runtime::gather_witness::note_gather(
         state,
         host,
-        crate::runtime::gather_witness::GatherRail::Type5,
+        crate::runtime::gather_witness::GatherRail::RefTexture,
         crate::runtime::gather_witness::GatherKey::Mapping { mid, base_off },
         crate::runtime::gather_witness::GatherWindow {
             gpas: &gpas,
@@ -5326,7 +5358,7 @@ fn load_linear_guest_memoized<M: HostMemory + HostOps>(
 /// Report a sampled texture served entirely as zeroes out of the guest's pages
 /// while the host cache holds an entry for the same address.
 ///
-/// A type-2/3 texture's guest GVA pages are a *pageable alias* of a body this
+/// A normal texture's guest GVA pages are a *pageable alias* of a body this
 /// device owns (`surface_cache::store_linear_texture`), so a blank read here
 /// could mean the device rendered the span, cached it, and its own writeback
 /// never landed in the guest's pages — a silent loss, since the draw then
@@ -5582,7 +5614,7 @@ pub(super) fn sync_store_allowed_pages<M: HostMemory>(
     sync_store_target_pages(state, host, task_id, color0?)
 }
 
-/// How much surface a taken type-11 seed elision covered, in whole texels.
+/// How much surface a taken mapper-ref-texture seed elision covered, in whole texels.
 ///
 /// Measured to price the repair for an unsound witness: the epoch could not see
 /// a guest CPU write to the surface's own pages, and the obvious fix was the one
@@ -5606,8 +5638,8 @@ pub(super) fn sync_store_allowed_pages<M: HostMemory>(
 /// One driven boot, x86 / Vulkan, six Finder recomposites:
 ///
 /// ```text
-/// type11_seed_elided      41389      t11elide_le_64x64          5
-/// type11_seed_provided      242      t11elide_le_256x256        4
+/// mapper_ref_texture_seed_elided      41389      t11elide_le_64x64          5
+/// mapper_ref_texture_seed_provided      242      t11elide_le_256x256        4
 ///                                    t11elide_le_512x512      903
 ///                                    t11elide_le_1024x1024  15641
 ///                                    t11elide_display       24836
@@ -5619,7 +5651,7 @@ pub(super) fn sync_store_allowed_pages<M: HostMemory>(
 /// **An unconditional revalidation is not affordable.** At RGBA8 the elided
 /// extent is ~237 GB of guest reads per session. The rail is not a micro-
 /// optimisation to be traded away for correctness; it is carrying essentially
-/// all of the composite seed traffic, and `type11_seed_provided` at 242 against
+/// all of the composite seed traffic, and `mapper_ref_texture_seed_provided` at 242 against
 /// 41 389 says what the un-elided rate would be.
 ///
 /// **The latch is not on the icon target.** Nine elisions in the entire session
@@ -5634,12 +5666,11 @@ pub(super) fn sync_store_allowed_pages<M: HostMemory>(
 /// So the repair could not be "revalidate before trusting", and it could not be
 /// "drop the elision". What was missing was a witness for guest CPU writes that
 /// does not cost a read of the surface, and the hypervisor already had one.
-/// [`type11_guest_wrote_since_store`] is that witness, over
-/// `HostOps::guest_write_gen`: O(pages) at the harvest instead of O(bytes) at
-/// every LOAD, with the 237 GB left saved. One driven boot after it landed
-/// measured `type11_seed_elided` 283 against `type11_seed_provided` 23, so the
-/// reuse survived the soundness.
-fn note_type11_elision_extent(w: u32, h: u32) {
+/// [`mapper_ref_texture_guest_wrote_since_store`] is that witness, over
+/// `HostOps::guest_write_gen`: O(pages) at the harvest instead of O(bytes) at every LOAD, with the
+/// 237 GB left saved. One driven boot after it landed measured `mapper_ref_texture_seed_elided` 283
+/// against `mapper_ref_texture_seed_provided` 23, so the reuse survived the soundness.
+fn note_mapper_ref_texture_elision_extent(w: u32, h: u32) {
     let texels = (w as u64).saturating_mul(h as u64);
     crate::runtime::drain::note_store_route(match texels {
         0..=4_096 => "t11elide_le_64x64",
@@ -5702,7 +5733,7 @@ fn note_type11_elision_extent(w: u32, h: u32) {
 /// Scored per round across the break, no counter in this crate separates a
 /// corrupt round from a clean one — `lin_rung_guest_blank`,
 /// `lin_rung_blank_with_host_entry`, `lin_rung_guest_memo`, `gvac_suspect`,
-/// `type11_seed_elided` and `draw_partial_load_from_target` are all simply
+/// `mapper_ref_texture_seed_elided` and `draw_partial_load_from_target` are all simply
 /// proportional to round length, and the set of decline names is identical on
 /// both sides. A defect that is stable on screen for minutes and leaves no
 /// trace in a census this large will not be found by adding another counter to
@@ -5925,7 +5956,7 @@ fn note_draw_coverage(
             // device can have changed the surface since the resident was
             // published — and the one writer this device cannot see is the
             // guest's own CPU writing the surface's pages. A target with a
-            // type-11 mapping or a task GVA has such pages, and reusing its
+            // mapper-ref-texture mapping or a task GVA has such pages, and reusing its
             // resident without the currency query is the documented fixpoint
             // where "renders correctly for a few frames then stays corrupted"
             // comes from.
@@ -6245,7 +6276,7 @@ fn note_load_seed_outcome(
     }
 }
 
-/// Store type-2/3 encode into texture_ref + GVA host caches (BGRA).
+/// Store normal-texture encode into texture_ref + GVA host caches (BGRA).
 ///
 /// `task_id` is the task whose page table gives the GVA meaning; the store
 /// records the pages it resolves to so a later sample can tell whether the
@@ -6310,7 +6341,7 @@ enum M2vDrawSpan {
     None,
     /// CPU-side pixels (readback path), in the order the engine reports.
     ///
-    /// The order is carried rather than normalized because a type-11 composite
+    /// The order is carried rather than normalized because a mapper-ref-texture composite
     /// Store's consumers — `surface_cache`, the deferred window, the guest-page
     /// writeback — all want guest scanout order, and a BGRA resident hands them
     /// exactly that. Normalizing to RGBA here would restate a whole framebuffer
@@ -6331,7 +6362,7 @@ enum M2vDrawSpan {
     ResidentGvaStore {
         identity: crate::backend::vulkan::engine::TargetIdentity,
     },
-    /// Type-11 composite Store executed into its registry resident with
+    /// Mapper-ref-texture composite Store executed into its registry resident with
     /// `skip_readback`: the caller copies that image into the mapping's guest
     /// pages through [`crate::runtime::render_writeback`], which never brings
     /// the frame across host memory.
@@ -6346,7 +6377,7 @@ enum M2vDrawSpan {
     ///
     /// `identity` is the exact key this record handed `registry_ensure`, so the
     /// image the Store reads is the image the draw rendered into by
-    /// construction. The Store used to call `type11_store_identity` a second
+    /// construction. The Store used to call `mapper_ref_texture_store_identity` a second
     /// time instead, on the grounds that it is the same function that produced
     /// `DrawRequest::target_identity` — but it is not the same *value*. That
     /// identity carries `MappingEntry::map_generation`, the draw mutates
@@ -6421,7 +6452,7 @@ impl Drop for StoreCostSpan {
     }
 }
 
-/// Name which of the six routes a type-11 Store took: counted every time, and
+/// Name which of the six routes a mapper-ref-texture Store took: counted every time, and
 /// fail-logged once per route per process so a boot's route *set* is readable
 /// without the draw log.
 ///
@@ -6462,7 +6493,7 @@ impl Drop for StoreCostSpan {
 /// host GPU class to another, and this is exactly that boundary. Measuring these
 /// four needs a host whose quirk set turns deferral off, or one where the pin
 /// refuses — not another boot here.
-fn note_type11_store_route(route: &'static str) {
+fn note_mapper_ref_texture_store_route(route: &'static str) {
     use std::sync::Mutex;
     static SEEN: Mutex<Option<std::collections::BTreeSet<&'static str>>> = Mutex::new(None);
     crate::runtime::drain::note_store_route(route);
@@ -6472,7 +6503,7 @@ fn note_type11_store_route(route: &'static str) {
             return;
         }
     }
-    crate::observe::fail(format!("type11_store_route route={route}"));
+    crate::observe::fail(format!("mapper_ref_texture_store_route route={route}"));
 }
 
 /// Build the engine's secondary MRT attachments (slot 1..) from a draw's color
@@ -6578,8 +6609,8 @@ pub(super) fn build_secondary_targets<M: HostMemory + HostOps>(
             }
         };
         let format = attachment.vk;
-        // Identity mirrors the primary namespaces: type-2/3 linear GVA, else
-        // type-11 surface.
+        // Identity mirrors the primary namespaces: normal-texture linear GVA, else
+        // mapper-ref-texture surface.
         //
         // A secondary GVA is named by its own backing pages, exactly like color0
         // — the primary's generation describes a different address (a secondary
@@ -7555,7 +7586,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                     let texture_resource = retained.cloned().or_else(|| {
                         objects::resolve_resource(state, host, req.task_id, texture_ref).ok()
                     });
-                    // A type-8 view's channel remap. Resolved here rather than in
+                    // A texture-view's channel remap. Resolved here rather than in
                     // the loaders because it describes how the bind READS the
                     // texture, not what the texture contains: the engine hands it
                     // to the image view as a component mapping and the hardware
@@ -7740,7 +7771,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                 let mut byte_origin = crate::backend::vulkan::engine::SampledByteOrigin::Synthetic;
                 // Byte layout of a CPU-origin bind. Default RGBA8; a source that
                 // already holds its bytes in an uploadable order keeps them —
-                // BGRA8 from the type-4 scanout cache, a native single/dual-channel
+                // BGRA8 from the backing scanout cache, a native single/dual-channel
                 // video plane — and the host spelling is applied once, where the
                 // engine resource is built (`vk_texel_layout` below).
                 let sampled_vk_format;
@@ -8217,8 +8248,10 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // generation when the guest recycled a page, and the identity must
         // name that new generation rather than the one paired with the retired
         // alias.
-        let type11_guest_backing = type11_guest_target_backing(state, host, req);
-        let type11_resident_target = type11_store_identity(state, req, writeback_guest);
+        let mapper_ref_texture_guest_backing =
+            mapper_ref_texture_guest_target_backing(state, host, req);
+        let mapper_ref_texture_resident_target =
+            mapper_ref_texture_store_identity(state, req, writeback_guest);
         if req.chain_from_resident && render_chain_identity(state, req).is_some() {
             // The serialized chain names the resident it intends to load;
             // existence and readiness are engine state and are validated
@@ -8232,17 +8265,17 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // pages. Honour that here, or put the seed back.
         let mut gva_load_identity =
             honour_gva_load_elision(state, host, req, &mut chain_load_from_target);
-        // Type-11 composite Load. A retained guest-allocation target is the
+        // Mapper-ref-texture composite Load. A retained guest-allocation target is the
         // guest's texture resource itself, so its LOAD is authoritative without
         // comparing two copies. A device-allocation target is a mirror: only
         // when it was stamped with the mapping's current
         // `surface_content_epoch` does it hold exactly the bytes
-        // `resolve_type11_load_seed` would upload.
+        // `resolve_mapper_ref_texture_load_seed` would upload.
         //
         // The epoch is the witness. `mark_mapping_written` advances it and every
         // guest-page writer *in this crate* calls it, so a blit or a compute
         // writeback invalidates the stamp without knowing this rail exists. The
-        // deferred type-11 publish — the one writer that changes the pixels
+        // deferred mapper-ref-texture publish — the one writer that changes the pixels
         // without touching guest pages — advances it explicitly. Anything that
         // leaves the answer unknown (no slot, an evicted or recycled image, a
         // draw since the stamp, a `map_generation` rewire that renames the
@@ -8251,7 +8284,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // # The epoch cannot see the guest, so it is only half the test
         //
         // The epoch's closure does *not* include a guest CPU write, and cannot.
-        // A type-11 surface's pages are plain guest RAM; the guest writes them
+        // A mapper-ref-texture surface's pages are plain guest RAM; the guest writes them
         // with its own CPU and no device operation is involved, so nothing calls
         // `mark_mapping_written` and the epoch does not move. Every caller of it
         // is a device-side writer — `compute_exec`, `mapping_write`, `exec`,
@@ -8277,7 +8310,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // pixels that is not the resident, and the seed's only other source is
         // the surface's own guest pages, so the guest must be writing them.
         //
-        // `type11_guest_wrote_since_store` is the other half: the hypervisor's
+        // `mapper_ref_texture_guest_wrote_since_store` is the other half: the hypervisor's
         // dirty bitmap, the one witness for a write this device did not make.
         // Both halves must agree, and every unknown on either side reads as
         // "not current".
@@ -8312,12 +8345,14 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         //
         // Why not the sibling rail's shape — `load_linear_guest_memoized`
         // re-reads the guest's native rows on every call and byte-compares
-        // before reusing its `Arc`. Priced on one boot: `type11_seed_elided`
-        // 41 389 against `type11_seed_provided` 242, at a mean 1.43 M texels per
+        // before reusing its `Arc`. Priced on one boot: `mapper_ref_texture_seed_elided`
+        // 41 389 against `mapper_ref_texture_seed_provided` 242, at a mean 1.43 M texels per
         // elision, so revalidating by re-reading would move ~237 GB of guest
         // memory a session. The bitmap answers the same question in a word.
         if !chain_load_from_target {
-            if let Some((identity, mapping_epoch)) = type11_load_currency_query(state, req) {
+            if let Some((identity, mapping_epoch)) =
+                mapper_ref_texture_load_currency_query(state, req)
+            {
                 // Both arms counted, into the same one-second window as
                 // `drain_duty`. An elision count alone cannot tell "the seed was
                 // skipped" from "this record was never a candidate", and the
@@ -8333,35 +8368,40 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         .map(|resource| resource.resident_target_backing(&identity))
                 });
                 let (resident_current, guest_wrote) =
-                    type11_load_resident_is_current(backing, || {
+                    mapper_ref_texture_load_resident_is_current(backing, || {
                         let resident_epoch =
                             crate::backend::vulkan::engine::resident_content_epoch(&identity);
                         let mapping_id = req.colors.first().map(|c| c.mapping_id).unwrap_or(0);
-                        let guest_wrote = type11_guest_wrote_since_store(state, host, mapping_id);
+                        let guest_wrote =
+                            mapper_ref_texture_guest_wrote_since_store(state, host, mapping_id);
                         (
-                            type11_resident_is_current(mapping_epoch, resident_epoch)
+                            mapper_ref_texture_resident_is_current(mapping_epoch, resident_epoch)
                                 && !guest_wrote,
                             guest_wrote,
                         )
                     });
                 if resident_current {
                     chain_load_from_target = true;
-                    crate::runtime::drain::note_store_route("type11_seed_elided");
+                    crate::runtime::drain::note_store_route("mapper_ref_texture_seed_elided");
                     if backing
                         == Some(
                             crate::backend::vulkan::engine::ResidentContentBacking::GuestAllocation,
                         )
                     {
-                        crate::runtime::drain::note_store_route("type11_seed_guest_allocation");
+                        crate::runtime::drain::note_store_route(
+                            "mapper_ref_texture_seed_guest_allocation",
+                        );
                     }
-                    note_type11_elision_extent(w, h);
+                    note_mapper_ref_texture_elision_extent(w, h);
                 } else {
-                    crate::runtime::drain::note_store_route("type11_seed_provided");
+                    crate::runtime::drain::note_store_route("mapper_ref_texture_seed_provided");
                     // Separated from the epoch's refusal so a boot can say which
                     // half refused. The two answer different questions and a
                     // single counter would hide a rail that never fires.
                     if guest_wrote {
-                        crate::runtime::drain::note_store_route("type11_seed_guest_wrote");
+                        crate::runtime::drain::note_store_route(
+                            "mapper_ref_texture_seed_guest_wrote",
+                        );
                     }
                 }
             }
@@ -8455,11 +8495,11 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         // own the packet's final guest writeback. The Store-only
                         // identity below is deliberately narrower and would
                         // misclassify that record as a pooled RGBA target here.
-                        let target_format = type11_render_identity(state, req)
+                        let target_format = mapper_ref_texture_render_identity(state, req)
                             .as_ref()
                             .map(|identity| identity.resident_format())
                             .unwrap_or(translate::pixel::RESIDENT_RGBA_FORMAT);
-                        match resolve_type11_load_seed(
+                        match resolve_mapper_ref_texture_load_seed(
                             state,
                             host,
                             c0.mapping_id,
@@ -8467,11 +8507,13 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                             h,
                             target_format,
                         ) {
-                            Some(Type11LoadSeed::Host(bytes, order)) => {
+                            Some(MapperRefTextureLoadSeed::Host(bytes, order)) => {
                                 target_rgba8 = Some(bytes);
                                 seed_order = order;
                             }
-                            Some(Type11LoadSeed::Guest(seed)) => target_guest_seed = Some(seed),
+                            Some(MapperRefTextureLoadSeed::Guest(seed)) => {
+                                target_guest_seed = Some(seed)
+                            }
                             None => {}
                         }
                     }
@@ -8502,7 +8544,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         // The widened arm's own instrument, and it is a counter
                         // rather than the latched line below it. DontCare now
                         // walks the same doors as a Load — a provenance seed
-                        // clone, or `resolve_type11_load_seed` reading the
+                        // clone, or `resolve_mapper_ref_texture_load_seed` reading the
                         // surface out of guest memory — and that work is new
                         // per pass, so both outcomes are counted or nothing
                         // says how often the widening pays or what it costs.
@@ -8676,7 +8718,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                 req.colors.first().map(|c| c.load_action),
                 target_rgba8.is_some() || target_guest_seed.is_some(),
                 chain_load_from_target,
-                // Guest-visible backing is a type-11 mapping or a task GVA, and
+                // Guest-visible backing is a mapper-ref-texture mapping or a task GVA, and
                 // the two are exclusive — `ColorRtRequest::target_gva` documents
                 // that. Either one means the surface has pages the guest's own
                 // CPU can write without this device seeing it.
@@ -8811,7 +8853,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                 }
             }
         }
-        // A type-11 composite Store renders into its registry resident, and skips
+        // A mapper-ref-texture composite Store renders into its registry resident, and skips
         // its readback when the deferred rail can name that resident as the
         // window's frame instead of owning a CPU copy of it.
         //
@@ -8833,7 +8875,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         let mut surface_resident_store: Option<crate::backend::vulkan::engine::TargetIdentity> =
             None;
         if resources.target_identity.is_none() {
-            resources.target_identity = type11_resident_target.clone();
+            resources.target_identity = mapper_ref_texture_resident_target.clone();
         }
         // Whether the slot this record renders into is the one this rail would
         // pin, asked by comparing the two identities rather than by testing that
@@ -8843,14 +8885,14 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // `target_identity` already set when it is the last record of a resident
         // render-pass chain: the block above resolved `render_chain_identity` so
         // the record could take `LoadOp::LoadFromTarget`, and for `mapping_id != 0`
-        // that *is* the `surface_identity` `type11_store_identity` returns. An
+        // that *is* the `surface_identity` `mapper_ref_texture_store_identity` returns. An
         // `is_none()` test read that agreement as a conflict and kept the readback
         // for 100 % of the population. The GVA rail cannot collide — its identity
         // requires `mapping_id == 0` and this one requires `mapping_id != 0` — so a
         // genuine mismatch means another namespace owns the attachment and the
         // frame this rail would vouch for is not in the slot it would pin.
-        let renders_into_surface_identity =
-            type11_resident_target.is_some() && resources.target_identity == type11_resident_target;
+        let renders_into_surface_identity = mapper_ref_texture_resident_target.is_some()
+            && resources.target_identity == mapper_ref_texture_resident_target;
         // `!skip_readback` is implied — a set flag means one of the rails above
         // claimed this record, and each returns its own span before
         // `ResidentSurfaceStore` is reached, so a record that armed here as well
@@ -8862,13 +8904,13 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
             // this same value, and which is what `registry_ensure` will be
             // handed. Taken from here rather than unwrapped from the `Option`
             // above so the span cannot name a slot the draw did not register.
-            surface_resident_store = type11_resident_target.clone();
+            surface_resident_store = mapper_ref_texture_resident_target.clone();
         }
         resources.record_guest_store = surface_resident_store.is_some();
         // A first-failure classifier for a composite Store that still reads
         // back used to sit here. Its outer gate was never once true — none of
         // its four counters, nor its `else` arm, appears anywhere in the
-        // always-on log across every boot it holds. Every type-11 Store either
+        // always-on log across every boot it holds. Every mapper-ref-texture Store either
         // skips its readback or is not a writeback Store.
         // What the guest asked for, carried alongside what this device managed
         // to offer. The engine decides between clearing and beginning the pass
@@ -8904,15 +8946,15 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
             resources.load_from_target = true;
             resources.target_rgba8 = None;
         }
-        // The backing belongs only to the type-11 surface identity it was
+        // The backing belongs only to the mapper-ref-texture surface identity it was
         // resolved from. A GVA or render-chain namespace may legitimately own
         // this draw's primary attachment instead, in which case handing it the
         // surface allocation would bind two unrelated resources together.
-        if resources.target_identity == type11_render_identity(state, req) {
-            resources.guest_target_memory = type11_guest_backing;
+        if resources.target_identity == mapper_ref_texture_render_identity(state, req) {
+            resources.guest_target_memory = mapper_ref_texture_guest_backing;
             resources.load_guest_target_backing = resources.guest_target_memory.is_some()
                 && req.colors.first().is_some_and(|color| {
-                    // Same admission as `type11_load_is_a_seed_candidate`, and
+                    // Same admission as `mapper_ref_texture_load_is_a_seed_candidate`, and
                     // for the same reason: a DontCare that this device can
                     // serve prior contents for must be served them, or the
                     // attachment starts at a colour nothing asked for.
@@ -8921,7 +8963,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
                         && color.target_seed_rgba.is_none()
                 });
         }
-        // Type-11 Load used to have a GPU rail here — ~170 lines of front-frame
+        // Mapper-ref-texture Load used to have a GPU rail here — ~170 lines of front-frame
         // retention policy resolving which resident image held the frame the
         // guest computes its damage against. It was reachable only under
         // `try_import`. A shared resident now keeps the guest allocation as
@@ -8932,7 +8974,7 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
         // previously left `resources.blend = None` → opaque replace for every
         // draw, so Load seeds (gray/wallpaper/logo bases) were wiped by sparse
         // dock/chrome layers that Metal would alpha-blend over the attachment.
-        // Contract: type-7 color attachment blend tags (decode/resource).
+        // Contract: serializer-object color attachment blend tags (decode/resource).
         // Outside the `blending_enabled` guard below, and deliberately: an
         // unblended attachment with a mask still leaves its unwritten channels
         // alone, so gating the mask on blending would drop it exactly where the
@@ -9567,8 +9609,8 @@ fn try_metal2vulkan_draw<M: HostMemory + HostOps>(
 /// Engine-resident identity for a color0 render-pass chain.
 ///
 /// This identity lives only from the first serialized record through its final
-/// Store. Type-11 targets use their current protocol mapping identity; linear
-/// type-2/3 targets use the GVA identity below. Unlike deferred writeback, this
+/// Store. Mapper-ref-texture targets use their current protocol mapping identity; linear
+/// normal-texture targets use the GVA identity below. Unlike deferred writeback, this
 /// lifetime is safe on portability-subset devices because the final record
 /// materializes guest bytes before the packet completes.
 /// The registry resident this draw's **depth** attachment renders into, if the
@@ -9857,7 +9899,7 @@ pub(crate) fn render_chain_identity(
     gva_chain_identity(req)
 }
 
-/// The registry resident a type-11 composite Store renders into, if this record
+/// The registry resident a mapper-ref-texture composite Store renders into, if this record
 /// is one.
 ///
 /// Unlike the GVA rail this is **not** a `skip_readback` deferral: a composite
@@ -9885,7 +9927,7 @@ pub(crate) fn render_chain_identity(
 /// [`render_chain_identity`] — and the intermediates already render into that
 /// resident under `skip_readback` with `LoadOp::LoadFromTarget`. The last record
 /// differs only in what happens *after* the draw.
-pub(super) fn type11_store_identity(
+pub(super) fn mapper_ref_texture_store_identity(
     state: &DeviceState,
     req: &DrawEncodeRequest,
     writeback_guest: bool,
@@ -9893,11 +9935,11 @@ pub(super) fn type11_store_identity(
     if !writeback_guest {
         return None;
     }
-    type11_render_identity(state, req)
+    mapper_ref_texture_render_identity(state, req)
 }
 
-/// The registry resident this record renders its type-11 color0 *into*, whatever
-/// its role in the packet — the strict superset of [`type11_store_identity`],
+/// The registry resident this record renders its mapper-ref-texture color0 *into*, whatever
+/// its role in the packet — the strict superset of [`mapper_ref_texture_store_identity`],
 /// which is this same slot restricted to the record that also stores it for the
 /// guest.
 ///
@@ -9908,10 +9950,10 @@ pub(super) fn type11_store_identity(
 /// Conflating them cost the whole seed elision on multi-record packets: record 1
 /// of a chain has `writeback_guest == false`, so the currency check keyed on the
 /// Store identity never ran for it, and its LOAD fell through to
-/// `resolve_type11_load_seed` — which, with the host cache ceded to the resident
+/// `resolve_mapper_ref_texture_load_seed` — which, with the host cache ceded to the resident
 /// rail, reads the mapping's guest pages and therefore lands the very window the
 /// rail armed. One boot measured that loop directly: `surface_flush /
-/// surface_resident` = 1369/1373, one flush per arm, with `type11_load_seed`
+/// surface_resident` = 1369/1373, one flush per arm, with `mapper_ref_texture_load_seed`
 /// reporting `outcome=guest_pages` 110 times against 17 `cache_hit` and
 /// `hostgen=0` on every one.
 ///
@@ -9920,7 +9962,7 @@ pub(super) fn type11_store_identity(
 /// `!writeback_guest` intermediate, and the composite-Store rail claims it for the
 /// last record. So the condition here is the same one those blocks share, asked
 /// once.
-fn type11_render_identity(
+fn mapper_ref_texture_render_identity(
     state: &DeviceState,
     req: &DrawEncodeRequest,
 ) -> Option<crate::backend::vulkan::engine::TargetIdentity> {
@@ -9933,15 +9975,15 @@ fn type11_render_identity(
     render_chain_identity(state, req)
 }
 
-/// Stable shared allocation behind the type-11 primary attachment, if this
+/// Stable shared allocation behind the mapper-ref-texture primary attachment, if this
 /// host can retain the mapping view until its explicit retirement.
 ///
 /// The mapping revalidation inside `ensure_contig_view` is part of the answer:
 /// it retires an alias when the guest has recycled any of its pages, and that
-/// advances the generation carried by `type11_render_identity`. The engine is
+/// advances the generation carried by `mapper_ref_texture_render_identity`. The engine is
 /// therefore handed a pointer and an identity derived from the same current
 /// page ownership, never a cached pointer paired with a newly rewired surface.
-fn type11_guest_target_backing<H: HostMemory + HostOps>(
+fn mapper_ref_texture_guest_target_backing<H: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut H,
     req: &DrawEncodeRequest,
@@ -9950,11 +9992,13 @@ fn type11_guest_target_backing<H: HostMemory + HostOps>(
         return None;
     }
     let c0 = req.colors.first()?;
-    type11_render_identity(state, req)?;
+    mapper_ref_texture_render_identity(state, req)?;
     let (plane_offset, row_pitch, span_end) = {
         let mapping = state.mappings.get(&c0.mapping_id)?;
         let format = crate::runtime::mapping_write::mapping_store_format(mapping);
-        crate::runtime::mapping_write::type11_sample_window(mapping, c0.width, c0.height, format)?
+        crate::runtime::mapping_write::mapper_ref_texture_sample_window(
+            mapping, c0.width, c0.height, format,
+        )?
     };
     let (import, footprint) =
         crate::runtime::mapper::ensure_contig_import_with_footprint(state, host, c0.mapping_id)?;
@@ -9983,13 +10027,13 @@ fn type11_guest_target_backing<H: HostMemory + HostOps>(
 /// [`crate::contract::pass_action::LoadAction::preserves_prior_contents`] for
 /// why undefined contents permit the prior ones, and why serving them is what
 /// keeps this arm agreeing with the Metal one.
-pub(super) fn type11_load_is_a_seed_candidate(c0: &ColorRtRequest) -> bool {
+pub(super) fn mapper_ref_texture_load_is_a_seed_candidate(c0: &ColorRtRequest) -> bool {
     crate::contract::pass_action::LoadAction::from_declared(c0.load_action)
         .preserves_prior_contents()
         && c0.target_seed_rgba.is_none()
 }
 
-/// The `(resident, mapping epoch)` pair a record's type-11 LOAD has to compare to
+/// The `(resident, mapping epoch)` pair a record's mapper-ref-texture LOAD has to compare to
 /// decide whether the image it is about to render into already holds the seed —
 /// or `None` when this record's LOAD is not one a resident could serve at all.
 ///
@@ -10003,15 +10047,15 @@ pub(super) fn type11_load_is_a_seed_candidate(c0: &ColorRtRequest) -> bool {
 /// a rescheduling with a GPU round trip added: `surface_flush / surface_resident`
 /// = 1369/1373 on one boot. Structure rather than a test, because a unit test on
 /// the resolver passes whatever the call site then decides to pass it.
-pub(super) fn type11_load_currency_query(
+pub(super) fn mapper_ref_texture_load_currency_query(
     state: &DeviceState,
     req: &DrawEncodeRequest,
 ) -> Option<(crate::backend::vulkan::engine::TargetIdentity, Option<u32>)> {
     let c0 = req.colors.first()?;
-    if !type11_load_is_a_seed_candidate(c0) {
+    if !mapper_ref_texture_load_is_a_seed_candidate(c0) {
         return None;
     }
-    let identity = type11_render_identity(state, req)?;
+    let identity = mapper_ref_texture_render_identity(state, req)?;
     let mapping_epoch = state
         .mappings
         .get(&c0.mapping_id)
@@ -10024,7 +10068,7 @@ pub(super) fn type11_load_currency_query(
 ///
 /// The device-side half of the currency test — the `surface_content_epoch`
 /// comparison one function up — can only witness writers inside this crate.
-/// A type-11 surface's pages are plain guest RAM, and the guest CPU stores
+/// A mapper-ref-texture surface's pages are plain guest RAM, and the guest CPU stores
 /// into them with no device operation, so the epoch does not move and the
 /// resident silently stops matching what the seed would upload. This is the
 /// only witness for that copied-allocation question, and it is the hypervisor's.
@@ -10051,7 +10095,7 @@ pub(super) fn type11_load_currency_query(
 /// surface it has just asked the GPU to render into, and — unlike the epoch-only
 /// rail this replaced — the very next guest write moves the generation again and
 /// clears it.
-pub(super) fn type11_guest_wrote_since_store<M: HostOps>(
+pub(super) fn mapper_ref_texture_guest_wrote_since_store<M: HostOps>(
     state: &DeviceState,
     host: &M,
     mapping_id: u32,
@@ -10078,7 +10122,7 @@ pub(super) fn type11_guest_wrote_since_store<M: HostOps>(
 }
 
 /// Whether the hypervisor watched the guest write anywhere in the allocation a
-/// type-4 surface's host-side copies were taken from.
+/// backing record's host-side copies were taken from.
 ///
 /// The first of two stages, and the coarse one: the tracking token covers the
 /// mapping's whole page list and its generation moves for a write to any page
@@ -10113,8 +10157,8 @@ enum GuestWriteSite {
 /// Narrow a `Wrote` verdict to the pixel window, so a write that misses it does
 /// not discard a resident that is still exactly the surface.
 ///
-/// The tracking token is per *page list*, and a type-4 allocation is more than
-/// its sampled plane: `type11_sample_window` reports a `base_off` precisely
+/// The tracking token is per *page list*, and a backing allocation is more than
+/// its sampled plane: `mapper_ref_texture_sample_window` reports a `base_off` precisely
 /// because the pixels do not start at offset 0, and an allocation can carry a
 /// second plane and end padding past `span_end`. A guest store into any of that
 /// moves the set-wide generation. Refusing on it discarded whole 1920x1080
@@ -10143,7 +10187,7 @@ fn guest_write_site<M: HostOps>(
         pixel_format::MTL_FORMAT_BGRA8_UNORM
     };
     let Some((base_off, _bpr, span_end)) =
-        crate::runtime::mapping_write::type11_sample_window(m, width, height, format)
+        crate::runtime::mapping_write::mapper_ref_texture_sample_window(m, width, height, format)
     else {
         return GuestWriteSite::Unknown;
     };
@@ -10258,7 +10302,7 @@ fn ranges_touch_window(ranges: &[(u64, u64)], base_off: u64, span_end: u64) -> b
         .any(|&(lo, hi)| lo < span_end && hi > base_off)
 }
 
-/// Census only: which rung of the type-4 sampled ladder served this bind, and,
+/// Census only: which rung of the backing sampled ladder served this bind, and,
 /// for the rungs that serve a host-side *copy* of guest memory, what the
 /// hypervisor said about those bytes when the rung was chosen.
 ///
@@ -10338,7 +10382,7 @@ fn ranges_touch_window(ranges: &[(u64, u64)], base_off: u64, span_end: u64) -> b
 /// `gw_wrote_elsewhere` on either rung. They are denominators, not dead code —
 /// their being empty is what says a served copy is never a copy the hypervisor
 /// actively contradicted.
-fn note_type11_sample_rung(rung: &'static str, guest_write: GuestWriteVerdict) {
+fn note_mapper_ref_texture_sample_rung(rung: &'static str, guest_write: GuestWriteVerdict) {
     crate::runtime::drain::note_store_route(rung);
     if let Some(gw) = sample_rung_gw_route(rung, guest_write) {
         crate::runtime::drain::note_store_route(gw);
@@ -10382,18 +10426,21 @@ fn sample_rung_gw_route(rung: &str, guest_write: GuestWriteVerdict) -> Option<&'
 /// mapping has no entry" and "this image was never stamped" as agreement and
 /// load undefined memory as though it were the guest's prior frame. That is
 /// precisely the black-layer class. Absence on either side is a refusal.
-fn type11_resident_is_current(mapping_epoch: Option<u32>, resident_epoch: Option<u32>) -> bool {
+fn mapper_ref_texture_resident_is_current(
+    mapping_epoch: Option<u32>,
+    resident_epoch: Option<u32>,
+) -> bool {
     mapping_epoch.is_some() && mapping_epoch == resident_epoch
 }
 
-/// Decide whether a type-11 LOAD can use its retained target.
+/// Decide whether a mapper-ref-texture LOAD can use its retained target.
 ///
 /// A guest allocation is the serialized texture's own storage, not a cached
 /// copy, so a host or guest write changes the allocation the next render pass
 /// loads. The copied-allocation currency query is supplied as a closure so the
 /// shared case cannot accidentally pay either engine lookup or guest-write
 /// lookup on a warm LOAD.
-fn type11_load_resident_is_current(
+fn mapper_ref_texture_load_resident_is_current(
     backing: Option<crate::backend::vulkan::engine::ResidentContentBacking>,
     copied_currency: impl FnOnce() -> (bool, bool),
 ) -> (bool, bool) {
@@ -10407,7 +10454,7 @@ fn type11_load_resident_is_current(
 /// Record that the resident this Store rendered into holds the mapping's
 /// content as of `epoch`, so the surface's next LOAD can skip its CPU seed.
 ///
-/// Keyed through [`type11_store_identity`] — the same call the draw's
+/// Keyed through [`mapper_ref_texture_store_identity`] — the same call the draw's
 /// `target_identity` came from — so the slot stamped is the slot rendered into.
 /// A miss is expected and silent: the identity resolves to `None` when this
 /// record never took the resident path, and `stamp_resident_content_epoch`
@@ -10421,14 +10468,14 @@ fn type11_load_resident_is_current(
 /// device operation. Registration happens here rather than at mapping resolve
 /// because this is the first moment the device has a host-side copy whose reuse
 /// would depend on the answer.
-fn stamp_type11_resident<M: HostMemory + HostOps>(
+fn stamp_mapper_ref_texture_resident<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     req: &DrawEncodeRequest,
     writeback_guest: bool,
     epoch: u32,
 ) {
-    if let Some(identity) = type11_store_identity(state, req, writeback_guest) {
+    if let Some(identity) = mapper_ref_texture_store_identity(state, req, writeback_guest) {
         crate::backend::vulkan::engine::stamp_resident_content_epoch(&identity, epoch);
         // Both callers reach here only on a route that has already put these
         // pixels outside the image — the synchronous one through `write_bgra8`
@@ -10537,7 +10584,7 @@ pub(crate) fn gva_span_alloc_generation<M: HostMemory + HostOps>(
     gva_page_set_hash(&pages)
 }
 
-/// Engine-resident identity for a GVA (type-2/3) color0 render target.
+/// Engine-resident identity for a GVA (normal-texture) color0 render target.
 ///
 /// Single source of truth for the resident GVA chain rail: the draw path,
 /// the alias-sample bind, and the abandon-path landing must all agree on the
@@ -10710,7 +10757,7 @@ pub(crate) fn read_resident_chain(
         }
     }
 }
-/// Land a type-11 render Store's frame in the guest's pages, from the resident
+/// Land a mapper-ref-texture render Store's frame in the guest's pages, from the resident
 /// the draw just rendered into.
 ///
 /// The Store never reads the frame back off the GPU: the copy's destination is
@@ -10727,7 +10774,7 @@ pub(crate) fn read_resident_chain(
 /// [`M2vDrawSpan::ResidentSurfaceStore`], so the image read here is the image
 /// the draw rendered into by construction.
 ///
-/// It used to be [`type11_store_identity`] called again here, on the argument
+/// It used to be [`mapper_ref_texture_store_identity`] called again here, on the argument
 /// that this is the same function that produced the draw's `target_identity`.
 /// The same function is not the same value: that identity carries
 /// `MappingEntry::map_generation`, and the draw mutates `DeviceState` between
@@ -10806,10 +10853,9 @@ fn store_surface_resident<M: HostMemory + HostOps>(
     ) {
         return false;
     }
-    // The guest half of the write witness, recorded here rather than by the
-    // caller because this rail returns straight out of `encode_draw` — it never
-    // reaches `stamp_type11_resident`, and it is where nearly all type-11 Stores
-    // go.
+    // The guest half of the write witness, recorded here rather than by the caller because this
+    // rail returns straight out of `encode_draw` — it never reaches
+    // `stamp_mapper_ref_texture_resident`, and it is where nearly all mapper-ref-texture Stores go.
     crate::runtime::mapper::stamp_guest_write_gen(state, host, mapping_id);
     true
 }
@@ -10824,7 +10870,7 @@ fn store_surface_resident<M: HostMemory + HostOps>(
 /// # Why the resident is stamped here, where no copy has happened
 ///
 /// The stamp says the resident holds the mapping's content, and it is what
-/// licenses the type-11 attachment LOAD to seed from that image instead of
+/// licenses the mapper-ref-texture attachment LOAD to seed from that image instead of
 /// reading a whole frame back out of guest memory — 802 elided against 36
 /// uploaded on a driven boot. `registry_mark_ready` clears it on every draw that
 /// renders into the resident, so a Store that did not re-stamp would hand the
@@ -10856,7 +10902,7 @@ fn arm_surface_writeback_debt<M: HostMemory + HostOps>(
     // and a cession says so — see [`surface_cache::cede_surface_to_resident`],
     // which was written for this call and had no caller.
     //
-    // Without it the type-11 sampled ladder's host-cache rung serves the
+    // Without it the mapper-ref-texture sampled ladder's host-cache rung serves the
     // *previous* frame for as long as the debt is outstanding: that rung is
     // gated on the guest-write witness alone, which by construction cannot see a
     // publish this device made itself, and it sits above both rungs that read
@@ -10892,7 +10938,9 @@ fn arm_surface_writeback_debt<M: HostMemory + HostOps>(
             pixel_format::MTL_FORMAT_BGRA8_UNORM
         };
         if let Some((base_off, _bpr, span_end)) =
-            crate::runtime::mapping_write::type11_sample_window(m, width, height, format)
+            crate::runtime::mapping_write::mapper_ref_texture_sample_window(
+                m, width, height, format,
+            )
         {
             state.invalidate_storage_residency_window(mapping_id, base_off, span_end);
         }
@@ -11747,9 +11795,9 @@ mod vulkan_split_tests {
 
     #[test]
     fn an_unstamped_resident_never_matches_a_mapping_with_no_epoch() {
-        assert!(!type11_resident_is_current(None, None));
-        assert!(!type11_resident_is_current(None, Some(0)));
-        assert!(!type11_resident_is_current(Some(7), None));
+        assert!(!mapper_ref_texture_resident_is_current(None, None));
+        assert!(!mapper_ref_texture_resident_is_current(None, Some(0)));
+        assert!(!mapper_ref_texture_resident_is_current(Some(7), None));
     }
 
     #[test]
@@ -11757,7 +11805,7 @@ mod vulkan_split_tests {
         use crate::backend::vulkan::engine::ResidentContentBacking;
 
         assert_eq!(
-            type11_load_resident_is_current(
+            mapper_ref_texture_load_resident_is_current(
                 Some(ResidentContentBacking::GuestAllocation),
                 || panic!("one allocation has no second copy whose currency can be queried"),
             ),
@@ -11770,7 +11818,7 @@ mod vulkan_split_tests {
         ] {
             for copied_answer in [(false, true), (true, false)] {
                 assert_eq!(
-                    type11_load_resident_is_current(backing, || copied_answer),
+                    mapper_ref_texture_load_resident_is_current(backing, || copied_answer),
                     copied_answer,
                     "{backing:?} must retain the copied-allocation currency test"
                 );
@@ -11778,7 +11826,7 @@ mod vulkan_split_tests {
         }
     }
 
-    /// A sampled bind may only be served from a host-side copy of a type-4
+    /// A sampled bind may only be served from a host-side copy of a backing
     /// surface while the hypervisor has not watched the guest replace the pages
     /// that copy was taken from — and the GPU resident is bound by that rule
     /// exactly as the byte cache is.
@@ -11787,7 +11835,7 @@ mod vulkan_split_tests {
     /// `mapping_guest_write_verdict` before serving; `t11rung_resident`, which
     /// sits above it in the ladder and took 92 730 binds to the cache's 14 396
     /// on the boot that first measured them, asked nothing and returned
-    /// `SampledSourceRequest::Target` unconditionally. A type-11 surface's pages
+    /// `SampledSourceRequest::Target` unconditionally. A mapper-ref-texture surface's pages
     /// are plain guest RAM: the guest CPU repaints them with no device
     /// operation, so a resident produced for one tenant of a pooled IOSurface
     /// keeps claiming to hold its pixels after a different tenant has been
@@ -11820,7 +11868,7 @@ mod vulkan_split_tests {
     }
 
     /// The second stage, which is what keeps the first from being ruinous. A
-    /// type-4 allocation is bigger than the plane a bind samples — pixels start
+    /// backing allocation is bigger than the plane a bind samples — pixels start
     /// at `base_off` and padding follows `span_end` — and the tracking token's
     /// generation moves for a write to any page of it. Refusing on that alone
     /// discarded whole 1920x1080 compositor scanouts the GPU had rendered and
@@ -11892,8 +11940,8 @@ mod vulkan_split_tests {
     /// current against a resident explicitly stamped with 0.
     #[test]
     fn epoch_zero_is_current_only_against_an_explicit_stamp() {
-        assert!(type11_resident_is_current(Some(0), Some(0)));
-        assert!(!type11_resident_is_current(Some(0), None));
+        assert!(mapper_ref_texture_resident_is_current(Some(0), Some(0)));
+        assert!(!mapper_ref_texture_resident_is_current(Some(0), None));
     }
 
     /// The elision is exact equality, not "at least as new". A resident stamped
@@ -11902,9 +11950,9 @@ mod vulkan_split_tests {
     /// fall back to the CPU seed.
     #[test]
     fn any_epoch_movement_since_the_stamp_refuses_the_elision() {
-        assert!(type11_resident_is_current(Some(4), Some(4)));
-        assert!(!type11_resident_is_current(Some(5), Some(4)));
-        assert!(!type11_resident_is_current(Some(4), Some(5)));
+        assert!(mapper_ref_texture_resident_is_current(Some(4), Some(4)));
+        assert!(!mapper_ref_texture_resident_is_current(Some(5), Some(4)));
+        assert!(!mapper_ref_texture_resident_is_current(Some(4), Some(5)));
     }
 
     /// Every guest-page writer in this crate goes through
@@ -11927,7 +11975,7 @@ mod vulkan_split_tests {
         );
     }
 
-    /// The deferred type-11 publish writes only the host shadow — no guest
+    /// The deferred mapper-ref-texture publish writes only the host shadow — no guest
     /// page, so `mark_mapping_written` never runs — and it is the one writer
     /// that would otherwise change the mapping's pixels invisibly to the epoch.
     /// `surface_cache` holds one entry per mapping, so a sibling Store at
@@ -11976,10 +12024,10 @@ mod vulkan_split_tests {
             load_action: MTL_LOAD_ACTION_LOAD,
             ..Default::default()
         };
-        assert!(type11_load_is_a_seed_candidate(&c0));
+        assert!(mapper_ref_texture_load_is_a_seed_candidate(&c0));
 
         c0.target_seed_rgba = Some(vec![0u8; 4]);
-        assert!(!type11_load_is_a_seed_candidate(&c0));
+        assert!(!mapper_ref_texture_load_is_a_seed_candidate(&c0));
     }
 
     /// A CLEAR is not a LOAD. Eliding a seed there would replace the guest's
@@ -11990,10 +12038,10 @@ mod vulkan_split_tests {
             load_action: MTL_LOAD_ACTION_CLEAR,
             ..Default::default()
         };
-        assert!(!type11_load_is_a_seed_candidate(&c0));
+        assert!(!mapper_ref_texture_load_is_a_seed_candidate(&c0));
     }
 
-    /// A type-11 `LOAD` whose host cache misses seeds from the surface's own
+    /// A mapper-ref-texture `LOAD` whose host cache misses seeds from the surface's own
     /// guest pages, and only refuses when those cannot serve the extent.
     ///
     /// Without the guest-pages rung this returns `None`, `target_rgba8` stays
@@ -12007,13 +12055,13 @@ mod vulkan_split_tests {
     /// Every one of those 121 lines had `want == mapgeom` and `hostgen=0`: the
     /// cache had never held the surface and its pages were readable. That pair is
     /// what makes reading them the fix rather than a guess.
-    /// The lazy type-11 Store publishes a frame nothing has written down yet, so
+    /// The lazy mapper-ref-texture Store publishes a frame nothing has written down yet, so
     /// the host surface cache — the other host-side copy of the same mapping —
     /// must stop naming the frame before it.
     ///
     /// The eager Store's GPU-direct arm ends in `surface_cache::forget` and says
     /// why; the lazy arm published a strictly newer frame and left the entry
-    /// alone. The consumer that would read it is the type-11 sampled ladder's
+    /// alone. The consumer that would read it is the mapper-ref-texture sampled ladder's
     /// host-cache rung, gated on the guest-write witness alone — which cannot
     /// see a publish this device made itself — and sitting above both rungs that
     /// read the guest's pages, so nothing below it corrects the answer.
@@ -12070,13 +12118,14 @@ mod vulkan_split_tests {
         // The third host-side claim on the same window: a compute dispatch's
         // storage image, recorded as holding what the guest's pages hold. This
         // Store supersedes both halves of that claim.
-        let (base_off, bpr, span_end) = crate::runtime::mapping_write::type11_sample_window(
-            state.mappings.get(&mid).expect("mapped above"),
-            w,
-            h,
-            MTL_FORMAT_BGRA8_UNORM,
-        )
-        .expect("a latched geometry resolves its window");
+        let (base_off, bpr, span_end) =
+            crate::runtime::mapping_write::mapper_ref_texture_sample_window(
+                state.mappings.get(&mid).expect("mapped above"),
+                w,
+                h,
+                MTL_FORMAT_BGRA8_UNORM,
+            )
+            .expect("a latched geometry resolves its window");
         let residency = crate::model::ComputeStorageResidencyKey {
             mapping_id: mid,
             map_generation: state.mappings[&mid].map_generation,
@@ -12199,7 +12248,7 @@ mod vulkan_split_tests {
         );
     }
 
-    /// The type-11 zero-copy sampled rail hands the engine the surface's guest
+    /// The mapper-ref-texture zero-copy sampled rail hands the engine the surface's guest
     /// pages, so an owed frame has to be written into them first.
     ///
     /// The rail is exempt from the *settle* and its comment says why: a
@@ -12210,7 +12259,7 @@ mod vulkan_split_tests {
     /// written before the debt rail existed and silently took the payment with
     /// it.
     #[test]
-    fn the_type11_zero_copy_gather_pays_the_frame_those_pages_owe() {
+    fn the_mapper_ref_texture_zero_copy_gather_pays_the_frame_those_pages_owe() {
         use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
         use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
 
@@ -12223,7 +12272,7 @@ mod vulkan_split_tests {
         let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
         let mut host = FakeHost::new();
         // The rail refuses a host whose page views are transient before it ever
-        // builds one — see `type11_zero_copy_declines_transient_host_mappings`.
+        // builds one — see `mapper_ref_texture_zero_copy_declines_transient_host_mappings`.
         host.stable_map_pages = true;
         let mid = 913u32;
         let first_pfn = 0x40u32;
@@ -12263,8 +12312,15 @@ mod vulkan_split_tests {
         );
 
         assert!(
-            try_type11_sample_zero_copy(&mut state, &mut host, mid, w, h, resource.lifetime_ref())
-                .is_some(),
+            try_mapper_ref_texture_sample_zero_copy(
+                &mut state,
+                &mut host,
+                mid,
+                w,
+                h,
+                resource.lifetime_ref()
+            )
+            .is_some(),
             "the rail has to take, or this test proves nothing about what it does"
         );
         assert!(
@@ -12323,7 +12379,7 @@ mod vulkan_split_tests {
     /// over the pages the guest just wrote. The guest's repaint is then gone
     /// from both copies and the next frame loads what this one stored.
     #[test]
-    fn the_type11_load_seed_cache_rung_refuses_a_surface_the_guest_rewrote() {
+    fn the_mapper_ref_texture_load_seed_cache_rung_refuses_a_surface_the_guest_rewrote() {
         use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
         use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
         use crate::runtime::host::HostOps;
@@ -12375,7 +12431,7 @@ mod vulkan_split_tests {
             .get_mut(&mid)
             .expect("mapped above")
             .guest_write_gen_at_store = host.guest_write_gen(token).expect("a live token has one");
-        let Type11LoadSeed::Host(bytes, order) = resolve_type11_load_seed(
+        let MapperRefTextureLoadSeed::Host(bytes, order) = resolve_mapper_ref_texture_load_seed(
             &mut state,
             &mut host,
             mid,
@@ -12401,7 +12457,7 @@ mod vulkan_split_tests {
              test is being asked the wrong question"
         );
 
-        let Type11LoadSeed::Guest(seed) = resolve_type11_load_seed(
+        let MapperRefTextureLoadSeed::Guest(seed) = resolve_mapper_ref_texture_load_seed(
             &mut state,
             &mut host,
             mid,
@@ -12413,7 +12469,7 @@ mod vulkan_split_tests {
             panic!("a repainted surface must bypass the stale host cache");
         };
         assert_eq!(seed.format, ash::vk::Format::B8G8R8A8_UNORM);
-        let (_, bpr, _) = crate::runtime::mapping_write::type11_sample_window(
+        let (_, bpr, _) = crate::runtime::mapping_write::mapper_ref_texture_sample_window(
             &state.mappings[&mid],
             w,
             h,
@@ -12427,7 +12483,7 @@ mod vulkan_split_tests {
     }
 
     #[test]
-    fn a_type11_load_seed_falls_back_to_the_surfaces_own_guest_pages() {
+    fn a_mapper_ref_texture_load_seed_falls_back_to_the_surfaces_own_guest_pages() {
         use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
         use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
         use crate::runtime::mapping_write::write_bgra8;
@@ -12471,7 +12527,7 @@ mod vulkan_split_tests {
         // refused rather than showing a bare `None`: every rung on this ladder
         // declines by name, and the panic message is where that is worth reading.
         let cap = crate::observe::sink::FailCapture::start();
-        let served = resolve_type11_load_seed(
+        let served = resolve_mapper_ref_texture_load_seed(
             &mut state,
             &mut host,
             mid,
@@ -12486,11 +12542,11 @@ mod vulkan_split_tests {
             )
         });
         drop(cap);
-        let Type11LoadSeed::Guest(seed) = seed else {
+        let MapperRefTextureLoadSeed::Guest(seed) = seed else {
             panic!("a cold cache should preserve the native guest-page source");
         };
         assert_eq!(seed.format, ash::vk::Format::B8G8R8A8_UNORM);
-        let (_, bpr, _) = crate::runtime::mapping_write::type11_sample_window(
+        let (_, bpr, _) = crate::runtime::mapping_write::mapper_ref_texture_sample_window(
             &state.mappings[&mid],
             w,
             h,
@@ -12513,7 +12569,7 @@ mod vulkan_split_tests {
             px.copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xFF]);
         }
         crate::runtime::surface_cache::store(&mut state, mid, w, h, cached);
-        let Type11LoadSeed::Host(bytes, order) = resolve_type11_load_seed(
+        let MapperRefTextureLoadSeed::Host(bytes, order) = resolve_mapper_ref_texture_load_seed(
             &mut state,
             &mut host,
             mid,
@@ -12531,7 +12587,7 @@ mod vulkan_split_tests {
         // and refusing is right: a seed of the wrong length is rejected by the
         // engine anyway, and the decline names both geometries.
         assert!(
-            resolve_type11_load_seed(
+            resolve_mapper_ref_texture_load_seed(
                 &mut state,
                 &mut host,
                 mid,
@@ -12544,7 +12600,7 @@ mod vulkan_split_tests {
         );
     }
 
-    /// The type-4 host-cache sample rung must not serve a surface the
+    /// The backing host-cache sample rung must not serve a surface the
     /// hypervisor has watched the guest rewrite.
     ///
     /// That rung sits above both rungs that read the guest's own pages
@@ -12611,7 +12667,7 @@ mod vulkan_split_tests {
         );
     }
 
-    /// The type-11 `LOAD` seed branch reports both ways, and the miss arm names
+    /// The mapper-ref-texture `LOAD` seed branch reports both ways, and the miss arm names
     /// the geometry the cache actually holds.
     ///
     /// The miss is a whole-layer loss, not a degradation: with no seed the engine
@@ -12628,7 +12684,7 @@ mod vulkan_split_tests {
     /// `first_sight` latches per `(reason, discriminant)` for the life of the
     /// process and never resets.
     #[test]
-    fn the_type11_load_seed_branch_reports_both_ways() {
+    fn the_mapper_ref_texture_load_seed_branch_reports_both_ways() {
         let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
         let mid = 909u32;
         state.map_surface(mid);
@@ -12648,14 +12704,14 @@ mod vulkan_split_tests {
             let hits: Vec<String> = cap
                 .lines()
                 .into_iter()
-                .filter(|l| l.contains("type11_load_seed"))
+                .filter(|l| l.contains("mapper_ref_texture_load_seed"))
                 .collect();
             assert_eq!(hits.len(), 1, "expected exactly one line, got {hits:?}");
             hits.into_iter().next().unwrap_or_default()
         };
 
         let cap = crate::observe::sink::FailCapture::start();
-        note_type11_load_seed(&state, mid, 8, 4, Some(Type11SeedRung::Cache));
+        note_mapper_ref_texture_load_seed(&state, mid, 8, 4, Some(MapperRefTextureSeedRung::Cache));
         let hit = only(&cap);
         assert!(hit.contains("outcome=cache_hit"), "{hit}");
         assert!(hit.contains("mapgeom=8x4"), "{hit}");
@@ -12666,7 +12722,13 @@ mod vulkan_split_tests {
         // rate is the only thing that prices the guest-pages fallback, and fusing
         // it would make the fix unmeasurable the moment it worked.
         let cap = crate::observe::sink::FailCapture::resume();
-        note_type11_load_seed(&state, mid, 4, 4, Some(Type11SeedRung::GuestPages));
+        note_mapper_ref_texture_load_seed(
+            &state,
+            mid,
+            4,
+            4,
+            Some(MapperRefTextureSeedRung::GuestPages),
+        );
         let pages = only(&cap);
         assert!(pages.contains("outcome=guest_pages"), "{pages}");
         drop(cap);
@@ -12675,19 +12737,22 @@ mod vulkan_split_tests {
         // geometry is the load-bearing field, since it says a Store at another
         // extent orphaned every window still living at this one.
         let cap = crate::observe::sink::FailCapture::resume();
-        note_type11_load_seed(&state, mid, 8, 1, None);
+        note_mapper_ref_texture_load_seed(&state, mid, 8, 1, None);
         let geom = only(&cap);
-        assert!(geom.contains("reason=type11_seed_cache_geom"), "{geom}");
+        assert!(
+            geom.contains("reason=mapper_ref_texture_seed_cache_geom"),
+            "{geom}"
+        );
         assert!(geom.contains("have=8x4"), "{geom}");
         assert!(geom.contains("want=8x1"), "{geom}");
         drop(cap);
 
         // A mapping the cache has never held reports absence, not a geometry.
         let cap = crate::observe::sink::FailCapture::resume();
-        note_type11_load_seed(&state, 910, 8, 4, None);
+        note_mapper_ref_texture_load_seed(&state, 910, 8, 4, None);
         let absent = only(&cap);
         assert!(
-            absent.contains("reason=type11_seed_cache_absent"),
+            absent.contains("reason=mapper_ref_texture_seed_cache_absent"),
             "{absent}"
         );
         assert!(!absent.contains("have="), "{absent}");
@@ -12699,10 +12764,16 @@ mod vulkan_split_tests {
         // ones made are exactly what this last one asserts, and `start` would
         // clear them and see all four lines again.
         let cap = crate::observe::sink::FailCapture::resume();
-        note_type11_load_seed(&state, mid, 8, 4, Some(Type11SeedRung::Cache));
-        note_type11_load_seed(&state, mid, 4, 4, Some(Type11SeedRung::GuestPages));
-        note_type11_load_seed(&state, mid, 8, 1, None);
-        note_type11_load_seed(&state, 910, 8, 4, None);
+        note_mapper_ref_texture_load_seed(&state, mid, 8, 4, Some(MapperRefTextureSeedRung::Cache));
+        note_mapper_ref_texture_load_seed(
+            &state,
+            mid,
+            4,
+            4,
+            Some(MapperRefTextureSeedRung::GuestPages),
+        );
+        note_mapper_ref_texture_load_seed(&state, mid, 8, 1, None);
+        note_mapper_ref_texture_load_seed(&state, 910, 8, 4, None);
         assert!(
             cap.lines().is_empty(),
             "second sighting must be latched: {:?}",
@@ -12806,17 +12877,17 @@ mod vulkan_split_tests {
 
         // Routes distinct from every product route so this test cannot be
         // satisfied by a line some other case in this binary emitted.
-        note_type11_store_route("test_route_a");
-        note_type11_store_route("test_route_a");
-        note_type11_store_route("test_route_a");
-        note_type11_store_route("test_route_b");
+        note_mapper_ref_texture_store_route("test_route_a");
+        note_mapper_ref_texture_store_route("test_route_a");
+        note_mapper_ref_texture_store_route("test_route_a");
+        note_mapper_ref_texture_store_route("test_route_b");
 
         let whole = std::fs::read_to_string(path).expect("fail log");
         let appended = &whole[mark.min(whole.len())..];
         let count = |route: &str| {
             appended
                 .lines()
-                .filter(|l| l.contains(&format!("type11_store_route route={route}")))
+                .filter(|l| l.contains(&format!("mapper_ref_texture_store_route route={route}")))
                 .count()
         };
         assert_eq!(count("test_route_a"), 1, "three calls, one line");
@@ -13309,7 +13380,7 @@ pub fn encode_icb_execute_and_writeback<M: HostMemory + HostOps>(
 /// a direction, because that is what makes the call sites auditable: a readback's
 /// order is a property of the attachment it came out of, so the caller states the
 /// fact it was told and the ordering logic lives here. Spelled as a direction
-/// ("swizzle if type-11") each site would re-derive the predicate, which is how
+/// ("swizzle if mapper-ref-texture") each site would re-derive the predicate, which is how
 /// the two halves of a conversion end up disagreeing.
 ///
 /// The exchange is an involution, so one routine serves both directions. Trailing
@@ -13549,10 +13620,10 @@ pub(super) fn depth_stencil_descriptor_is_trivial(
         && !d.back_stencil_enabled
 }
 
-/// Decode the type-7 depth-stencil descriptor a draw bound, on the Linux path
+/// Decode the serializer-object depth-stencil descriptor a draw bound, on the Linux path
 /// (the Metal `load_depth_stencil_state` is `backend-metal`-gated). Mirrors
 /// `load_render_pipeline`: object-list lookup → descriptor read → decode (which
-/// validates the type-7 depth-stencil tag). Returns the specific reason slug on
+/// validates the serializer-object depth-stencil tag). Returns the specific reason slug on
 /// failure so the caller — which only reaches this for a bound `ds_ref != 0`, i.e.
 /// a guest that explicitly asked for a depth-stencil state — can fail-visibly
 /// name why the state silently fell back to no-depth instead of dropping it into
@@ -13567,9 +13638,14 @@ pub(super) fn load_depth_stencil_descriptor<M: HostMemory + HostOps>(
         crate::runtime::drain::note_store_route("ds_state_held");
         return Ok((*state_).clone());
     }
-    let (_entry, desc) =
-        objects::resolve_descriptor(state, host, task_id, ds_ref, &[OBJECT_TYPE_TYPE7])
-            .map_err(crate::observe::ladder_slugs!("depth_stencil"))?;
+    let (_entry, desc) = objects::resolve_descriptor(
+        state,
+        host,
+        task_id,
+        ds_ref,
+        &[OBJECT_TYPE_SERIALIZER_OBJECT],
+    )
+    .map_err(crate::observe::ladder_slugs!("depth_stencil"))?;
     let decoded = decode_depth_stencil_descriptor(&desc)
         .map_err(|_| crate::observe::ladder_slug!("depth_stencil", desc_decode))?;
     // Registered only after a successful decode, on the same terms as
@@ -14337,7 +14413,7 @@ impl std::fmt::Display for PlaneDrawDrain {
 ///
 /// Called from the draw encode's own entry, which every draw reaches. The
 /// latched census below sits at the colour-seed site instead, and that site is
-/// skipped whenever the type-11 seed is elided — which is the overwhelming
+/// skipped whenever the mapper-ref-texture seed is elided — which is the overwhelming
 /// majority of passes (about 1 000 elided against 50 provided on a boot), so a
 /// ring filled there recorded one pass out of a frame's worth and missed
 /// whichever one it was supposed to name.
@@ -14471,8 +14547,8 @@ fn prepare_memo_scratch(scratch: &mut Vec<u8>, span: usize, filled: usize) {
     scratch[filled..].fill(0);
 }
 
-/// Byte-exact revalidated memo for the type-11 mapping-backed guest-page sampled
-/// path. Same contract as [`load_linear_guest_memoized`] / the type-5 view memo:
+/// Byte-exact revalidated memo for the mapper-ref-texture mapping-backed guest-page sampled
+/// path. Same contract as [`load_linear_guest_memoized`] / the ref-texture view memo:
 /// re-read the native BGRA rect every bind (a guest CPU write is always
 /// observed — neither `map_generation` nor `content_generation` tracks in-place
 /// guest writes), memcmp against the memo, and on an unchanged hit return the
@@ -14481,7 +14557,7 @@ fn prepare_memo_scratch(scratch: &mut Vec<u8>, span: usize, filled: usize) {
 /// magnification burst re-binds the same static icons ~1000×, so this collapses
 /// the `t11_guest` CPU copies that saturate the serial drain worker (the
 /// dock-hover whole-VM freeze). Returns `(rgba, identity)`.
-fn load_type11_rgba_memoized<M: HostMemory + HostOps>(
+fn load_mapper_ref_texture_rgba_memoized<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     mid: u32,
@@ -14502,7 +14578,7 @@ fn load_type11_rgba_memoized<M: HostMemory + HostOps>(
     // Coherence re-read: land any resident-authoritative writeback and read the
     // current native BGRA (read_mapping_bgra8 runs ensure_resolved_for_scanout +
     // flush internally). Reuse the scratch so a memo hit costs no allocation.
-    let mut scratch = std::mem::take(&mut state.type11_memo_scratch);
+    let mut scratch = std::mem::take(&mut state.mapper_ref_texture_memo_scratch);
     prepare_memo_scratch(
         &mut scratch,
         span,
@@ -14511,21 +14587,21 @@ fn load_type11_rgba_memoized<M: HostMemory + HostOps>(
     if !{
         crate::runtime::scanout::read_mapping_bgra8(state, host, mid, &mut scratch, stride, w, h)
     } {
-        state.type11_memo_scratch = scratch;
+        state.mapper_ref_texture_memo_scratch = scratch;
         return None;
     }
-    // Identity key namespace: bits 63+62 mark type-11 memo content, distinct from
-    // raw-GVA keys (bit 63 clear) and type-5 view keys (bit 63 set, bit 62 clear).
+    // Identity key namespace: bits 63+62 mark mapper-ref-texture memo content, distinct from
+    // raw-GVA keys (bit 63 clear) and ref-texture view keys (bit 63 set, bit 62 clear).
     // Every producer draws its generation from
     // `DeviceState::next_sampled_content_generation`, so a (key, generation)
     // pair is unique device-wide and content can never alias on a collision.
     let identity_key = (1u64 << 63) | (1u64 << 62) | mid as u64;
     let key = (mid, w, h);
-    if let Some(m) = state.type11_memo.get_touch(&key) {
+    if let Some(m) = state.mapper_ref_texture_memo.get_touch(&key) {
         if m.native == scratch {
             let rgba = m.rgba.clone();
             let generation = m.generation;
-            state.type11_memo_scratch = scratch;
+            state.mapper_ref_texture_memo_scratch = scratch;
             return Some((
                 rgba,
                 LinearSampleIdentity {
@@ -14547,13 +14623,13 @@ fn load_type11_rgba_memoized<M: HostMemory + HostOps>(
         )
     });
     if !converted {
-        state.type11_memo_scratch = scratch;
+        state.mapper_ref_texture_memo_scratch = scratch;
         return None;
     }
     let rgba = std::sync::Arc::new(rgba);
     let generation = state.next_sampled_content_generation();
     let entry_bytes = scratch.len() + rgba.len();
-    state.type11_memo.insert(
+    state.mapper_ref_texture_memo.insert(
         key,
         crate::model::GuestLinearMemo {
             native: scratch,

--- a/crates/reims-vgpu/src/runtime/exec/mod.rs
+++ b/crates/reims-vgpu/src/runtime/exec/mod.rs
@@ -77,7 +77,7 @@ struct RenderIcbExecute {
 /// Archive `apple_pv_gpu_render_worker_run` executes **every** draw in order,
 /// seeding draw N from draw N-1's writeback. Product previously kept only
 /// `last_draw`, which dropped the logo when the pill was the final draw in the
-/// same stream (journal: logo RG8 168×206 + pill → one type-11 FB).
+/// same stream (journal: logo RG8 168×206 + pill → one mapper-ref-texture FB).
 #[derive(Clone, Debug, Default)]
 struct PendingDraw {
     pipeline_ref: u32,
@@ -520,7 +520,7 @@ pub struct ExecResult {
     /// The caller must keep this packet at the channel head and retry it.
     pub deferred: bool,
     pub texture_refs: Vec<u32>,
-    pub type11_mappings: Vec<u32>,
+    pub mapper_ref_texture_mappings: Vec<u32>,
     pub saw_draw: bool,
     pub clears_applied: u32,
     pub metal_draws_ok: u32,
@@ -776,7 +776,7 @@ fn note_exec_header(exec_started: std::time::Instant, measured_ns: u64) {
 ///
 /// `validity_unknown_object` is **not** by itself a defect either, and a reader
 /// scoring it needs to know why: `DeviceState::objects` is populated lazily, by
-/// `objects::resolve_type11_ref` and `resolve_type4_surface_ex` at the moment a
+/// `objects::resolve_mapper_ref_texture` and `resolve_backing_ex` at the moment a
 /// decoded command names a ref. A resource the guest has created in its own
 /// object list but has not yet named in an executed stream is absent from the
 /// set by construction. The table names the submission's whole residency list,
@@ -1027,7 +1027,7 @@ fn handle_info_record<M: HostMemory + HostOps>(
     if opcode == INFO_OP_ICB_HOST_RESOURCE {
         // `icb_backing_fail` was a counter with no reason beside it: an ICB
         // whose command memory never bound looked identical whether the payload
-        // was malformed, the type-1 buffer was short, or the pathway has no ICB
+        // was malformed, the buffer was short, or the pathway has no ICB
         // execution at all. Latched per ICB ref — the guest re-sends `0x1d1`
         // for the same ICB, so an unlatched line would be one per frame.
         //
@@ -1358,7 +1358,7 @@ fn handle_blit_record<M: HostMemory + HostOps>(
         // decides whether an executor is worth building.
         //
         // Not executed here on purpose. A texture fill needs the destination
-        // resolved through the type-4/5/11 rails, the region walked per row,
+        // resolved through the backing/5/11 rails, the region walked per row,
         // and — for the colour form — the clear colour converted into the
         // texture's pixel format, which is a converter this device does not
         // have. The count is what says whether to build one, and for which of
@@ -1624,15 +1624,16 @@ fn handle_render_record<M: HostMemory + HostOps>(
                     if !out.texture_refs.contains(&texture_ref) {
                         out.texture_refs.push(texture_ref);
                     }
-                    if let Some(m) = objects::resolve_type11_ref(state, host, task_id, texture_ref)
+                    if let Some(m) =
+                        objects::resolve_mapper_ref_texture(state, host, task_id, texture_ref)
                     {
-                        if !out.type11_mappings.contains(&m) {
-                            out.type11_mappings.push(m);
+                        if !out.mapper_ref_texture_mappings.contains(&m) {
+                            out.mapper_ref_texture_mappings.push(m);
                         }
-                    } else if objects::resolve_type4_surface(state, host, texture_ref) {
-                        // x86 type-4: object ref is surface_id / mapping_id.
-                        if !out.type11_mappings.contains(&texture_ref) {
-                            out.type11_mappings.push(texture_ref);
+                    } else if objects::resolve_backing(state, host, texture_ref) {
+                        // x86 backing: object ref is surface_id / mapping_id.
+                        if !out.mapper_ref_texture_mappings.contains(&texture_ref) {
+                            out.mapper_ref_texture_mappings.push(texture_ref);
                         }
                     }
                     Some(TextureBind {
@@ -1869,19 +1870,19 @@ fn handle_render_record<M: HostMemory + HostOps>(
                         out.texture_refs.push(att.resolve_texture_ref);
                     }
                     if let Some(m) =
-                        objects::resolve_type11_ref(state, host, task_id, published_ref)
+                        objects::resolve_mapper_ref_texture(state, host, task_id, published_ref)
                     {
                         note_pass_extent_for_slot(state, task_id, slot, m, &cmd);
-                        if !out.type11_mappings.contains(&m) {
-                            out.type11_mappings.push(m);
+                        if !out.mapper_ref_texture_mappings.contains(&m) {
+                            out.mapper_ref_texture_mappings.push(m);
                         }
-                    } else if objects::resolve_type4_surface(state, host, published_ref) {
-                        // A type-4 attachment is its own mapping id — the arm
-                        // below pushes `att.texture_ref` where the type-11 arm
+                    } else if objects::resolve_backing(state, host, published_ref) {
+                        // A backing attachment is its own mapping id — the arm
+                        // below pushes `att.texture_ref` where the mapper-ref-texture arm
                         // pushes the id it resolved to.
                         note_pass_extent_for_slot(state, task_id, slot, published_ref, &cmd);
-                        if !out.type11_mappings.contains(&published_ref) {
-                            out.type11_mappings.push(published_ref);
+                        if !out.mapper_ref_texture_mappings.contains(&published_ref) {
+                            out.mapper_ref_texture_mappings.push(published_ref);
                         }
                     }
                     // The load action decides this, and only the load action.
@@ -2800,7 +2801,7 @@ struct BindTables<'a, B> {
 ///
 /// `make` builds the bind for a live slot and returns `None` for the zero ref,
 /// which keeps the ref field's name — and any side registration, such as the
-/// texture arm's type-11 mapping list — with the caller. The clear count comes
+/// texture arm's mapper-ref-texture mapping list — with the caller. The clear count comes
 /// back as a return value rather than through an `&mut` counter so `make` can
 /// hold the rest of `ExecResult`.
 fn apply_binds<T: Copy, B: Clone>(
@@ -3223,7 +3224,7 @@ fn finish_stream<M: HostMemory + HostOps>(
                 fill_draw_binds_from_pending(&mut req, pd);
                 (req.continues_render_pass, req.render_pass_continues) =
                     render_pass_chain_position(di, draw_list.len());
-                // A resident type-11 target carries attachment contents between
+                // A resident mapper-ref-texture target carries attachment contents between
                 // records without a CPU chain buffer. Like a native Metal render
                 // pass, only the final record performs the guest-visible Store;
                 // importing a full frame after every draw held DeviceInner for
@@ -3235,7 +3236,7 @@ fn finish_stream<M: HostMemory + HostOps>(
                     .unwrap_or(false);
                 // Records 2+ of a chain composite over the prior record: force
                 // loadAction=Load on every color. Leaving the pass action alone
-                // on a type-11 target let a CLEAR re-run before each record,
+                // on a mapper-ref-texture target let a CLEAR re-run before each record,
                 // wiping the full composite drawn by record 1 (live poison=1:
                 // mid peak 10.9M native → 2.5M after later records).
                 if di > 0 {
@@ -3245,7 +3246,7 @@ fn finish_stream<M: HostMemory + HostOps>(
                     // Chain from the engine resident when available; otherwise
                     // seed from the prior encode output (archive "thread each
                     // record's output as next initial content"). MoltenVK's
-                    // portability path returns CPU pixels for type-11 mappings,
+                    // portability path returns CPU pixels for mapper-ref-texture mappings,
                     // so `unified` does not imply that a resident exists.
                     // Moved, not cloned (multi-MiB).
                     match multi_draw_chain_source(resident_chain, chain_rgba.is_some()) {
@@ -3866,11 +3867,11 @@ fn dirty_color_targets<M: HostMemory + HostOps>(
     refs: &[u32],
 ) {
     for &tex_ref in refs {
-        if let Some(mid) = objects::resolve_type11_ref(state, host, task_id, tex_ref) {
-            // The guest pages are the only copy of a type-11 surface, so there
+        if let Some(mid) = objects::resolve_mapper_ref_texture(state, host, task_id, tex_ref) {
+            // The guest pages are the only copy of a mapper-ref-texture surface, so there
             // is no mirror to drop — only bump gen for scanout skips.
             let _ = state.mark_mapping_written(mid);
-        } else if objects::resolve_type4_surface(state, host, tex_ref) {
+        } else if objects::resolve_backing(state, host, tex_ref) {
             let _ = state.mark_mapping_written(tex_ref);
         }
     }
@@ -4032,7 +4033,7 @@ fn apply_clear<M: HostMemory + HostOps>(
             return false;
         }
     };
-    // Prefer full draw-path resolve (type-11 or type-2/3 GVA wallpaper targets).
+    // Prefer full draw-path resolve (mapper-ref-texture or normal-texture GVA wallpaper targets).
     let Some(req) =
         // A clear-only pass: no pipeline and no geometry, so every draw
         // argument including the base instance is zero by construction.

--- a/crates/reims-vgpu/src/runtime/exec/report.rs
+++ b/crates/reims-vgpu/src/runtime/exec/report.rs
@@ -275,11 +275,11 @@ pub(super) const PASS_EXTENT_SLUGS: [&str; 7] = [
 /// Score slot 0's attachment, whichever resolve arm found it.
 ///
 /// Both arms of the colour-attachment resolve consume the same wire form and
-/// must be scored the same way; only the mapping id differs, because a type-11
-/// attachment resolves *to* an id and a type-4 attachment *is* one. This existed
-/// on the type-11 arm alone, and the consequence was not that the census
+/// must be scored the same way; only the mapping id differs, because a mapper-ref-texture
+/// attachment resolves *to* an id and a backing attachment *is* one. This existed
+/// on the mapper-ref-texture arm alone, and the consequence was not that the census
 /// undercounted — it was that the census read **zero** on the whole x86/Vulkan
-/// pathway, where the workload takes the type-4 arm. A pathway-shaped blind spot
+/// pathway, where the workload takes the backing arm. A pathway-shaped blind spot
 /// reads exactly like "the guest never states an extent", which is the opposite
 /// of what it does.
 ///

--- a/crates/reims-vgpu/src/runtime/exec/tests.rs
+++ b/crates/reims-vgpu/src/runtime/exec/tests.rs
@@ -308,7 +308,7 @@ fn an_unknown_segment_family_is_refused_and_the_type_5_envelope_is_not() {
         segment_disposition, SegmentDisposition, SEGMENT_TYPE_BLIT, SEGMENT_TYPE_PROTECTION_OPTIONS,
     };
     // `walk_stream` ended in `_ => {}`, which gave one silence to two very
-    // different things. Type 5 is a contract-correct skip; type 6 is wire
+    // different things. Ref-texture is a contract-correct skip; function is wire
     // format the host has never seen.
     assert_eq!(
         segment_disposition(SEGMENT_TYPE_PROTECTION_OPTIONS),
@@ -1082,10 +1082,10 @@ fn the_pass_extent_census_scores_a_fraction_and_clamps_it() {
 /// The extent census scores whichever resolve arm supplied the mapping id,
 /// and only for slot 0.
 ///
-/// This is the arm-parity test. The census used to hang off the type-11
+/// This is the arm-parity test. The census used to hang off the mapper-ref-texture
 /// resolve alone, so on the x86/Vulkan pathway — where the workload takes
-/// the type-4 arm — every band read zero, which is indistinguishable from a
-/// guest that never states an extent. A type-4 attachment *is* its own
+/// the backing arm — every band read zero, which is indistinguishable from a
+/// guest that never states an extent. A backing attachment *is* its own
 /// mapping id, so the only difference between the two call sites is which
 /// id they pass, and this pins that the scoring does not care which.
 #[test]
@@ -1745,12 +1745,11 @@ fn accepted_render_without_executor_is_fail_visible() {
     };
     let task_id = 0xfeed;
     let mut command = vec![0u8; OP_HEADER_LEN];
-    // An opcode inside the encoder's range that no arm claims, found rather
-    // than named. It used to be `wire_render::OPCODE_SET_VERTEX_BUFFER_OFFSET_STRIDE`, which stopped working
-    // the moment that bound was corrected to `0xa6` -- because `0xa6` is a
-    // record this rail now decodes. `0x99` was the replacement and lasted
-    // one commit, until `setVertexAmplificationMode:value:` turned out to be
-    // that number. The catch-all is what is under test, not any literal.
+    // An opcode inside the encoder's range that no arm claims, found rather than named. It used to
+    // be `wire_render::OPCODE_SET_VERTEX_BUFFER_OFFSET_STRIDE`, which stopped working the moment
+    // that bound was corrected to `0xa6` -- because `0xa6` is a record this rail now decodes.
+    // `0x99` was the replacement and lasted one commit, until `setVertexAmplificationMode:value:`
+    // turned out to be that number. The catch-all is what is under test, not any literal.
     let op = render::unclaimed_accepted_opcode();
     st32(&mut command[0..], op);
     st32(&mut command[4..], OP_HEADER_LEN as u32);
@@ -1946,14 +1945,14 @@ fn zero_ref_render_bind_unbinds_existing_slots() {
     assert_eq!(out.sampler_unbinds, 1);
 }
 
-/// x86 type-4 display mid: clear-only stream must Store solid BGRA into pages.
+/// x86 backing display mid: clear-only stream must Store solid BGRA into pages.
 #[test]
-fn clear_only_type4_surface_writes_guest_pages() {
+fn clear_only_backing_surface_writes_guest_pages() {
     use crate::contract::endian::{st32, st64};
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
     use crate::runtime::decode::render::ColorAttachment;
-    use crate::runtime::objects::{self, OBJECT_TYPE_SURFACE};
+    use crate::runtime::objects::{self, OBJECT_TYPE_BACKING};
 
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -1981,11 +1980,11 @@ fn clear_only_type4_surface_writes_guest_pages() {
     let _ = host.write_gpa(root_gpa + 0x40 * 4, &d[..4]);
     state.define_task(1, 0x1000, 2);
     assert!(state.set_object_list(1, 0, 8));
-    // Type-4 at surface_id=5.
+    // Backing at surface_id=5.
     let mut entry = [0u8; 12];
     st32(
         &mut entry[0..],
-        (OBJECT_TYPE_SURFACE as u32) | (0x30u32 << 8),
+        (OBJECT_TYPE_BACKING as u32) | (0x30u32 << 8),
     );
     entry[4..12].copy_from_slice(&0x80u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa + 5 * 12, &entry);
@@ -1999,7 +1998,7 @@ fn clear_only_type4_surface_writes_guest_pages() {
     st32(&mut desc[0x20..], 64);
     let _ = host.write_gpa(data_gpa + 0x80, &desc);
 
-    assert!(objects::resolve_type4_surface(&mut state, &host, 5));
+    assert!(objects::resolve_backing(&mut state, &host, 5));
     let mut out = ExecResult::default();
     let mut acc = StreamAccum::default();
     acc.clears.push(ColorAttachment {
@@ -2015,7 +2014,7 @@ fn clear_only_type4_surface_writes_guest_pages() {
     finish_stream(&mut state, &mut host, 1, &mut out, &acc);
     assert!(
         out.clears_applied >= 1,
-        "type-4 clear must apply, got {}",
+        "backing clear must apply, got {}",
         out.clears_applied
     );
     // Read first pixel from guest page (BGRA).
@@ -2057,7 +2056,7 @@ fn finish_stream_clear_only_branch_without_draws() {
 ///
 /// The GPU draw path already carries the clear as a typed union member. This
 /// exercises the other publication path: no draw exists, so `finish_stream`
-/// must materialize the result directly in the type-11 mapping's native texels.
+/// must materialize the result directly in the mapper-ref-texture mapping's native texels.
 #[test]
 fn clear_only_rg16uint_publishes_native_guest_texels() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
@@ -2082,13 +2081,13 @@ fn clear_only_rg16uint_publishes_native_guest_texels() {
         .texture_to_mapping
         .insert((task_id, texture_ref), mapping_id);
 
-    let (_, row_stride, _) = mapping_write::type11_sample_window(
+    let (_, row_stride, _) = mapping_write::mapper_ref_texture_sample_window(
         state.mappings.get(&mapping_id).expect("mapping"),
         2,
         2,
         MTL_FORMAT_RG16_UINT,
     )
-    .expect("the type-11 texture has a sample window");
+    .expect("the mapper-ref-texture has a sample window");
     assert!(row_stride >= 2 * RG16_BPP);
 
     let mut acc = StreamAccum::default();
@@ -2120,7 +2119,7 @@ fn clear_only_rg16uint_publishes_native_guest_texels() {
     }
 }
 
-/// The same clear representation reaches a linear type-2/3 target, including
+/// The same clear representation reaches a linear normal-texture target, including
 /// its guest-declared row pitch rather than a tightly packed substitute.
 #[test]
 fn clear_only_rg16uint_publishes_native_linear_gva_rows() {
@@ -2296,14 +2295,14 @@ fn finish_stream_with_draws_skips_guest_clear_prelude() {
     );
 }
 
-/// Linux NoMetal: draws fail but CLEAR seed still Stores into type-4 pages.
+/// Linux NoMetal: draws fail but CLEAR seed still Stores into backing pages.
 #[test]
-fn nometal_draw_falls_back_to_type4_clear() {
+fn nometal_draw_falls_back_to_backing_clear() {
     use crate::contract::endian::{st32, st64};
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::runtime::decode::render::ColorAttachment;
     use crate::runtime::draw::BufferBind;
-    use crate::runtime::objects::{self, OBJECT_TYPE_SURFACE};
+    use crate::runtime::objects::{self, OBJECT_TYPE_BACKING};
 
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -2330,7 +2329,7 @@ fn nometal_draw_falls_back_to_type4_clear() {
     let mut entry = [0u8; 12];
     st32(
         &mut entry[0..],
-        (OBJECT_TYPE_SURFACE as u32) | (0x30u32 << 8),
+        (OBJECT_TYPE_BACKING as u32) | (0x30u32 << 8),
     );
     entry[4..12].copy_from_slice(&0x80u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa + 5 * 12, &entry);
@@ -2343,7 +2342,7 @@ fn nometal_draw_falls_back_to_type4_clear() {
     st32(&mut desc[0x1c..], 16);
     st32(&mut desc[0x20..], 64);
     let _ = host.write_gpa(data_gpa + 0x80, &desc);
-    assert!(objects::resolve_type4_surface(&mut state, &host, 5));
+    assert!(objects::resolve_backing(&mut state, &host, 5));
 
     let mut out = ExecResult::default();
     let mut acc = StreamAccum::default();
@@ -2404,7 +2403,7 @@ fn nometal_draw_falls_back_to_type4_clear() {
         out.render_attachment_resolves, 1,
         "one render stream resolves its fixed attachment set once"
     );
-    // Non-Apple: Linux encode Stores CLEAR load into type-4 (Ok) or
+    // Non-Apple: Linux encode Stores CLEAR load into backing (Ok) or
     // NoMetal clear fallback — either path must land green BGRA.
     #[cfg(feature = "backend-vulkan")]
     {
@@ -3547,7 +3546,7 @@ fn an_indirect_draw_takes_its_counts_from_the_guest_buffer() {
     };
     use crate::runtime::gva_mem::{self, write_task_gva_arm64e};
 
-    // A type-1 buffer at ref 7 holding `words`, resolvable through the task's
+    // A buffer at ref 7 holding `words`, resolvable through the task's
     // own page table — the shape `resolve_indirect_threadgroups_from_buffer`
     // uses on the compute rail.
     let build = |words: &[u32]| {
@@ -5008,7 +5007,7 @@ fn a_visibility_count_lands_at_the_guest_offset_the_pass_named() {
     state.define_task(1, 0x1000, dir_pfn);
     assert!(state.set_object_list(1, 0, 32));
 
-    // A type-1 buffer of one page at handle 5, named by object ref 7 — the
+    // A buffer of one page at handle 5, named by object ref 7 — the
     // `handle << page_shift` shape `resolve_buffer_span` decodes.
     const BUF_REF: u32 = 7;
     const BUF_HANDLE: u32 = 5;
@@ -5358,7 +5357,7 @@ fn clear_fallback_draw_accounting_is_scoped_to_one_render_stream() {
 ///
 /// # The contract
 ///
-/// On rail macos-15 the guest renders 300x300 tiles into type-2/3 linear
+/// On rail macos-15 the guest renders 300x300 tiles into normal-texture linear
 /// textures whose descriptors declare `sampleCount = 4`, and it sizes those
 /// allocations to match: the boot's `gva_view_fragmented ... pages=352` at two
 /// separate targets fixes `height * bpr` inside `(351, 352] * 4096`, which for

--- a/crates/reims-vgpu/src/runtime/gather_witness.rs
+++ b/crates/reims-vgpu/src/runtime/gather_witness.rs
@@ -1,7 +1,7 @@
 //! Which sampled windows the engine may bind without reading a byte of guest RAM.
 //!
 //! The three zero-copy sampled producers ([`super::draw::vulkan`]'s
-//! linear, type-11 and type-5 rails) hand the engine a
+//! linear, mapper-ref-texture and ref-texture rails) hand the engine a
 //! [`crate::backend::vulkan::engine::SampledSource::GuestRuns`], and the engine's
 //! only byte-moving arm gathers the whole window out of guest RAM into a staging
 //! buffer. That arm had no content cache — measured on a driven x86/PCI boot at
@@ -259,7 +259,7 @@
 //! page above the first non-RAM byte, and nothing unwound it short of a reboot.
 //!
 //! It is worth recognising from the other side too, because the same step drives
-//! `runtime::draw`'s type-11 sampled rung into
+//! `runtime::draw`'s mapper-ref-texture sampled rung into
 //! `t11rung_resident_refused`, whose merge skips every page the witness claims
 //! and so leaves a GPU-side composite reading blank. Twelve recorded boots
 //! separated on this counter with no overlap — 155-186 clean against
@@ -306,10 +306,10 @@ use crate::contract::fnv;
 pub enum GatherRail {
     /// Linear guest texture addressed through task GVA.
     Linear,
-    /// Type-11 mapping-backed sampled bind.
-    Type11,
-    /// Type-5 serialized IOSurface plane view (the video path).
-    Type5,
+    /// Mapper-ref-texture mapping-backed sampled bind.
+    MapperRefTexture,
+    /// Ref-texture serialized IOSurface plane view (the video path).
+    RefTexture,
 }
 
 impl GatherRail {
@@ -317,8 +317,8 @@ impl GatherRail {
     fn names(self) -> (&'static str, &'static str) {
         match self {
             Self::Linear => ("gw_rail_linear", "gw_rail_linear_kb"),
-            Self::Type11 => ("gw_rail_t11", "gw_rail_t11_kb"),
-            Self::Type5 => ("gw_rail_t5", "gw_rail_t5_kb"),
+            Self::MapperRefTexture => ("gw_rail_t11", "gw_rail_t11_kb"),
+            Self::RefTexture => ("gw_rail_t5", "gw_rail_t5_kb"),
         }
     }
 }
@@ -327,7 +327,7 @@ impl GatherRail {
 ///
 /// The two shapes are the two ways the producers name a window: a task-GVA span
 /// (the linear texture rail, which has no mapping) and a mapping-relative offset
-/// (the type-11 and type-5 rails). Those two rails can name the same
+/// (the mapper-ref-texture and ref-texture rails). Those two rails can name the same
 /// `(mid, base_off)` for a single-plane surface, and that is harmless — same
 /// mapping, same offset and same span is the same bytes.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/crates/reims-vgpu/src/runtime/gva_mem.rs
+++ b/crates/reims-vgpu/src/runtime/gva_mem.rs
@@ -146,7 +146,7 @@ pub fn read_task_gva_by_id<M: HostMemory>(
 ///
 /// There is exactly one such shape in this device and it is worth naming,
 /// because using the loud read for it put 18 lines per boot on the fail channel
-/// that meant nothing. `objects::type4_probe_order` walks the live tasks asking
+/// that meant nothing. `objects::backing_probe_order` walks the live tasks asking
 /// "does this one own surface N?", and a task that does not own it has no entry
 /// at that slot — so the walk *must* miss on every task before the owner. The
 /// miss is how the search works.

--- a/crates/reims-vgpu/src/runtime/gva_store_witness.rs
+++ b/crates/reims-vgpu/src/runtime/gva_store_witness.rs
@@ -3,16 +3,16 @@
 //!
 //! # Why this exists
 //!
-//! A type-11 render Store publishes into a mapping, and the device can ask
+//! A mapper-ref-texture render Store publishes into a mapping, and the device can ask
 //! whether anything has written that mapping since — the token lives on
 //! [`crate::model::MappingEntry`] and
 //! [`crate::runtime::mapper::mapping_guest_write_verdict`] reads it. That
-//! witness is what licenses the type-11 attachment LOAD elision, which serves a
+//! witness is what licenses the mapper-ref-texture attachment LOAD elision, which serves a
 //! `MTLLoadActionLoad` straight out of the engine resident instead of reading a
 //! whole frame back out of guest memory: one driven boot elided **11 484** seeds
 //! against 94 uploaded.
 //!
-//! A **GVA** (type-2/3) render target has no mapping and so had no witness, and
+//! A **GVA** (normal-texture) render target has no mapping and so had no witness, and
 //! its LOAD reads the attachment's full span out of guest pages every time —
 //! `load_seed_ok_color` 4 949 per driven Safari-drag boot, blocking on a
 //! guest-write settle for 2 923 of them, because those are exactly the pages the
@@ -25,7 +25,7 @@
 //! * **The guest CPU** wrote the span. Only the hypervisor's dirty bitmap can
 //!   see this, through a token registered over the target's pages.
 //! * **This device** wrote the span through some other rail — a compute
-//!   writeback, a blit, a type-11 write whose pages alias it. The hypervisor
+//!   writeback, a blit, a mapper-ref-texture write whose pages alias it. The hypervisor
 //!   cannot see those; [`crate::runtime::host_writes`] is the record that can,
 //!   and aliasing across id namespaces is real rather than theoretical (see that
 //!   module's own doc).
@@ -37,7 +37,7 @@
 //! # Why the key is the whole identity
 //!
 //! A token registered over one page list says nothing about another, and the
-//! guest recycles GVAs. The type-11 twin handles this with an explicit
+//! guest recycles GVAs. The mapper-ref-texture twin handles this with an explicit
 //! `guest_write_token_gen != map_generation` check that a future writer has to
 //! remember. Here the page-set hash *is part of the key*
 //! (`draw::vulkan::gva_span_alloc_generation`, the same value the engine
@@ -328,7 +328,7 @@ pub fn retire_pages(state: &mut DeviceState, gone: &[u64]) {
 /// Every variant but [`GvaWriteReach::Quiet`] means "assume written". They are
 /// kept apart because "this rail never got started", "the guest rewrites this
 /// target every frame" and "the record aged out" are the same refusal and three
-/// completely different findings — the same reason the type-11 twin splits its
+/// completely different findings — the same reason the mapper-ref-texture twin splits its
 /// own.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GvaWriteReach {

--- a/crates/reims-vgpu/src/runtime/gva_view.rs
+++ b/crates/reims-vgpu/src/runtime/gva_view.rs
@@ -1108,7 +1108,7 @@ mod tests {
     /// The rail's whole shape is that the destination is not knowable from the
     /// call — it is whatever the task's page table says at write time — so the
     /// footprint has to be marked from the *resolved* GPA. Marking from the GVA
-    /// instead would be the same substitution the type-4 identity guard exists
+    /// instead would be the same substitution the backing identity guard exists
     /// to refuse, and it would fill the set with addresses in low guest RAM,
     /// which is exactly where the panic census's victims live. Every such frame
     /// would then read as a hit.

--- a/crates/reims-vgpu/src/runtime/heap_query.rs
+++ b/crates/reims-vgpu/src/runtime/heap_query.rs
@@ -47,7 +47,7 @@ pub struct TextureDescriptor {
     pub resource_options: u16,
     pub protection_options: u64,
     /// `MTLTextureSwizzleChannels` as four raw `MTLTextureSwizzle` ordinals in
-    /// red, green, blue, alpha order — the same encoding the type-8 swizzle
+    /// red, green, blue, alpha order — the same encoding the texture-view swizzle
     /// view carries, so [`crate::contract::pixel_format::swizzle_plan`] reads
     /// both.
     ///

--- a/crates/reims-vgpu/src/runtime/icb/metal.rs
+++ b/crates/reims-vgpu/src/runtime/icb/metal.rs
@@ -1,7 +1,7 @@
 //! The Metal rail's half of the indirect command buffer: the host
 //! `MTLIndirectCommandBuffer` its parent's decode describes.
 //!
-//! [`super`] owns the guest contract — the type-7 descriptor, the command
+//! [`super`] owns the guest contract — the serializer-object descriptor, the command
 //! layout, and the encode/decode of one command slot's bytes — and that half is
 //! rail-neutral by construction: it is the guest's own serialization and it
 //! reads the same whichever rail executes it. Everything here is the other
@@ -197,7 +197,7 @@ pub fn fill_icb_from_command_memory<M: HostMemory + HostOps>(
     Ok(())
 }
 
-/// An attribute of the guest's type-7 vertex-input block that this device could
+/// An attribute of the guest's serializer-object vertex-input block that this device could
 /// not encode, which refuses the pipeline that declared it.
 ///
 /// Carries what the [`DroppedVertexAttribute`] line reports, so the caller's
@@ -209,7 +209,7 @@ pub(crate) struct VertexAttributeUnencodable {
     pub value: u32,
 }
 
-/// Build an `MTLVertexDescriptor` from the type-7 pipeline vertex-input block.
+/// Build an `MTLVertexDescriptor` from the serializer-object pipeline vertex-input block.
 ///
 /// `Ok(None)` ⇒ the pipeline declares no vertex input at all (SSBO-only, or
 /// every entry undeclared); `Err` ⇒ an attribute the guest *did* declare could
@@ -220,7 +220,7 @@ pub(crate) fn metal_vertex_descriptor_from_attrs(
     metal_vertex_descriptor_from_attrs_for_draw(attrs, false)
 }
 
-/// Build `MTLVertexDescriptor` from type-7 vertex attributes.
+/// Build `MTLVertexDescriptor` from serializer-object vertex attributes.
 ///
 /// When `for_patches` is true and a layout lacks an explicit step function,
 /// use `PerPatchControlPoint` (SDK value 4) so post-tessellation vertex
@@ -261,7 +261,7 @@ pub(crate) fn metal_vertex_descriptor_from_attrs_for_draw(
             crate::runtime::drain::note_store_route("icb_vertex_attr_undeclared");
             continue;
         }
-        // Both words come straight off the guest's type-7 descriptor and had no
+        // Both words come straight off the guest's serializer-object descriptor and had no
         // check at all — they were reinterpreted as `MTLVertexFormat` and
         // `MTLVertexStepFunction` directly.
         let Some(format) = mtl_enum::vertex_format(a.format) else {
@@ -356,9 +356,9 @@ fn icb_primitive_type(
 
 /// Fill one **render** command slot on a cached host ICB (Metal IndirectRenderCommand).
 ///
-/// Builds an ICB-capable render PSO from the type-7 render pipeline's vertex/
+/// Builds an ICB-capable render PSO from the serializer-object render pipeline's vertex/
 /// fragment MTLBs (color0 = BGRA8Unorm, matching product mapping/scanout).
-/// When the type-7 body carries a vertex-input block, attaches an
+/// When the serializer-object body carries a vertex-input block, attaches an
 /// `MTLVertexDescriptor` so `[[stage_in]]` attributes bind correctly.
 pub fn fill_render_command<M: HostMemory + HostOps>(
     state: &DeviceState,
@@ -372,7 +372,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
     use crate::runtime::compute_exec::ComputeBufferBind;
     use crate::runtime::decode::resource::{
         decode_function_descriptor, decode_render_pipeline_descriptor, FunctionDescriptor,
-        OBJECT_TYPE_FUNCTION, OBJECT_TYPE_TYPE7,
+        OBJECT_TYPE_FUNCTION, OBJECT_TYPE_SERIALIZER_OBJECT,
     };
     use crate::runtime::gva_mem;
     use ::metal::{
@@ -414,7 +414,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             host,
             task_id,
             fill.pipeline_ref,
-            &[OBJECT_TYPE_TYPE7],
+            &[OBJECT_TYPE_SERIALIZER_OBJECT],
         )
         .map_err(|rung| {
             let slug = crate::observe::ladder_slugs!("icb_frc_pipeline")(rung);
@@ -499,7 +499,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             .map_err(|_| IcbStatus::MetalFailed("icb_frc_fragment_function_get"))?;
 
         // Mesh draws need MTLMeshRenderPipelineDescriptor + mesh descriptor factory.
-        // Prefer mesh SPI type-7 shape (tag 0x14; 0x01 object / 0x02 mesh / 0x03 frag);
+        // Prefer mesh SPI serializer-object shape (tag 0x14; 0x01 object / 0x02 mesh / 0x03 frag);
         // else dual-export or mesh-only metallib in classic `vertex_func_ref`.
         let built = if is_mesh {
             use crate::backend::metal::raw_metal::{
@@ -632,7 +632,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             if is_patches {
                 let cp_index_ty = match fill.draw {
                     IcbRenderDraw::IndexedPatches { .. } => {
-                        // UInt16 control-point indices (product fill stages type-1 bytes).
+                        // UInt16 control-point indices (product fill stages buffer bytes).
                         crate::backend::metal::raw_metal::MTL_TESSELLATION_CONTROL_POINT_INDEX_UINT16
                     }
                     _ => {
@@ -645,7 +645,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
                     cp_index_ty,
                 );
             }
-            // Stage-in / control-point: type-7 vertex-input block → MTLVertexDescriptor.
+            // Stage-in / control-point: serializer-object vertex-input block → MTLVertexDescriptor.
             // Patch draws force PerPatchControlPoint when the layout does not already
             // carry a step function (host tessellation oracle fixture).
             // Three answers, and the two that are not `Ok(Some)` used to be one
@@ -698,9 +698,9 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
     }
 
     // Stage index / patch / tessellation factor buffers by object-list ref.
-    let stage_type1 = |buffer_ref: u32, offset: u64| -> Result<::metal::Buffer, IcbStatus> {
+    let stage_buffer = |buffer_ref: u32, offset: u64| -> Result<::metal::Buffer, IcbStatus> {
         if buffer_ref == 0 {
-            return Err(IcbStatus::Args("icb_frc_type1_ref_zero"));
+            return Err(IcbStatus::Args("icb_frc_buffer_ref_zero"));
         }
         let bind = ComputeBufferBind {
             index: 0,
@@ -710,9 +710,9 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             has_attribute_stride: false,
         };
         let s = stage_buffer(state, host, task_id, &bind)
-            .map_err(|_| IcbStatus::Missing("icb_frc_type1_stage_buffer"))?;
+            .map_err(|_| IcbStatus::Missing("icb_frc_buffer_stage_buffer"))?;
         new_buffer_from_host(device, s.bytes.as_ptr(), s.bytes.len())
-            .ok_or(IcbStatus::MetalFailed("icb_frc_type1_host_buffer"))
+            .ok_or(IcbStatus::MetalFailed("icb_frc_buffer_host_buffer"))
     };
 
     let index_mtl = match fill.draw {
@@ -734,7 +734,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             if need == 0 {
                 return Err(IcbStatus::Args("icb_frc_index_span_zero"));
             }
-            let mtl = stage_type1(index_buffer_ref, index_buffer_offset)?;
+            let mtl = stage_buffer(index_buffer_ref, index_buffer_offset)?;
             // Product stages the index window at offset 0 in the retained buffer.
             let _ = need;
             Some(mtl)
@@ -757,7 +757,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             patch_index_buffer_ref,
             patch_index_buffer_offset,
             ..
-        } if patch_index_buffer_ref != 0 => Some(stage_type1(
+        } if patch_index_buffer_ref != 0 => Some(stage_buffer(
             patch_index_buffer_ref,
             patch_index_buffer_offset,
         )?),
@@ -769,7 +769,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             control_point_index_buffer_ref,
             control_point_index_buffer_offset,
             ..
-        } => Some(stage_type1(
+        } => Some(stage_buffer(
             control_point_index_buffer_ref,
             control_point_index_buffer_offset,
         )?),
@@ -789,7 +789,7 @@ pub fn fill_render_command<M: HostMemory + HostOps>(
             if tessellation_factor.buffer_ref == 0 {
                 return Err(IcbStatus::Args("icb_frc_tess_factor_ref_zero"));
             }
-            Some(stage_type1(
+            Some(stage_buffer(
                 tessellation_factor.buffer_ref,
                 tessellation_factor.offset,
             )?)
@@ -1113,7 +1113,7 @@ pub(crate) fn new_icb_compute_pso(
 /// Fill one compute command slot on a cached host ICB from guest object-list state.
 ///
 /// Mirrors Metal: `indirectComputeCommandAtIndex` → set PSO / kernel buffers /
-/// concurrent dispatch. Stages type-1 buffer contents into shared Metal buffers
+/// concurrent dispatch. Stages buffer contents into shared Metal buffers
 /// and records GVA writebacks for post-execute flush.
 ///
 /// When the ICB was created with `inheritPipelineState` / `inheritBuffers`, those

--- a/crates/reims-vgpu/src/runtime/icb/mod.rs
+++ b/crates/reims-vgpu/src/runtime/icb/mod.rs
@@ -1,4 +1,4 @@
-//! The guest's indirect command buffer: its type-7 create body, its command
+//! The guest's indirect command buffer: its serializer-object create body, its command
 //! layout, and the encode/decode of one command slot's bytes.
 //!
 //! Rail-neutral, all of it — this is the guest's own serialization and it reads
@@ -10,7 +10,7 @@
 //!
 //! Guest create is serialized by
 //! `PGSerializer newIndirectCommandBufferWithDescriptor:layout:maxCommandCount:options:allocator:`
-//! into an 88-byte type-7 body (tag `0x36`) including a 52-byte command
+//! into an 88-byte serializer-object body (tag `0x36`) including a 52-byte command
 //! **layout** at `+0x1c`. Product materializes a host ICB and caches it per
 //! `(task_id, icb_ref)`.
 //!
@@ -33,7 +33,7 @@
 use crate::contract::endian::{ld32, ld64}; // ld64: 0x1d1 gpu_address + dispatch args
 use crate::model::DeviceState;
 use crate::runtime::decode::resource::{
-    decode_type7_descriptor, icb_layout_attribute_stride_slot_count,
+    decode_serializer_object_descriptor, icb_layout_attribute_stride_slot_count,
     icb_layout_kernel_tg_slot_count, icb_layout_table_len, Descriptor as ResourceDescriptor,
     IcbCommandLayout, IndirectCommandBufferDescriptor, ICB_ATTRIBUTE_STRIDE_ENTRY_SIZE,
     ICB_BUFFER_BIND_STRIDE, ICB_CMD_TYPE_CONCURRENT_DISPATCH_THREADGROUPS,
@@ -41,7 +41,7 @@ use crate::runtime::decode::resource::{
     ICB_CMD_TYPE_DRAW_INDEXED_PATCHES, ICB_CMD_TYPE_DRAW_MESH_THREADGROUPS,
     ICB_CMD_TYPE_DRAW_MESH_THREADS, ICB_CMD_TYPE_DRAW_PATCHES, ICB_CONCURRENT_DISPATCH_ARGS_LEN,
     ICB_DRAW_INDEXED_PATCHES_ARGS_LEN, ICB_DRAW_MESH_ARGS_LEN, ICB_DRAW_PATCHES_ARGS_LEN,
-    ICB_TESSELLATION_FACTOR_LEN, ICB_TG_MEMORY_STRIDE, OBJECT_TYPE_TYPE7,
+    ICB_TESSELLATION_FACTOR_LEN, ICB_TG_MEMORY_STRIDE, OBJECT_TYPE_SERIALIZER_OBJECT,
 }; // ICB_TG_MEMORY_STRIDE: object + kernel TG length tables
 #[cfg(test)]
 use crate::runtime::decode::resource::{
@@ -156,7 +156,7 @@ impl From<IcbStatus> for crate::runtime::compute_exec::ComputeStatus {
 pub struct IcbKernelBufferBind {
     pub index: u32,
     pub buffer_ref: u32,
-    /// Byte offset into the type-1 buffer (host fill API, or resolved from [`Self::wire_va`]).
+    /// Byte offset into the buffer (host fill API, or resolved from [`Self::wire_va`]).
     pub offset: u64,
     /// Absolute guest VA from bind record `va@+4` (PGSerializer: base+offset).
     /// `0` means host-only fill / ref-at-base. Resolved to [`Self::offset`] before stage.
@@ -202,7 +202,7 @@ pub struct IcbThreadgroupMemory {
 #[derive(Clone, Debug)]
 pub struct IcbComputeFill {
     pub command_index: u32,
-    /// Type-7 compute pipeline object-list ref (kernel function + optional stage-in).
+    /// Serializer-object compute pipeline object-list ref (kernel function + optional stage-in).
     pub pipeline_ref: u32,
     pub buffers: Vec<IcbKernelBufferBind>,
     /// `setThreadgroupMemoryLength:atIndex:` entries (wire: u64 lengths table).
@@ -232,7 +232,7 @@ impl IcbRenderBindStage {
     /// The bind count the create descriptor declared for this stage.
     ///
     /// Each stage is a separate Metal argument table with its own maximum, taken
-    /// at ICB create from the four sibling fields the type-7 body carries and
+    /// at ICB create from the four sibling fields the serializer-object body carries and
     /// pushed straight into the `MTLIndirectCommandBufferDescriptor` (see
     /// [`metal::materialize_metal_icb`]). They are decoded per stage, so they
     /// are compared per stage: a guest that overruns the vertex table and one
@@ -299,7 +299,7 @@ pub(crate) fn refuse_render_bind_past_declared_max(
 pub struct IcbRenderBufferBind {
     pub index: u32,
     pub buffer_ref: u32,
-    /// Byte offset into the type-1 buffer (host fill API, or resolved from [`Self::wire_va`]).
+    /// Byte offset into the buffer (host fill API, or resolved from [`Self::wire_va`]).
     pub offset: u64,
     /// Absolute guest VA from bind record `va@+4` (PGSerializer: base+offset).
     /// `0` means host-only fill / ref-at-base. Resolved to [`Self::offset`] before stage.
@@ -358,7 +358,7 @@ pub enum IcbRenderDraw {
         index_type: u16,
         index_buffer_ref: u32,
         index_count: u64,
-        /// Byte offset into the index type-1 buffer (host fill or resolved from wire VA).
+        /// Byte offset into the index buffer (host fill or resolved from wire VA).
         index_buffer_offset: u64,
         /// Absolute guest VA of the index range (`va@+0x10` in DrawIndexed args); `0` = base.
         index_wire_va: u64,
@@ -1201,7 +1201,7 @@ pub fn encode_compute_command_slot(
     Ok(slot)
 }
 
-/// Load and decode a type-7 ICB descriptor for `icb_ref` on the task object list.
+/// Load and decode a serializer-object ICB descriptor for `icb_ref` on the task object list.
 pub fn load_icb_descriptor<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
@@ -1212,22 +1212,26 @@ pub fn load_icb_descriptor<M: HostMemory + HostOps>(
         return Err(IcbStatus::Missing("icb_desc_ref_zero"));
     }
     // The two statuses this rail splits the ladder into, stated once: a tag that
-    // is not type-7 means the guest described something, wrongly, while a
+    // is not serializer-object means the guest described something, wrongly, while a
     // missing entry or unreadable bytes mean it described nothing this device
     // can see yet.
-    let (_entry, desc) =
-        objects::resolve_descriptor(state, host, task_id, icb_ref, &[OBJECT_TYPE_TYPE7]).map_err(
-            |rung| {
-                let slug = crate::observe::ladder_slugs!("icb")(rung);
-                match rung {
-                    objects::LadderRung::NoListEntry | objects::LadderRung::DescRead { .. } => {
-                        IcbStatus::Missing(slug)
-                    }
-                    objects::LadderRung::WrongType { .. } => IcbStatus::BadDescriptor(slug),
-                }
-            },
-        )?;
-    match decode_type7_descriptor(&desc) {
+    let (_entry, desc) = objects::resolve_descriptor(
+        state,
+        host,
+        task_id,
+        icb_ref,
+        &[OBJECT_TYPE_SERIALIZER_OBJECT],
+    )
+    .map_err(|rung| {
+        let slug = crate::observe::ladder_slugs!("icb")(rung);
+        match rung {
+            objects::LadderRung::NoListEntry | objects::LadderRung::DescRead { .. } => {
+                IcbStatus::Missing(slug)
+            }
+            objects::LadderRung::WrongType { .. } => IcbStatus::BadDescriptor(slug),
+        }
+    })?;
+    match decode_serializer_object_descriptor(&desc) {
         Ok(ResourceDescriptor::IndirectCommandBuffer(icb)) => {
             note_unapplied_icb_flags(task_id, icb_ref, &icb);
             Ok(icb)
@@ -1542,11 +1546,11 @@ pub fn bind_icb_command_memory(
     Ok(())
 }
 
-/// Associate ICB command memory from a type-1 buffer object-list ref (sync path).
+/// Associate ICB command memory from a buffer object-list ref (sync path).
 ///
-/// Resolves buffer GVA/size via the type-1 descriptor (`handle << PAGE_SHIFT`).
+/// Resolves buffer GVA/size via the buffer descriptor (`handle << PAGE_SHIFT`).
 /// Byte length is min(buffer size, command_size × max_command_count) from the
-/// ICB create layout so oversize type-1 allocations are truncated to the ICB.
+/// ICB create layout so oversize buffer allocations are truncated to the ICB.
 pub fn associate_icb_backing_buffer_ref<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
@@ -1557,12 +1561,12 @@ pub fn associate_icb_backing_buffer_ref<M: HostMemory + HostOps>(
     if icb_ref == 0 || buffer_ref == 0 {
         return Err(IcbStatus::Args("icb_associate_ref_zero"));
     }
-    // Record the type-7 create layout if it is not already recorded. This used
+    // Record the serializer-object create layout if it is not already recorded. This used
     // to materialize the host `MTLIndirectCommandBuffer` as a side effect, which
     // is why associating a backing buffer refused outright on the Vulkan arm —
     // the association is guest bookkeeping and needs no host object at all.
     let desc = resolve_icb_record(state, host, task_id, icb_ref)?;
-    let (gva, buf_size) = type1_buffer_gva_size(state, host, task_id, buffer_ref)?;
+    let (gva, buf_size) = buffer_gva_size(state, host, task_id, buffer_ref)?;
     let need = (desc.layout.command_size as u64).saturating_mul(desc.max_command_count as u64);
     if need == 0 {
         return Err(IcbStatus::Args("icb_associate_zero_layout_span"));
@@ -1591,7 +1595,7 @@ pub fn associate_icb_backing_buffer_ref<M: HostMemory + HostOps>(
 /// was worse than refusing. `reply_buffer_ref` went to
 /// [`associate_icb_backing_buffer_ref`] as the ICB's command backing and
 /// `reply_offset` became a command-memory GVA — so a guest whose scratch
-/// allocator happened to return a resolvable type-1 ref would have had *its own
+/// allocator happened to return a resolvable buffer ref would have had *its own
 /// reply staging area* bound as an ICB's command slots, and the next
 /// `executeCommandsInBuffer:` would decode whatever sat there and run it as
 /// draws. A refusal loses the guest's query; that lost the query and then
@@ -1656,7 +1660,7 @@ fn write_attribute_stride(
     Ok(())
 }
 
-fn type1_buffer_gva_size<M: HostMemory + HostOps>(
+fn buffer_gva_size<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
     task_id: u32,
@@ -1665,7 +1669,7 @@ fn type1_buffer_gva_size<M: HostMemory + HostOps>(
     objects::resolve_buffer_span(state, host, task_id, buffer_ref).map_err(
         |refusal| match refusal {
             objects::BufferSpanRefusal::Rung(rung) => {
-                let slug = crate::observe::ladder_slugs!("icb_type1")(rung);
+                let slug = crate::observe::ladder_slugs!("icb_buffer")(rung);
                 match rung {
                     objects::LadderRung::NoListEntry | objects::LadderRung::DescRead { .. } => {
                         IcbStatus::Missing(slug)
@@ -1674,14 +1678,14 @@ fn type1_buffer_gva_size<M: HostMemory + HostOps>(
                 }
             }
             objects::BufferSpanRefusal::Decode => {
-                IcbStatus::BadDescriptor(crate::observe::ladder_slug!("icb_type1", desc_decode))
+                IcbStatus::BadDescriptor(crate::observe::ladder_slug!("icb_buffer", desc_decode))
             }
-            objects::BufferSpanRefusal::NoBacking => IcbStatus::Missing("icb_type1_no_backing"),
+            objects::BufferSpanRefusal::NoBacking => IcbStatus::Missing("icb_buffer_no_backing"),
         },
     )
 }
 
-/// Convert absolute bind VA → offset into type-1 allocation (`handle << page_shift`).
+/// Convert absolute bind VA → offset into buffer allocation (`handle << page_shift`).
 ///
 /// PGSerializer stores `base+offset` in the bind VA field (not a separate offset).
 /// `wire_va == 0` means base (offset 0). Fail-closed if VA is below base or past size.
@@ -1695,7 +1699,7 @@ fn offset_from_wire_va<M: HostMemory + HostOps>(
     if wire_va == 0 {
         return Ok(0);
     }
-    let (base, size) = type1_buffer_gva_size(state, host, task_id, buffer_ref)?;
+    let (base, size) = buffer_gva_size(state, host, task_id, buffer_ref)?;
     if wire_va < base {
         return Err(IcbStatus::Args("icb_wire_va_below_base"));
     }
@@ -1706,7 +1710,7 @@ fn offset_from_wire_va<M: HostMemory + HostOps>(
     Ok(off)
 }
 
-/// Resolve wire VAs on a compute fill into type-1 bind offsets (mutates in place).
+/// Resolve wire VAs on a compute fill into buffer bind offsets (mutates in place).
 pub fn resolve_compute_fill_offsets<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
@@ -1721,7 +1725,7 @@ pub fn resolve_compute_fill_offsets<M: HostMemory + HostOps>(
     Ok(())
 }
 
-/// Resolve wire VAs on a render fill into type-1 bind / index offsets (mutates in place).
+/// Resolve wire VAs on a render fill into buffer bind / index offsets (mutates in place).
 pub fn resolve_render_fill_offsets<M: HostMemory + HostOps>(
     state: &DeviceState,
     host: &M,
@@ -1831,7 +1835,7 @@ pub enum IcbCommandFill {
 /// Decode guest command memory into host ICB fills for the given index range.
 ///
 /// Dispatches compute vs render fills from wire `commandTypes` / slot
-/// command-type tags, and resolves every wire VA into a type-1 bind offset, so
+/// command-type tags, and resolves every wire VA into a buffer bind offset, so
 /// the result names only refs and offsets. Nothing here touches a backend: this
 /// is the half of ICB execute that is the same on all three pathways, and it is
 /// portable so that the Vulkan arm has something to replay.

--- a/crates/reims-vgpu/src/runtime/icb/tests.rs
+++ b/crates/reims-vgpu/src/runtime/icb/tests.rs
@@ -25,15 +25,17 @@ use crate::runtime::decode::resource::{
     ICB_DESC_MAX_FRAGMENT_BINDS, ICB_DESC_MAX_KERNEL_BINDS, ICB_DESC_MAX_VERTEX_BINDS,
     ICB_DESC_OPTIONS, ICB_FLAG_INHERIT_BUFFERS, ICB_LAYOUT_LEN,
     MTL_INDIRECT_CMD_CONCURRENT_DISPATCH, MTL_INDIRECT_CMD_DRAW, MTL_INDIRECT_CMD_DRAW_INDEXED,
-    OBJECT_LIST_ENTRY_LEN, OBJECT_TYPE_BUFFER, OBJECT_TYPE_TYPE7, PIPELINE_TAG_FRAGMENT_FUNC,
-    PIPELINE_TAG_VERTEX_FUNC, RESOURCE_PAGE_SHIFT, TYPE7_OBJECT_ICB, TYPE7_OBJECT_RENDER_PIPELINE,
+    OBJECT_LIST_ENTRY_LEN, OBJECT_TYPE_BUFFER, OBJECT_TYPE_SERIALIZER_OBJECT,
+    PIPELINE_TAG_FRAGMENT_FUNC, PIPELINE_TAG_VERTEX_FUNC, RESOURCE_PAGE_SHIFT,
+    SERIALIZER_OBJECT_ICB, SERIALIZER_OBJECT_RENDER_PIPELINE,
 };
 /// Compute-pipeline and function descriptor constants, used only by the
 /// Metal-arm execute tests below. Kept in their own gated `use` so the Vulkan arm
 /// does not carry unused imports.
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 use crate::runtime::decode::resource::{
-    OBJECT_TYPE_FUNCTION, PIPELINE_TAG_KERNEL_FUNC, TYPE7_FIRST_TLVS, TYPE7_OBJECT_COMPUTE_PIPELINE,
+    OBJECT_TYPE_FUNCTION, PIPELINE_TAG_KERNEL_FUNC, SERIALIZER_OBJECT_COMPUTE_PIPELINE,
+    SERIALIZER_OBJECT_FIRST_TLVS,
 };
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 use crate::runtime::draw::metal::encode_icb_execute_and_writeback;
@@ -346,7 +348,7 @@ fn make_icb_desc_bytes_tg(
 ) -> Vec<u8> {
     use crate::runtime::decode::resource::{compute_icb_layout, ICB_DESC_MAX_KERNEL_TG_BINDS};
     let mut b = vec![0u8; ICB_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_ICB);
+    st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
     st32(&mut b[4..], ICB_DESC_LEN as u32);
     st32(&mut b[8..], MTL_INDIRECT_CMD_CONCURRENT_DISPATCH);
     b[ICB_DESC_MAX_VERTEX_BINDS] = 0;
@@ -414,7 +416,7 @@ fn make_render_icb_desc_bytes_ex(
         ICB_FLAG_INHERIT_PIPELINE_STATE,
     };
     let mut b = vec![0u8; ICB_DESC_LEN];
-    st32(&mut b[0..], TYPE7_OBJECT_ICB);
+    st32(&mut b[0..], SERIALIZER_OBJECT_ICB);
     st32(&mut b[4..], ICB_DESC_LEN as u32);
     st32(&mut b[8..], command_types);
     b[ICB_DESC_MAX_VERTEX_BINDS] = max_vertex as u8;
@@ -457,22 +459,22 @@ fn load_stagein_mtlb() -> (Vec<u8>, Vec<u8>) {
     (vtx, frag)
 }
 
-/// Minimal compute pipeline type-7 descriptor: one first-TLV entry naming the
+/// Minimal compute pipeline serializer-object descriptor: one first-TLV entry naming the
 /// kernel function ref. Eight call sites built these same seven lines. Gated
 /// like its constants and all eight callers, which are Metal-arm execute tests.
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 fn make_compute_pipeline_desc(kernel_ref: u32) -> Vec<u8> {
     let mut pdesc = vec![0u8; 32];
-    st32(&mut pdesc[0..], TYPE7_OBJECT_COMPUTE_PIPELINE);
+    st32(&mut pdesc[0..], SERIALIZER_OBJECT_COMPUTE_PIPELINE);
     st32(&mut pdesc[4..], 32);
-    pdesc[TYPE7_FIRST_TLVS] = 1;
-    pdesc[TYPE7_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
-    pdesc[TYPE7_FIRST_TLVS + 2] = 4;
-    st32(&mut pdesc[TYPE7_FIRST_TLVS + 3..], kernel_ref);
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS] = 1;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 1] = PIPELINE_TAG_KERNEL_FUNC;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 2] = 4;
+    st32(&mut pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 3..], kernel_ref);
     pdesc
 }
 
-/// Minimal render pipeline type-7 descriptor: a first-TLV block carrying only
+/// Minimal render pipeline serializer-object descriptor: a first-TLV block carrying only
 /// the vertex and fragment function refs — no vertex-input and no colour
 /// attachment, unlike [`make_stagein_render_pipeline_desc`]. Six call sites
 /// built these same twelve lines. Gated like its constants and all six callers,
@@ -481,20 +483,20 @@ fn make_compute_pipeline_desc(kernel_ref: u32) -> Vec<u8> {
 fn make_render_pipeline_desc(vert_ref: u32, frag_ref: u32) -> Vec<u8> {
     let mut pdesc = vec![0u8; 16 + 1 + 6 + 6];
     let blen = pdesc.len() as u32;
-    st32(&mut pdesc[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut pdesc[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut pdesc[4..], blen);
     st32(&mut pdesc[8..], 6);
-    pdesc[TYPE7_FIRST_TLVS] = 2;
-    pdesc[TYPE7_FIRST_TLVS + 1] = PIPELINE_TAG_VERTEX_FUNC;
-    pdesc[TYPE7_FIRST_TLVS + 2] = 4;
-    st32(&mut pdesc[TYPE7_FIRST_TLVS + 3..], vert_ref);
-    pdesc[TYPE7_FIRST_TLVS + 7] = PIPELINE_TAG_FRAGMENT_FUNC;
-    pdesc[TYPE7_FIRST_TLVS + 8] = 4;
-    st32(&mut pdesc[TYPE7_FIRST_TLVS + 9..], frag_ref);
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS] = 2;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 1] = PIPELINE_TAG_VERTEX_FUNC;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 2] = 4;
+    st32(&mut pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 3..], vert_ref);
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 7] = PIPELINE_TAG_FRAGMENT_FUNC;
+    pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 8] = 4;
+    st32(&mut pdesc[SERIALIZER_OBJECT_FIRST_TLVS + 9..], frag_ref);
     pdesc
 }
 
-/// Type-7 render pipeline with vertex-input block: Float4 attr0 @ buffer0 stride 16.
+/// Serializer-object render pipeline with vertex-input block: Float4 attr0 @ buffer0 stride 16.
 ///
 /// Layout matches `parse_vertex_block` / color-attachment section (offset from
 /// header end via tag `0x08`).
@@ -519,7 +521,7 @@ fn make_stagein_render_pipeline_desc(vert_ref: u32, frag_ref: u32) -> Vec<u8> {
     let color_off_from_header = (color_abs - 16) as u32; // 86
 
     let mut b = vec![0u8; 117];
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], 117);
     st32(&mut b[8..], 6); // object id
                           // First TLVs
@@ -585,7 +587,7 @@ fn make_stagein_render_pipeline_desc(vert_ref: u32, frag_ref: u32) -> Vec<u8> {
     b
 }
 
-/// Compact type-7 mesh pipeline (host SPI shape): tag `0x14` section offset
+/// Compact serializer-object mesh pipeline (host SPI shape): tag `0x14` section offset
 /// + optional object `0x01` + mesh `0x02` + fragment `0x03`.
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 fn make_mesh_render_pipeline_desc(
@@ -595,7 +597,7 @@ fn make_mesh_render_pipeline_desc(
 ) -> Vec<u8> {
     use crate::runtime::decode::resource::{
         PIPELINE_TAG_MESH_FRAGMENT_FUNC, PIPELINE_TAG_MESH_FUNC, PIPELINE_TAG_MESH_SECTION_OFFSET,
-        PIPELINE_TAG_OBJECT_FUNC, TYPE7_OBJECT_RENDER_PIPELINE,
+        PIPELINE_TAG_OBJECT_FUNC, SERIALIZER_OBJECT_RENDER_PIPELINE,
     };
     let mut fields = Vec::new();
     // Section offset filled after we know field payload size (matches SPI:
@@ -611,7 +613,7 @@ fn make_mesh_render_pipeline_desc(
     let first_tlv_len = 1 + n * 6;
     let mut b = vec![0u8; 16 + first_tlv_len];
     let blen = b.len() as u32;
-    st32(&mut b[0..], TYPE7_OBJECT_RENDER_PIPELINE);
+    st32(&mut b[0..], SERIALIZER_OBJECT_RENDER_PIPELINE);
     st32(&mut b[4..], blen);
     st32(&mut b[8..], 6);
     b[16] = n as u8;
@@ -628,13 +630,7 @@ fn make_mesh_render_pipeline_desc(
 }
 
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
-fn put_type1_buffer(
-    host: &mut FakeHost,
-    state: &DeviceState,
-    obj_ref: u32,
-    handle: u32,
-    bytes: &[u8],
-) {
+fn put_buffer(host: &mut FakeHost, state: &DeviceState, obj_ref: u32, handle: u32, bytes: &[u8]) {
     let gva = (handle as u64) << RESOURCE_PAGE_SHIFT;
     gva_mem::write_task_gva_arm64e(host, &state.tasks[1], gva, bytes);
     let mut bdesc = vec![0u8; 16];
@@ -872,7 +868,14 @@ fn load_icb_from_object_list() {
     let (mut host, state) = icb_device();
     let desc = make_icb_desc_bytes(8, 4, true);
     let gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, gva, &desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        gva,
+        &desc,
+    );
     let icb = load_icb_descriptor(&state, &host, 1, 9).unwrap();
     assert_eq!(icb.max_command_count, 8);
     assert_eq!(icb.max_kernel_buffer_bind_count, 4);
@@ -908,7 +911,14 @@ fn a_flag_this_device_does_not_apply_is_counted_when_the_guest_asks_for_it() {
         let (mut host, state) = icb_device();
         let desc = make_icb_desc_bytes(8, 4, true);
         let gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, gva, &desc);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            gva,
+            &desc,
+        );
         load_icb_descriptor(&state, &host, 1, 9).unwrap();
     }
     for (route, was) in routes.iter().zip(&before) {
@@ -943,7 +953,14 @@ fn a_flag_this_device_does_not_apply_is_counted_when_the_guest_asks_for_it() {
         let word = crate::contract::endian::ld16(&desc[ICB_DESC_FLAGS..]);
         st16(&mut desc[ICB_DESC_FLAGS..], word & !clear);
         let gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, gva, &desc);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            gva,
+            &desc,
+        );
         let before_route = store_route_count(route);
         let before_other = store_route_count(other);
         load_icb_descriptor(&state, &host, 1, 9).unwrap();
@@ -971,7 +988,14 @@ fn materialize_and_execute_empty_range() {
     let (mut host, state) = icb_device();
     let desc = make_icb_desc_bytes(8, 4, true);
     let gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, gva, &desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        gva,
+        &desc,
+    );
     let (d, icb) = resolve_metal_icb(&state, &host, 1, 9).expect("materialize");
     assert_eq!(d.max_command_count, 8);
     assert_eq!(icb.size(), 8);
@@ -996,14 +1020,28 @@ fn fill_and_execute_mul3add1_writeback() {
     // ICB object ref 9: 1 command, maxKernel=1, no inherit (explicit fills).
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     // Function + pipeline + data buffer (mul3add1).
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
     let pdesc_gva = 0x140u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -1300,7 +1338,14 @@ fn fill_render_draw_patches_tessellation_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 1, 0, MTL_INDIRECT_CMD_DRAW_PATCHES);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -1308,7 +1353,14 @@ fn fill_render_draw_patches_tessellation_oracle() {
 
     // Vertex-input Float4 @ buffer0 stride 16 (step defaults to PerPatchControlPoint).
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // Full-screen clip-space triangle as 3 control points.
     let tri: [[f32; 4]; 3] = [
@@ -1320,7 +1372,7 @@ fn fill_render_draw_patches_tessellation_oracle() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &cp_bytes);
+    put_buffer(&mut host, &state, 11, 4, &cp_bytes);
 
     // MTLTriangleTessellationFactorsHalf: edge[3] + inside, half 1.0 = 0x3c00.
     let tess_bytes: [u8; 8] = [
@@ -1329,7 +1381,7 @@ fn fill_render_draw_patches_tessellation_oracle() {
         0x00, 0x3c, // edge2
         0x00, 0x3c, // inside
     ];
-    put_type1_buffer(&mut host, &state, 12, 5, &tess_bytes);
+    put_buffer(&mut host, &state, 12, 5, &tess_bytes);
 
     fill_render(
         &state,
@@ -1392,14 +1444,28 @@ fn fill_render_draw_indexed_patches_tessellation_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 1, 0, MTL_INDIRECT_CMD_DRAW_INDEXED_PATCHES);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // Control points: dummy at 0, real full-screen triangle at 1,2,3.
     let cps: [[f32; 4]; 4] = [
@@ -1412,15 +1478,15 @@ fn fill_render_draw_indexed_patches_tessellation_oracle() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &cp_bytes);
+    put_buffer(&mut host, &state, 11, 4, &cp_bytes);
 
     // UInt16 control-point indices [1,2,3].
     let indices: [u16; 3] = [1, 2, 3];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &index_bytes);
+    put_buffer(&mut host, &state, 13, 5, &index_bytes);
 
     let tess_bytes: [u8; 8] = [0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c];
-    put_type1_buffer(&mut host, &state, 12, 6, &tess_bytes);
+    put_buffer(&mut host, &state, 12, 6, &tess_bytes);
 
     fill_render(
         &state,
@@ -1672,9 +1738,16 @@ fn fill_render_draw_mesh_threads_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
-    // Mesh function lives in the type-7 "vertex" function slot (no guest
+    // Mesh function lives in the serializer-object "vertex" function slot (no guest
     // mesh-pipeline descriptor yet — host-fill only path).
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
@@ -1682,7 +1755,14 @@ fn fill_render_draw_mesh_threads_oracle() {
 
     // No vertex attributes needed for mesh; reuse stage-in desc helper with empty attrs.
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     fill_render(
         &state,
@@ -1724,14 +1804,28 @@ fn fill_render_draw_mesh_threadgroups_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     fill_render(
         &state,
@@ -1837,14 +1931,28 @@ fn fill_render_negative_base_vertex_stagein_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 1, 1, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // Clip-space full-cover triangle at vertex indices 0,1,2.
     let tri: [[f32; 4]; 3] = [
@@ -1856,18 +1964,18 @@ fn fill_render_negative_base_vertex_stagein_oracle() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &pos_bytes);
+    put_buffer(&mut host, &state, 11, 4, &pos_bytes);
 
     // indices [1,2,3] + baseVertex(-1) → vertex_id 0,1,2.
     let indices: [u16; 3] = [1, 2, 3];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 12, 5, &index_bytes);
+    put_buffer(&mut host, &state, 12, 5, &index_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 6, &color_bytes);
+    put_buffer(&mut host, &state, 13, 6, &color_bytes);
 
     fill_render(
         &state,
@@ -1937,13 +2045,27 @@ fn buffer_backed_fill_execute_mul3add1() {
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let layout = compute_only_icb_layout(1);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
     let pdesc_gva = 0x140u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -1955,7 +2077,7 @@ fn buffer_backed_fill_execute_mul3add1() {
     let bdesc_gva = 0x180u64;
     put_object(&mut host, &state, 7, OBJECT_TYPE_BUFFER, bdesc_gva, &bdesc);
 
-    // Guest-style fill: command slot in a type-1 backing buffer (handle 4).
+    // Guest-style fill: command slot in a buffer backing buffer (handle 4).
     let slot = encode_compute_command_slot(
         &layout,
         &IcbComputeFill {
@@ -1984,7 +2106,7 @@ fn buffer_backed_fill_execute_mul3add1() {
         &cmd_bdesc,
     );
 
-    // Auto-bind via type-1 buffer_ref (sync path / 0x1d1 payload).
+    // Auto-bind via buffer_ref (sync path / 0x1d1 payload).
     let mem = associate_icb_backing_buffer_ref(&state, &host, 1, 9, 10).expect("associate");
     assert_eq!(mem.gva, cmd_mem_gva);
     assert_eq!(mem.byte_len, layout.command_size as u64);
@@ -2010,7 +2132,7 @@ fn buffer_backed_fill_execute_mul3add1() {
     assert_eq!(
         out,
         vec![4, 7, 10, 13],
-        "type-1 associated ICB fill+execute mul3add1"
+        "buffer associated ICB fill+execute mul3add1"
     );
 }
 
@@ -2041,12 +2163,12 @@ fn icb_host_resource_info_decode_and_apply() {
 /// The record names an ICB and a scratch `(buffer, offset)` pair for the two
 /// `u64`s the guest is waiting to be handed. This device used to read that pair
 /// as the ICB's command backing, so a guest whose stream allocator returned a
-/// resolvable type-1 ref would have had its own reply staging area bound as an
+/// resolvable buffer ref would have had its own reply staging area bound as an
 /// ICB's command slots — and the next `executeCommandsInBuffer:` would have
 /// decoded whatever sat there and run it as real work.
 ///
 /// The fixture is built to be exactly that trap: object 11 is a well-formed
-/// type-1 buffer whose pages hold a *valid* encoded command slot, so the old
+/// buffer whose pages hold a *valid* encoded command slot, so the old
 /// code path succeeds on it. Both halves are asserted, because the refusal
 /// alone would still pass if the bind happened first and the error came later:
 /// the call refuses, **and** the ICB still has no command memory afterwards.
@@ -2058,7 +2180,14 @@ fn a_0x1d1_query_is_refused_and_binds_nothing() {
     let layout = compute_only_icb_layout(1);
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
     // Record the create body, as `execute` would, so the decode below refuses
     // for want of command memory rather than for want of the ICB itself.
     resolve_icb_record(&state, &host, 1, 9).expect("record the ICB create body");
@@ -2118,7 +2247,14 @@ fn fill_render_draw_indexed_execute_oracle() {
     // ICB: DrawIndexed, maxFragment=1 for color constant at fragment buffer 0.
     let icb_desc = make_render_icb_desc_bytes(1, 0, 1, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     // Vertex function (ref 2) + fragment function (ref 3).
     // Descriptor GVAs stay past object-list region (32×12 = 0x180).
@@ -2126,22 +2262,29 @@ fn fill_render_draw_indexed_execute_oracle() {
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
-    // Render pipeline type-7 (ref 6): vertex=2, fragment=3.
+    // Render pipeline serializer-object (ref 6): vertex=2, fragment=3.
     let pdesc = make_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     // Index buffer (ref 12, handle 4): UInt16 [0,1,2].
     let indices: [u16; 3] = [0, 1, 2];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
 
     // Fragment color buffer (ref 13, handle 5): RGBA float4 for sid=7.
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     // Mapping for color writeback (4×4 BGRA).
     let mapping_id = map_draw_target(&mut host, &mut state, 0x30);
@@ -2189,7 +2332,14 @@ fn buffer_backed_render_draw_indexed_fill_execute() {
     let layout = render_icb_layout(max_v, max_f, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_desc = make_render_icb_desc_bytes(1, max_v, max_f, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -2197,17 +2347,24 @@ fn buffer_backed_render_draw_indexed_fill_execute() {
 
     let pdesc = make_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let indices: [u16; 3] = [0, 1, 2];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     let slot = encode_render_command_slot(
         &layout,
@@ -2244,7 +2401,7 @@ fn buffer_backed_render_draw_indexed_fill_execute() {
 /// Wire-backed E2E: DrawPatches tessellation.
 ///
 /// Guest path only — no `fill_render_command` host API:
-/// encode slot → type-1 command memory → `0x1d1` associate → execute
+/// encode slot → buffer command memory → `0x1d1` associate → execute
 /// re-fills via `fill_icb_from_command_memory` → solid BGRA.
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
@@ -2263,14 +2420,28 @@ fn wire_backed_draw_patches_tessellation_e2e() {
     let layout = render_draw_patches_icb_layout(1);
     let icb_desc = make_render_icb_desc_bytes(1, 1, 0, MTL_INDIRECT_CMD_DRAW_PATCHES);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let tri: [[f32; 4]; 3] = [
         [-1.0, -1.0, 0.0, 1.0],
@@ -2281,10 +2452,10 @@ fn wire_backed_draw_patches_tessellation_e2e() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &cp_bytes);
+    put_buffer(&mut host, &state, 11, 4, &cp_bytes);
 
     let tess_bytes: [u8; 8] = [0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c];
-    put_type1_buffer(&mut host, &state, 12, 5, &tess_bytes);
+    put_buffer(&mut host, &state, 12, 5, &tess_bytes);
 
     // Absolute wire VAs for control-point bind + tess factor (base+0).
     let cp_wire = (4u64) << RESOURCE_PAGE_SHIFT;
@@ -2364,14 +2535,28 @@ fn wire_backed_draw_indexed_patches_tessellation_e2e() {
     let layout = render_draw_indexed_patches_icb_layout(1);
     let icb_desc = make_render_icb_desc_bytes(1, 1, 0, MTL_INDIRECT_CMD_DRAW_INDEXED_PATCHES);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // Control points: dummy at 0, real triangle at 1,2,3.
     let cps: [[f32; 4]; 4] = [
@@ -2384,14 +2569,14 @@ fn wire_backed_draw_indexed_patches_tessellation_e2e() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &cp_bytes);
+    put_buffer(&mut host, &state, 11, 4, &cp_bytes);
 
     let indices: [u16; 3] = [1, 2, 3];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &index_bytes);
+    put_buffer(&mut host, &state, 13, 5, &index_bytes);
 
     let tess_bytes: [u8; 8] = [0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c, 0x00, 0x3c];
-    put_type1_buffer(&mut host, &state, 12, 6, &tess_bytes);
+    put_buffer(&mut host, &state, 12, 6, &tess_bytes);
 
     let cp_wire = (4u64) << RESOURCE_PAGE_SHIFT;
     let index_wire = (5u64) << RESOURCE_PAGE_SHIFT;
@@ -2458,7 +2643,7 @@ fn wire_backed_draw_indexed_patches_tessellation_e2e() {
     );
 }
 
-/// Object+mesh host fill: dual-function metallib (object type 8 + mesh type 7)
+/// Object+mesh host fill: dual-function metallib (object texture-view + mesh serializer-object)
 /// → drawMeshThreadgroups → solid BGRA (object sets mesh grid via payload).
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
@@ -2487,7 +2672,14 @@ fn fill_render_object_mesh_threadgroups_oracle() {
         b[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
             .copy_from_slice(&encode_icb_command_layout(&layout));
         let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &b);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            icb_gva,
+            &b,
+        );
     }
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
@@ -2495,7 +2687,14 @@ fn fill_render_object_mesh_threadgroups_oracle() {
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     fill_render(
         &state,
@@ -2525,7 +2724,7 @@ fn fill_render_object_mesh_threadgroups_oracle() {
 }
 
 /// Dedicated wire-backed E2E: dual-export object+mesh metallib in classic
-/// type-7 vertex slot (no mesh SPI tag 0x14) through command memory.
+/// serializer-object vertex slot (no mesh SPI tag 0x14) through command memory.
 /// Not claimed via mesh SPI separate-ref E2E.
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
@@ -2545,14 +2744,21 @@ fn wire_backed_dual_export_object_mesh_e2e() {
     let layout = render_draw_mesh_threadgroups_icb_layout();
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     // Dual-export object+mesh in classic "vertex" function slot only.
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
-    // Classic type-7 shape: tag 0x01/0x02 only (no mesh SPI 0x14).
+    // Classic serializer-object shape: tag 0x01/0x02 only (no mesh SPI 0x14).
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
     let decoded = decode_render_pipeline_descriptor(&pdesc).expect("classic pipeline");
     assert_eq!(decoded.vertex_func_ref, 2);
@@ -2562,7 +2768,14 @@ fn wire_backed_dual_export_object_mesh_e2e() {
     assert!(!decoded.has_color_attachment_offset || decoded.color_attachment_offset != 0);
     // Mesh SPI shape uses tag 0x14; classic stagein has tag 0x08.
     // object/mesh refs must stay zero so fill uses dual-export scan of vertex metallib.
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let fill = IcbRenderFill {
         command_index: 0,
@@ -2595,7 +2808,7 @@ fn wire_backed_dual_export_object_mesh_e2e() {
     );
 }
 
-/// Separate object + mesh + fragment function refs via mesh SPI type-7
+/// Separate object + mesh + fragment function refs via mesh SPI serializer-object
 /// tags 0x01 / 0x02 / 0x03 under section tag 0x14 (not dual-export).
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
@@ -2625,7 +2838,14 @@ fn fill_render_separate_object_mesh_func_refs_oracle() {
         b[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
             .copy_from_slice(&encode_icb_command_layout(&layout));
         let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &b);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            icb_gva,
+            &b,
+        );
     }
 
     // Object function ref 2, mesh ref 4, fragment ref 3 — three distinct objects.
@@ -2641,7 +2861,14 @@ fn fill_render_separate_object_mesh_func_refs_oracle() {
     assert_eq!(decoded.mesh_func_ref, 4);
     assert_eq!(decoded.fragment_func_ref, 3);
     assert_eq!(decoded.vertex_func_ref, 0);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x280, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x280,
+        &pdesc,
+    );
 
     fill_render(
         &state,
@@ -2695,7 +2922,14 @@ fn wire_backed_mesh_spi_pipeline_e2e() {
     let layout = render_draw_mesh_threadgroups_icb_layout();
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     // Three distinct function objects: object=2, frag=3, mesh=4.
     put_function_object(&mut host, &state, 2, 0x200, 2, &obj_mtlb);
@@ -2711,7 +2945,14 @@ fn wire_backed_mesh_spi_pipeline_e2e() {
     assert_eq!(decoded.fragment_func_ref, 3);
     assert_eq!(decoded.vertex_func_ref, 0);
     assert!(decoded.has_color_attachment_offset); // tag 0x14 shape
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x280, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x280,
+        &pdesc,
+    );
 
     let fill = IcbRenderFill {
         command_index: 0,
@@ -2761,18 +3002,32 @@ fn fill_render_mesh_buffer_bind_oracle() {
     let icb_desc =
         make_render_icb_desc_bytes_ex(1, 0, 0, 0, 1, MTL_INDIRECT_CMD_DRAW_MESH_THREADS, 0);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // scale = 1.0f LE (handle must be a setup_task-mapped page pfn).
     let scale_bytes = 1.0f32.to_le_bytes();
-    put_type1_buffer(&mut host, &state, 7, 4, &scale_bytes);
+    put_buffer(&mut host, &state, 7, 4, &scale_bytes);
 
     fill_render(
         &state,
@@ -2825,17 +3080,31 @@ fn fill_render_object_buffer_bind_oracle() {
     let icb_desc =
         make_render_icb_desc_bytes_ex(1, 0, 0, 1, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS, 0);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let scale_bytes = 1.0f32.to_le_bytes();
-    put_type1_buffer(&mut host, &state, 7, 4, &scale_bytes);
+    put_buffer(&mut host, &state, 7, 4, &scale_bytes);
 
     fill_render(
         &state,
@@ -2894,17 +3163,31 @@ fn wire_backed_mesh_buffer_bind_e2e() {
     icb_desc[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
         .copy_from_slice(&encode_icb_command_layout(&layout));
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let scale_bytes = 1.0f32.to_le_bytes();
-    put_type1_buffer(&mut host, &state, 7, 4, &scale_bytes);
+    put_buffer(&mut host, &state, 7, 4, &scale_bytes);
     let scale_gva = 4u64 << RESOURCE_PAGE_SHIFT;
 
     let fill = IcbRenderFill {
@@ -2970,17 +3253,31 @@ fn wire_backed_object_buffer_bind_e2e() {
     icb_desc[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
         .copy_from_slice(&encode_icb_command_layout(&layout));
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let scale_bytes = 1.0f32.to_le_bytes();
-    put_type1_buffer(&mut host, &state, 7, 4, &scale_bytes);
+    put_buffer(&mut host, &state, 7, 4, &scale_bytes);
     let scale_gva = 4u64 << RESOURCE_PAGE_SHIFT;
 
     let fill = IcbRenderFill {
@@ -3101,7 +3398,14 @@ fn fill_render_object_tg_memory_bad_length_rejected() {
         b[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
             .copy_from_slice(&encode_icb_command_layout(&layout));
         let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &b);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            icb_gva,
+            &b,
+        );
     }
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
@@ -3109,7 +3413,14 @@ fn fill_render_object_tg_memory_bad_length_rejected() {
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let err = fill_render(
         &state,
@@ -3164,7 +3475,14 @@ fn fill_render_object_tg_memory_oracle() {
         b[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
             .copy_from_slice(&encode_icb_command_layout(&layout));
         let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-        put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &b);
+        put_object(
+            &mut host,
+            &state,
+            9,
+            OBJECT_TYPE_SERIALIZER_OBJECT,
+            icb_gva,
+            &b,
+        );
     }
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
@@ -3172,7 +3490,14 @@ fn fill_render_object_tg_memory_oracle() {
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     fill_render(
         &state,
@@ -3225,14 +3550,28 @@ fn wire_backed_object_tg_memory_e2e() {
     icb_desc[ICB_DESC_LAYOUT..ICB_DESC_LAYOUT + ICB_LAYOUT_LEN]
         .copy_from_slice(&encode_icb_command_layout(&layout));
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &om_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let fill = IcbRenderFill {
         command_index: 0,
@@ -3265,7 +3604,7 @@ fn wire_backed_object_tg_memory_e2e() {
 
 /// Wire-backed E2E: drawMeshThreads.
 ///
-/// Same guest path as patches: encode slot into type-1 command memory,
+/// Same guest path as patches: encode slot into buffer command memory,
 /// `0x1d1` bind, execute re-fills from wire (no host `fill_render_command`).
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
@@ -3284,14 +3623,28 @@ fn wire_backed_mesh_threads_e2e() {
     let layout = render_draw_mesh_threads_icb_layout(0);
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let slot = encode_render_command_slot(
         &layout,
@@ -3343,14 +3696,28 @@ fn wire_backed_mesh_threadgroups_e2e() {
     let layout = render_draw_mesh_threadgroups_icb_layout();
     let icb_desc = make_render_icb_desc_bytes(1, 0, 0, MTL_INDIRECT_CMD_DRAW_MESH_THREADGROUPS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &mesh_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let slot = encode_render_command_slot(
         &layout,
@@ -3405,7 +3772,14 @@ fn inherit_buffers_encoder_fragment_color() {
         ICB_FLAG_INHERIT_BUFFERS,
     );
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -3413,17 +3787,24 @@ fn inherit_buffers_encoder_fragment_color() {
 
     let pdesc = make_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let indices: [u16; 3] = [0, 1, 2];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     // Fill: pipeline + draw only — no fragment buffer in the ICB slot.
     fill_render(
@@ -3491,7 +3872,14 @@ fn inherit_pipeline_encoder_fragment_color() {
         ICB_FLAG_INHERIT_PIPELINE_STATE,
     );
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -3499,17 +3887,24 @@ fn inherit_pipeline_encoder_fragment_color() {
 
     let pdesc = make_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let indices: [u16; 3] = [0, 1, 2];
     let index_bytes: Vec<u8> = indices.iter().flat_map(|v| v.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     // Fill: buffers + draw only — pipeline_ref 0 (inherited from parent).
     fill_render(
@@ -3576,7 +3971,14 @@ fn fill_render_stagein_draw_execute_oracle() {
     // Draw (not indexed): max_vertex=1 for position buffer bind.
     let icb_desc = make_render_icb_desc_bytes(1, 1, 1, MTL_INDIRECT_CMD_DRAW);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -3584,7 +3986,14 @@ fn fill_render_stagein_draw_execute_oracle() {
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     // Fullscreen triangle positions (clip space), stride 16 Float4.
     let tri: [[f32; 4]; 3] = [
@@ -3596,13 +4005,13 @@ fn fill_render_stagein_draw_execute_oracle() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &pos_bytes);
+    put_buffer(&mut host, &state, 11, 4, &pos_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     fill_render(
         &state,
@@ -3650,14 +4059,28 @@ fn wire_backed_draw_primitives_stagein_e2e() {
     let layout = render_icb_layout(1, 1, MTL_INDIRECT_CMD_DRAW);
     let icb_desc = make_render_icb_desc_bytes(1, 1, 1, MTL_INDIRECT_CMD_DRAW);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let tri: [[f32; 4]; 3] = [
         [-1.0, -1.0, 0.0, 1.0],
@@ -3668,13 +4091,13 @@ fn wire_backed_draw_primitives_stagein_e2e() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &pos_bytes);
+    put_buffer(&mut host, &state, 11, 4, &pos_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     let pos_wire = (4u64) << RESOURCE_PAGE_SHIFT;
     let color_wire = (5u64) << RESOURCE_PAGE_SHIFT;
@@ -3838,14 +4261,28 @@ fn fill_render_attribute_stride_stagein_execute() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 1, 1, MTL_INDIRECT_CMD_DRAW);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     // Tight Float4 positions (stride 16) — attributeStride matches layout stride.
     let tri: [[f32; 4]; 3] = [
@@ -3857,13 +4294,13 @@ fn fill_render_attribute_stride_stagein_execute() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &pos_bytes);
+    put_buffer(&mut host, &state, 11, 4, &pos_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     fill_render(
         &state,
@@ -3930,14 +4367,28 @@ fn wire_backed_attribute_stride_stagein_e2e() {
     assert!(icb_layout_attribute_stride_slot_count(&layout) >= 1);
     let icb_desc = make_render_icb_desc_bytes(1, 1, 1, MTL_INDIRECT_CMD_DRAW);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_stagein_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let tri: [[f32; 4]; 3] = [
         [-1.0, -1.0, 0.0, 1.0],
@@ -3948,13 +4399,13 @@ fn wire_backed_attribute_stride_stagein_e2e() {
         .iter()
         .flat_map(|v| v.iter().flat_map(|f| f.to_le_bytes()))
         .collect();
-    put_type1_buffer(&mut host, &state, 11, 4, &pos_bytes);
+    put_buffer(&mut host, &state, 11, 4, &pos_bytes);
 
     let sid = 7u8;
     let r = (0x60u32 + sid as u32) as f32 / 255.0;
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
-    put_type1_buffer(&mut host, &state, 13, 5, &color_bytes);
+    put_buffer(&mut host, &state, 13, 5, &color_bytes);
 
     let pos_wire = (4u64) << RESOURCE_PAGE_SHIFT;
     let color_wire = (5u64) << RESOURCE_PAGE_SHIFT;
@@ -4073,12 +4524,26 @@ fn fill_compute_barrier_and_tg_memory_execute() {
 
     let icb_desc = make_icb_desc_bytes_tg(1, 1, 1, 0);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -4140,12 +4605,26 @@ fn inherit_buffers_encoder_kernel_mul3add1() {
     // inheritBuffers; maxKernel still advertises encoder bind capacity.
     let icb_desc = make_icb_desc_bytes_tg(1, 1, 0, ICB_FLAG_INHERIT_BUFFERS);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -4214,12 +4693,26 @@ fn inherit_pipeline_encoder_kernel_mul3add1() {
 
     let icb_desc = make_icb_desc_bytes_tg(1, 1, 0, ICB_FLAG_INHERIT_PIPELINE_STATE);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -4268,11 +4761,11 @@ fn inherit_pipeline_encoder_kernel_mul3add1() {
     );
 }
 
-/// Install a type-2 linear texture (single level) and write seed texels.
+/// Install a texture linear texture (single level) and write seed texels.
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 // A test fixture builder: object ref, handle, geometry and seed texels.
 #[allow(clippy::too_many_arguments)]
-fn put_type2_texture(
+fn put_texture(
     host: &mut FakeHost,
     state: &mut DeviceState,
     obj_ref: u32,
@@ -4310,12 +4803,17 @@ fn put_type2_texture(
     gva_mem::write_task_gva_arm64e(host, &state.tasks[1], data_gva, &page);
 }
 
-/// Minimal type-7 sampler (36 B): clamp-to-edge, nearest, normalized coords.
+/// Minimal serializer-object sampler (36 B): clamp-to-edge, nearest, normalized coords.
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
-fn put_type7_sampler(host: &mut FakeHost, state: &DeviceState, obj_ref: u32, normalized: bool) {
-    use crate::runtime::decode::resource::{sampler_desc as off, TYPE7_OBJECT_SAMPLER};
+fn put_serializer_object_sampler(
+    host: &mut FakeHost,
+    state: &DeviceState,
+    obj_ref: u32,
+    normalized: bool,
+) {
+    use crate::runtime::decode::resource::{sampler_desc as off, SERIALIZER_OBJECT_SAMPLER};
     let mut desc = vec![0u8; off::LEN];
-    st32(&mut desc[off::TAG..], TYPE7_OBJECT_SAMPLER);
+    st32(&mut desc[off::TAG..], SERIALIZER_OBJECT_SAMPLER);
     st32(&mut desc[off::DECLARED_LEN..], off::LEN as u32);
     st32(&mut desc[off::ID..], obj_ref);
     // Address modes ClampToEdge=0 at bits 8/12/16; filters nearest=0.
@@ -4329,7 +4827,14 @@ fn put_type7_sampler(host: &mut FakeHost, state: &DeviceState, obj_ref: u32, nor
     st32(&mut desc[off::LOD_MIN..], 0f32.to_bits());
     st32(&mut desc[off::LOD_MAX..], f32::MAX.to_bits());
     let desc_gva = 0x300u64 + (obj_ref as u64) * 0x40;
-    put_object(host, state, obj_ref, OBJECT_TYPE_TYPE7, desc_gva, &desc);
+    put_object(
+        host,
+        state,
+        obj_ref,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        desc_gva,
+        &desc,
+    );
 }
 
 /// Textures/samplers always bind on the parent compute encoder at ICB
@@ -4353,12 +4858,26 @@ fn icb_parent_encoder_texture_and_sampler_binds() {
 
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     let data = [1u32, 2, 3, 4];
     let data_bytes: Vec<u8> = data.iter().flat_map(|v| v.to_le_bytes()).collect();
@@ -4372,7 +4891,7 @@ fn icb_parent_encoder_texture_and_sampler_binds() {
     const W: u32 = 2;
     const H: u32 = 2;
     let seed = vec![0xCDu8; (W * H * 4) as usize];
-    put_type2_texture(
+    put_texture(
         &mut host,
         &mut state,
         11,
@@ -4382,7 +4901,7 @@ fn icb_parent_encoder_texture_and_sampler_binds() {
         MTL_FORMAT_RGBA8_UNORM,
         &seed,
     );
-    put_type7_sampler(&mut host, &state, 14, true);
+    put_serializer_object_sampler(&mut host, &state, 14, true);
 
     fill_compute(
         &state,
@@ -4472,17 +4991,31 @@ fn icb_argument_buffer_storage_texture_xyplane() {
     // maxKernel=1 for the AB buffer slot; no inheritBuffers — AB recorded on ICB.
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     const W: u32 = 4;
     const H: u32 = 4;
     let seed = vec![0x00u8; (W * H * 4) as usize];
-    put_type2_texture(
+    put_texture(
         &mut host,
         &mut state,
         11,
@@ -4568,12 +5101,26 @@ fn icb_argument_buffer_sample_and_write() {
 
     let icb_desc = make_icb_desc_bytes(1, 1, false);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 5, 0x100, 2, &mtlb);
 
     let pdesc = make_compute_pipeline_desc(5);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x140, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x140,
+        &pdesc,
+    );
 
     const W: u32 = 4;
     const H: u32 = 4;
@@ -4587,7 +5134,7 @@ fn icb_argument_buffer_sample_and_write() {
             input[i + 3] = 255;
         }
     }
-    put_type2_texture(
+    put_texture(
         &mut host,
         &mut state,
         11,
@@ -4598,7 +5145,7 @@ fn icb_argument_buffer_sample_and_write() {
         &input,
     );
     let out_seed = vec![0x11u8; (W * H * 4) as usize];
-    put_type2_texture(
+    put_texture(
         &mut host,
         &mut state,
         12,
@@ -4608,7 +5155,7 @@ fn icb_argument_buffer_sample_and_write() {
         MTL_FORMAT_RGBA8_UINT,
         &out_seed,
     );
-    put_type7_sampler(&mut host, &state, 14, true);
+    put_serializer_object_sampler(&mut host, &state, 14, true);
 
     fill_compute(
         &state,
@@ -4688,7 +5235,7 @@ fn resolve_bind_offset_from_wire_va() {
     let color = [r, 0x44 as f32 / 255.0, 0x22 as f32 / 255.0, 1.0f32];
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
     bytes[16..32].copy_from_slice(&color_bytes);
-    put_type1_buffer(&mut host, &state, 13, 4, &bytes);
+    put_buffer(&mut host, &state, 13, 4, &bytes);
     let base = (4u64) << RESOURCE_PAGE_SHIFT;
     assert_eq!(
         offset_from_wire_va(&state, &host, 1, 13, base + 16).unwrap(),
@@ -4699,7 +5246,7 @@ fn resolve_bind_offset_from_wire_va() {
     assert!(offset_from_wire_va(&state, &host, 1, 13, base + 32).is_err());
 }
 
-/// Host fill with non-zero fragment bind offset into a padded type-1 buffer.
+/// Host fill with non-zero fragment bind offset into a padded buffer.
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 fn fill_render_nonzero_bind_offset_oracle() {
@@ -4710,7 +5257,14 @@ fn fill_render_nonzero_bind_offset_oracle() {
 
     let icb_desc = make_render_icb_desc_bytes(1, 0, 1, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
@@ -4718,13 +5272,20 @@ fn fill_render_nonzero_bind_offset_oracle() {
 
     let pdesc = make_render_pipeline_desc(2, 3);
     let pdesc_gva = 0x240u64;
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, pdesc_gva, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        pdesc_gva,
+        &pdesc,
+    );
 
     let indices: [u16; 3] = [0, 1, 2];
     // Index buffer: 4 B pad + 6 B indices (offset 4).
     let mut index_bytes = vec![0u8; 4];
     index_bytes.extend(indices.iter().flat_map(|v| v.to_le_bytes()));
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
     let index_base = (4u64) << RESOURCE_PAGE_SHIFT;
 
     let sid = 7u8;
@@ -4734,7 +5295,7 @@ fn fill_render_nonzero_bind_offset_oracle() {
     // Color buffer: 16 B pad + float4 (offset 16).
     let mut color_buf = vec![0xAAu8; 16];
     color_buf.extend_from_slice(&color_bytes);
-    put_type1_buffer(&mut host, &state, 13, 5, &color_buf);
+    put_buffer(&mut host, &state, 13, 5, &color_buf);
     let color_base = (5u64) << RESOURCE_PAGE_SHIFT;
 
     fill_render(
@@ -4787,7 +5348,7 @@ fn fill_render_nonzero_bind_offset_oracle() {
     let _ = (index_base, color_base);
 }
 
-/// Buffer-backed fill: wire VA = type-1 base+offset → resolve → execute.
+/// Buffer-backed fill: wire VA = buffer base+offset → resolve → execute.
 #[test]
 #[cfg(all(feature = "backend-metal", target_os = "macos"))]
 fn buffer_backed_nonzero_wire_va_offset() {
@@ -4801,19 +5362,33 @@ fn buffer_backed_nonzero_wire_va_offset() {
     let layout = render_icb_layout(max_v, max_f, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_desc = make_render_icb_desc_bytes(1, max_v, max_f, MTL_INDIRECT_CMD_DRAW_INDEXED);
     let icb_gva = 1u64 << RESOURCE_PAGE_SHIFT;
-    put_object(&mut host, &state, 9, OBJECT_TYPE_TYPE7, icb_gva, &icb_desc);
+    put_object(
+        &mut host,
+        &state,
+        9,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        icb_gva,
+        &icb_desc,
+    );
 
     put_function_object(&mut host, &state, 2, 0x200, 2, &vert_mtlb);
 
     put_function_object(&mut host, &state, 3, 0x220, 3, &frag_mtlb);
 
     let pdesc = make_render_pipeline_desc(2, 3);
-    put_object(&mut host, &state, 6, OBJECT_TYPE_TYPE7, 0x240, &pdesc);
+    put_object(
+        &mut host,
+        &state,
+        6,
+        OBJECT_TYPE_SERIALIZER_OBJECT,
+        0x240,
+        &pdesc,
+    );
 
     let indices: [u16; 3] = [0, 1, 2];
     let mut index_bytes = vec![0u8; 8]; // pad 8
     index_bytes.extend(indices.iter().flat_map(|v| v.to_le_bytes()));
-    put_type1_buffer(&mut host, &state, 12, 4, &index_bytes);
+    put_buffer(&mut host, &state, 12, 4, &index_bytes);
     let index_wire = ((4u64) << RESOURCE_PAGE_SHIFT) + 8;
 
     let sid = 7u8;
@@ -4822,7 +5397,7 @@ fn buffer_backed_nonzero_wire_va_offset() {
     let color_bytes: Vec<u8> = color.iter().flat_map(|f| f.to_le_bytes()).collect();
     let mut color_buf = vec![0u8; 24]; // pad 24
     color_buf.extend_from_slice(&color_bytes);
-    put_type1_buffer(&mut host, &state, 13, 5, &color_buf);
+    put_buffer(&mut host, &state, 13, 5, &color_buf);
     let color_wire = ((5u64) << RESOURCE_PAGE_SHIFT) + 24;
 
     let slot = encode_render_command_slot(
@@ -4894,7 +5469,7 @@ fn buffer_backed_nonzero_wire_va_offset() {
 ///
 /// The four maxima are decoded separately and handed to Metal separately, so
 /// mapping them onto one bound would report the wrong table for three stages out
-/// of four — the failure mode `8ad945e` found on the type-1 buffer span.
+/// of four — the failure mode `8ad945e` found on the buffer span.
 #[test]
 fn a_render_icb_bind_is_bounded_by_the_count_its_own_stage_declared() {
     use crate::observe::Decline;

--- a/crates/reims-vgpu/src/runtime/mapper/mod.rs
+++ b/crates/reims-vgpu/src/runtime/mapper/mod.rs
@@ -330,7 +330,7 @@ pub fn capture_at_producer<H: HostMemory + HostOps>(
 
 /// Apply a capture to the mapping named by the just-drained ring entry.
 pub fn apply_capture(state: &mut DeviceState, cap: &MapperCapture, mapping_id: u32) -> bool {
-    // Neither branch below releases a deferred writeback window. A type-11
+    // Neither branch below releases a deferred writeback window. A mapper-ref-texture
     // render Store writes guest pages on its own path, so an UNMAP (or a MAP
     // that re-backs the slot with a different MappingInternal, orphaning the
     // old identity) leaves no mapping-keyed render obligation behind, because a
@@ -505,7 +505,7 @@ pub fn resolve_mapping_backing<H: HostMemory + HostOps>(
         }
     }
 
-    // Texture-path geom (type-11 object dims) refines span for single-plane; for
+    // Texture-path geom (mapper-ref-texture object dims) refines span for single-plane; for
     // multi-plane, prefer alloc_size already latched from the device descriptor.
     if let Some(m) = state.mappings.get(&mapping_id) {
         if m.has_geom && m.width > 0 && m.height > 0 {
@@ -651,16 +651,16 @@ pub fn resolve_mapping_backing<H: HostMemory + HostOps>(
         if let Some((lo, hi)) = entry_gpa_span(&plan.entries, page_shift) {
             let key = span_first_sight_key(mapping_id, lo, hi, page_shift);
             if crate::observe::first_sight(SPAN_SEEN_MAPPER, key) {
-                // `src=mapper` against the type-4 adoption site's `src=type4`,
+                // `src=mapper` against the backing adoption site's `src=backing`,
                 // which says which path a surface's page list arrived through.
                 //
                 // Read that field with the latch in mind: until the two sites
                 // were given separate `first_sight` namespaces they shared one,
-                // and on identical keys, so the type-4 site claimed every
+                // and on identical keys, so the backing site claimed every
                 // footprint it reached first and this one was suppressed for
                 // that footprint permanently. Every `mapping_gpa_span` line in
-                // an x86 boot read `src=type4`, which was taken as evidence that
-                // the page list arrives at the type-4 site — but the latch could
+                // an x86 boot read `src=backing`, which was taken as evidence that
+                // the page list arrives at the backing site — but the latch could
                 // not have produced any other reading. Whether this site is
                 // genuinely quiet is now an open question again, and a driven
                 // boot is what answers it.
@@ -890,14 +890,14 @@ pub(crate) fn entry_gpa_span(entries: &[u32], page_shift: u32) -> Option<(u64, u
 ///
 /// That is not a harmless overlap, because the two lines are read against each
 /// other. `src=` exists to say which adoption path a surface's page list
-/// arrived through, and the type-4 site wins the race in practice, so the
+/// arrived through, and the backing site wins the race in practice, so the
 /// mapper's silence was manufactured by the latch rather than observed. Two
 /// namespaces make each site's silence its own evidence.
 pub(crate) const SPAN_SEEN_MAPPER: &str = "mapping_gpa_span_mapper";
 
-/// `first_sight` namespace for the type-4 adoption span line. See
+/// `first_sight` namespace for the backing adoption span line. See
 /// [`SPAN_SEEN_MAPPER`] for why the two are not one.
-pub(crate) const SPAN_SEEN_TYPE4: &str = "mapping_gpa_span_type4";
+pub(crate) const SPAN_SEEN_TYPE4: &str = "mapping_gpa_span_backing";
 
 /// Dedup discriminant for a `mapping_gpa_span` line: the footprint identity.
 ///
@@ -935,10 +935,10 @@ pub(crate) fn plan_adoption_decision(
     )
 }
 
-/// True when the cached page table covers the type-11 sample/write span for
+/// True when the cached page table covers the mapper-ref-texture sample/write span for
 /// the latched geom (archive table build uses the same min_size).
 ///
-/// Early resolve often runs before type-11 object dims land (`min_size` =
+/// Early resolve often runs before mapper-ref-texture object dims land (`min_size` =
 /// PAGE_SIZE only). Leaving a short `page_entries` while `has_geom` is true
 /// makes Store writeback and sample page walks fail-closed on tiles (Favourites
 /// 249² with ~16 pages vs ~63 required) while the Metal attachment still holds
@@ -969,7 +969,7 @@ pub fn pages_cover_geom(state: &DeviceState, mapping_id: u32) -> bool {
     covered >= span_end.max(page_size)
 }
 
-/// Ensure pages (and geom if possible) before scanout paint / type-11 Store.
+/// Ensure pages (and geom if possible) before scanout paint / mapper-ref-texture Store.
 ///
 /// Re-resolves when the table is empty, geom is missing, **or** the cached page
 /// count cannot cover the latched W×H sample window (stale early resolve).
@@ -1115,7 +1115,7 @@ pub fn revalidate_mapping_reason<H: HostMemory + HostOps>(
 /// Which of the two `true`s a bare "are these pages still ours" bool would
 /// have returned.
 ///
-/// [`type4_pages_witness`]'s contract says a caller must not read a bare
+/// [`backing_pages_witness`]'s contract says a caller must not read a bare
 /// "yes" as "these pages were verified", because four of its five exits check
 /// nothing at all. Every caller then collapsed both meanings into
 /// [`PagesVerdict::Ours`], and the counters built on it — `mapw_pages_vouched` 29 002 against
@@ -1127,9 +1127,9 @@ pub fn revalidate_mapping_reason<H: HostMemory + HostOps>(
 /// yields a token and still lets the write through, exactly as before. Nothing
 /// here changes policy; it changes what the boot can say about it.
 ///
-/// [`Unwitnessed`]: Type4Witness::Unwitnessed
+/// [`Unwitnessed`]: BackingWitness::Unwitnessed
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Type4Witness {
+pub enum BackingWitness {
     /// Every page of the cached list was re-walked and agreed. The only exit
     /// that is evidence the list still names the surface's memory.
     Verified,
@@ -1147,36 +1147,36 @@ pub enum Type4Witness {
 /// # Why the existing revalidation cannot answer this
 ///
 /// [`revalidate_mapping_reason`] re-resolves a mapping *only* when
-/// `mapping_internal != 0`. A type-4 surface has no MappingInternal, so that
+/// `mapping_internal != 0`. A backing record has no MappingInternal, so that
 /// function reaches its final `match` with `resolve_ran == false` and returns
 /// `None` — "resolvable" — on the strength of `mapped && !page_entries
 /// .is_empty()` alone. The list is accepted because it is non-empty, not
 /// because anything checked it. Its own doc records the scale: 2 280 render
 /// windows in one boot were armed on mappings with `mapping_internal == 0`.
 ///
-/// Nothing on the wire closes that gap. When the guest re-points a type-4
+/// Nothing on the wire closes that gap. When the guest re-points a backing
 /// surface's backing in its own page table there is no packet, so
 /// `map_generation` does not move and the cached entries stay trusted until the
-/// next type-4 command happens to re-resolve — which for an idle surface may be
-/// never. `resolve_type4_surface_ex` knows this and checks for it, but only
+/// next backing command happens to re-resolve — which for an idle surface may be
+/// never. `resolve_backing_ex` knows this and checks for it, but only
 /// there, and only on the first and last entry:
 ///
 /// ```text
-/// type4_pages_stale sid=49 task=0 n=256 gpa0=0x2e8cf6000 (task PT translation moved; rebuilding)
+/// backing_pages_stale sid=49 task=0 n=256 gpa0=0x2e8cf6000 (task PT translation moved; rebuilding)
 /// ```
 ///
 /// That line is from a live boot. The translations do move.
 ///
 /// # What this checks
 ///
-/// Every page, not two. [`crate::model::Type4Walk`] latched the task and GPU-VA
+/// Every page, not two. [`crate::model::BackingWalk`] latched the task and GPU-VA
 /// base the entries were walked from, so the walk repeats with no object search:
 /// page `i` is `(backing_pfn + i) << page_shift` translated through that task.
 /// Any page that translates differently — or no longer translates at all — means
 /// the list in hand names memory that is no longer the surface's.
 ///
-/// Answers [`Type4Witness::Unwitnessed`] when there is nothing to check
-/// (`type4_walk` absent, or latched at a superseded `map_generation`), because
+/// Answers [`BackingWitness::Unwitnessed`] when there is nothing to check
+/// (`backing_walk` absent, or latched at a superseded `map_generation`), because
 /// this is a *specific* witness and not a general one. That exit is the reason
 /// the return type is an enum rather than a bool: it is not evidence, and a
 /// caller must not read it as "these pages were verified".
@@ -1185,26 +1185,26 @@ pub enum Type4Witness {
 /// mapping-keyed rails write through.
 ///
 /// Re-walks the cached page list and reports which exit it took.
-pub fn type4_pages_witness<H: HostMemory>(
+pub fn backing_pages_witness<H: HostMemory>(
     state: &DeviceState,
     host: &H,
     mapping_id: u32,
-) -> Type4Witness {
+) -> BackingWitness {
     let Some(m) = state.mappings.get(&mapping_id) else {
-        return Type4Witness::Unwitnessed("no_mapping");
+        return BackingWitness::Unwitnessed("no_mapping");
     };
-    let Some(walk) = m.type4_walk else {
-        // No type-4 walk was ever latched for this mapping, so this witness has
-        // never had anything to say about it. The type-11 rail lives here.
-        return Type4Witness::Unwitnessed("no_walk");
+    let Some(walk) = m.backing_walk else {
+        // No backing walk was ever latched for this mapping, so this witness has
+        // never had anything to say about it. The mapper-ref-texture rail lives here.
+        return BackingWitness::Unwitnessed("no_walk");
     };
     if walk.map_generation != m.map_generation {
         // The list has been replaced since the walk was latched. The new list
         // may be perfectly good — it simply has no witness of its own yet.
-        return Type4Witness::Unwitnessed("walk_superseded");
+        return BackingWitness::Unwitnessed("walk_superseded");
     }
     if m.page_entries.is_empty() {
-        return Type4Witness::Unwitnessed("no_pages");
+        return BackingWitness::Unwitnessed("no_pages");
     }
     let page_shift = state.page_shift;
     let page_size = crate::contract::iosurface_pages::page_size_of(page_shift);
@@ -1221,7 +1221,7 @@ pub fn type4_pages_witness<H: HostMemory>(
             walk.task_id,
             m.page_entries.len()
         ));
-        return Type4Witness::Drifted;
+        return BackingWitness::Drifted;
     }
     // One walk over the whole run, not one per page.
     //
@@ -1264,7 +1264,7 @@ pub fn type4_pages_witness<H: HostMemory>(
             let Some(live) = walked else {
                 // No translation now. This used to answer the failed walk with
                 // the GVA, to match the identity fallback that produced the
-                // entry, and that mirror had to go with it: `apply_type4_backing`
+                // entry, and that mirror had to go with it: `apply_backing`
                 // no longer adopts a page at its own GVA, so the only entry this
                 // could still accept is one the control arm made.
                 //
@@ -1282,12 +1282,12 @@ pub fn type4_pages_witness<H: HostMemory>(
                     walk.task_id,
                     entries.len()
                 ));
-                verdict = Some(Type4Witness::Drifted);
+                verdict = Some(BackingWitness::Drifted);
                 return false;
             };
             if cached != Some(live) {
                 // Every entry in this list came from a walk that succeeded:
-                // `apply_type4_backing` refuses the whole surface on the first
+                // `apply_backing` refuses the whole surface on the first
                 // page it cannot walk, so it cannot leave a fabricated one
                 // behind. A disagreement here is therefore between two real
                 // translations taken at different times, which is the guest
@@ -1300,7 +1300,7 @@ pub fn type4_pages_witness<H: HostMemory>(
                     entries.len(),
                     Some(live)
                 ));
-                verdict = Some(Type4Witness::Drifted);
+                verdict = Some(BackingWitness::Drifted);
                 return false;
             }
             i += 1;
@@ -1323,9 +1323,9 @@ pub fn type4_pages_witness<H: HostMemory>(
             walk.task_id,
             entries.len()
         ));
-        return Type4Witness::Drifted;
+        return BackingWitness::Drifted;
     }
-    Type4Witness::Verified
+    BackingWitness::Verified
 }
 
 /// Proof that a mapping's cached page list named the guest memory it was walked
@@ -1334,7 +1334,7 @@ pub fn type4_pages_witness<H: HostMemory>(
 ///
 /// # Why a token and not a call
 ///
-/// [`type4_pages_witness`] existed for a release with exactly one caller — the
+/// [`backing_pages_witness`] existed for a release with exactly one caller — the
 /// render writeback — while every other write
 /// through `MappingEntry::page_entries` went unchecked. That is not an oversight
 /// that a second call site fixes: the check has to be *reachable only through*
@@ -1357,7 +1357,7 @@ pub fn type4_pages_witness<H: HostMemory>(
 /// records the generation it was taken at and [`PagesVouched::covers`] re-checks
 /// it at the point of use. A carried-over token is then unusable by
 /// construction rather than by every future writer remembering a second field —
-/// the same rule [`crate::model::Type4Walk`] states for its own latch.
+/// the same rule [`crate::model::BackingWalk`] states for its own latch.
 #[derive(Clone, Copy, Debug)]
 pub struct PagesVouched {
     mapping_id: u32,
@@ -1387,11 +1387,11 @@ impl PagesVouched {
 /// clears it, bumps `map_generation` and retires the contiguous view and the
 /// guest-write token with it. Every window still armed against the old
 /// incarnation then refuses on the `map_generation` check it already had, and
-/// the next type-4 bind re-resolves the surface from the object list.
+/// the next backing bind re-resolves the surface from the object list.
 ///
 /// Returning a token when there is nothing to check is deliberate and is why
-/// [`type4_pages_witness`] reports "nothing to check" separately rather than
-/// "verified": a mapping with no [`crate::model::Type4Walk`] latch has a page
+/// [`backing_pages_witness`] reports "nothing to check" separately rather than
+/// "verified": a mapping with no [`crate::model::BackingWalk`] latch has a page
 /// list this witness cannot speak about, and refusing every write to it would
 /// blank surfaces the device has no evidence against.
 /// The verdict is handed back alongside the token, not folded into it, because
@@ -1425,7 +1425,7 @@ pub enum PagesVerdict {
     /// The re-walk agreed with the cached list, every page of it.
     Ours,
     /// Nothing was checked; the payload is which of the four states it was, per
-    /// [`Type4Witness::Unwitnessed`]. **The write proceeds exactly as it does
+    /// [`BackingWitness::Unwitnessed`]. **The write proceeds exactly as it does
     /// for [`Self::Ours`]** — this variant changes no policy. It exists because
     /// `Ours` used to mean both "verified" and "unverifiable", so a boot
     /// reporting `mapw_pages_refused = 0` could not say whether its guard had
@@ -1450,12 +1450,12 @@ pub fn mapping_pages_verdict<H: HostMemory + HostOps>(
     host: &H,
     mapping_id: u32,
 ) -> PagesVerdict {
-    match type4_pages_witness(state, host, mapping_id) {
-        Type4Witness::Verified => return PagesVerdict::Ours,
+    match backing_pages_witness(state, host, mapping_id) {
+        BackingWitness::Verified => return PagesVerdict::Ours,
         // Same policy as `Verified` — the write goes through — and a different
         // counter, because only one of the two is evidence.
-        Type4Witness::Unwitnessed(why) => return PagesVerdict::Unwitnessed(why),
-        Type4Witness::Drifted => {}
+        BackingWitness::Unwitnessed(why) => return PagesVerdict::Unwitnessed(why),
+        BackingWitness::Drifted => {}
     }
     state.invalidate_mapping_pages(mapping_id);
     PagesVerdict::Drifted
@@ -1542,7 +1542,7 @@ pub fn drain_deferred_unmaps<H: HostOps>(host: &mut H) -> usize {
 /// What keys the token to the surface's *current* pages is
 /// [`crate::model::MappingEntry::map_generation`], not the eager retirement in
 /// the lifecycle mutators. Two writers replace `page_entries` in place without
-/// going near those mutators — the mapper's own plan adoption and the type-4
+/// going near those mutators — the mapper's own plan adoption and the backing
 /// page refresh — and both retired the contiguous view while leaving the token
 /// alone. Both do bump the generation exactly when the list changes, so
 /// checking it here makes a carried-over token unusable by construction instead
@@ -1566,7 +1566,7 @@ pub fn ensure_guest_write_token<H: HostOps>(
         //
         // Counted because retiring a token reopens its two-harvest arming
         // window, and everything downstream of an unarmed token falls back to
-        // the whole-surface answer: the type-11 LOAD elision refuses with
+        // the whole-surface answer: the mapper-ref-texture LOAD elision refuses with
         // `t11_gw_ref_no_stamp` and the draw pays a full-frame seed read plus a
         // full-frame staging upload. `t11_gw_unarmed` says the window was open;
         // this says whether it keeps being reopened, which separates "the token
@@ -1603,13 +1603,13 @@ pub fn ensure_guest_write_token<H: HostOps>(
 /// Record the host's guest-write generation for a mapping whose pixels a Store
 /// has just published, registering its pages for tracking the first time.
 ///
-/// Called from every rail that publishes a type-11 surface: the Vulkan Store
+/// Called from every rail that publishes a mapper-ref-texture surface: the Vulkan Store
 /// rails next to their `surface_content_epoch` stamp, and the CPU writer in
 /// [`crate::runtime::mapping_write`] next to the host-cache store it makes
 /// authoritative. Lives here rather than in the Vulkan draw path because
 /// `mapping_write` is backend-agnostic and the witness is not a backend concern.
 ///
-/// Historically only the Vulkan Store rails armed it, which is why the type-4
+/// Historically only the Vulkan Store rails armed it, which is why the backing
 /// sampled ladder's first census read `t11rung_host_cache_gw_no_stamp` 14 092
 /// against `gw_clean` 0: the copy that rung serves is written here, and nothing
 /// here had ever asked the host to watch the pages it is a copy of.
@@ -1658,7 +1658,7 @@ pub fn stamp_guest_write_gen<M: HostMemory + HostOps>(
     }
 }
 
-/// What the hypervisor's dirty bitmap can say about a type-4 surface's pages
+/// What the hypervisor's dirty bitmap can say about a backing record's pages
 /// since the Store that stamped them.
 ///
 /// Every variant but [`Self::Clean`] means "assume written". They are kept
@@ -1682,11 +1682,10 @@ pub enum GuestWriteVerdict {
 
 /// The verdict itself, with no counters attached.
 ///
-/// Split from the type-11 LOAD gate's `type11_guest_wrote_since_store` so more
-/// than one rail can ask
-/// the same question and report it under its own names. A shared counter would
-/// pool two rails' refusals into one number, and the number would then be
-/// unreadable for either.
+/// Split from the mapper-ref-texture LOAD gate's `mapper_ref_texture_guest_wrote_since_store` so
+/// more than one rail can ask the same question and report it under its own names. A shared counter
+/// would pool two rails' refusals into one number, and the number would then be unreadable for
+/// either.
 #[cfg(feature = "backend-vulkan")]
 pub(crate) fn mapping_guest_write_verdict<M: HostOps>(
     state: &DeviceState,

--- a/crates/reims-vgpu/src/runtime/mapper/tests.rs
+++ b/crates/reims-vgpu/src/runtime/mapper/tests.rs
@@ -56,11 +56,11 @@ fn windows_may_be_queried_out_of_order() {
     assert_eq!(sel(Some(&ranges), 16, 24), vec![(16, 24)]);
 }
 
-/// A type-4 surface can be re-pointed by the guest with no packet at all,
+/// A backing record can be re-pointed by the guest with no packet at all,
 /// and this is the only thing that can see it.
 ///
 /// The gap is precise. `revalidate_mapping_reason` re-resolves only when
-/// `mapping_internal != 0`; a type-4 surface has none, so that function
+/// `mapping_internal != 0`; a backing record has none, so that function
 /// falls through to `mapped && !page_entries.is_empty()` and answers
 /// "resolvable" without checking anything. The guest then re-points the
 /// backing in its own page table — no MapMemory2, no UnmapMemory, no
@@ -78,7 +78,7 @@ fn windows_may_be_queried_out_of_order() {
 fn the_page_witness_sees_a_rewire_no_packet_announced() {
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
-    use crate::model::{DeviceId, Type4Walk, PAGE_SHIFT_X86};
+    use crate::model::{BackingWalk, DeviceId, PAGE_SHIFT_X86};
     use crate::runtime::host::{FakeHost, HostMemory};
 
     let page = 1u64 << PAGE_SHIFT_X86;
@@ -108,14 +108,14 @@ fn the_page_witness_sees_a_rewire_no_packet_announced() {
         m.mapped = true;
         m.page_entries =
             vec![(((data0 >> PAGE_SHIFT_X86) as u32) << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID];
-        m.type4_walk = Some(Type4Walk {
+        m.backing_walk = Some(BackingWalk {
             task_id: 1,
             backing_pfn: 0,
             map_generation: m.map_generation,
         });
     }
     assert!(
-        super::type4_pages_witness(&state, &host, 6) == super::Type4Witness::Verified,
+        super::backing_pages_witness(&state, &host, 6) == super::BackingWitness::Verified,
         "the list was just walked from this page table"
     );
 
@@ -130,7 +130,7 @@ fn the_page_witness_sees_a_rewire_no_packet_announced() {
         "no packet arrived, so nothing bumped the incarnation"
     );
     assert!(
-        super::type4_pages_witness(&state, &host, 6) == super::Type4Witness::Drifted,
+        super::backing_pages_witness(&state, &host, 6) == super::BackingWitness::Drifted,
         "a fresh walk names a different page, and a writeback through the \
          cached one lands in whatever the guest gave it to"
     );
@@ -139,13 +139,13 @@ fn the_page_witness_sees_a_rewire_no_packet_announced() {
     // in hand, so it must not be read as drift.
     {
         let m = state.mappings.get_mut(&6).unwrap();
-        let mut walk = m.type4_walk.unwrap();
+        let mut walk = m.backing_walk.unwrap();
         walk.map_generation = m.map_generation.wrapping_sub(1);
-        m.type4_walk = Some(walk);
+        m.backing_walk = Some(walk);
     }
     assert!(
-        super::type4_pages_witness(&state, &host, 6)
-            == super::Type4Witness::Unwitnessed("walk_superseded"),
+        super::backing_pages_witness(&state, &host, 6)
+            == super::BackingWitness::Unwitnessed("walk_superseded"),
         "a stale latch says nothing about the current list — it must not refuse, \
          and it must not be counted as a verification either"
     );
@@ -155,14 +155,14 @@ fn the_page_witness_sees_a_rewire_no_packet_announced() {
     // would pass the assertion above and lose every frame in production.
     {
         let m = state.mappings.get_mut(&6).unwrap();
-        let mut walk = m.type4_walk.unwrap();
+        let mut walk = m.backing_walk.unwrap();
         walk.map_generation = m.map_generation;
-        m.type4_walk = Some(walk);
+        m.backing_walk = Some(walk);
     }
     st32(&mut pte, (data0 >> PAGE_SHIFT_X86) as u32);
     host.write_gpa(root_gpa, &pte).unwrap();
     assert!(
-        super::type4_pages_witness(&state, &host, 6) == super::Type4Witness::Verified,
+        super::backing_pages_witness(&state, &host, 6) == super::BackingWitness::Verified,
         "the translation is back where the list says it is"
     );
 }
@@ -193,12 +193,12 @@ fn a_mapping_with_nothing_to_check_is_not_counted_as_verified() {
         let m = state.mappings.get_mut(&6).unwrap();
         m.mapped = true;
         m.page_entries = vec![(4u32 << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID];
-        // No `type4_walk`: nothing ever latched a walk for this mapping.
-        m.type4_walk = None;
+        // No `backing_walk`: nothing ever latched a walk for this mapping.
+        m.backing_walk = None;
     }
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 6),
-        super::Type4Witness::Unwitnessed("no_walk"),
+        super::backing_pages_witness(&state, &host, 6),
+        super::BackingWitness::Unwitnessed("no_walk"),
         "a list nothing walked is unwitnessed, not verified"
     );
 
@@ -206,12 +206,12 @@ fn a_mapping_with_nothing_to_check_is_not_counted_as_verified() {
     // single slug would make four different gaps look like one.
     state.mappings.get_mut(&6).unwrap().page_entries.clear();
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 6),
-        super::Type4Witness::Unwitnessed("no_walk"),
+        super::backing_pages_witness(&state, &host, 6),
+        super::BackingWitness::Unwitnessed("no_walk"),
     );
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 999),
-        super::Type4Witness::Unwitnessed("no_mapping"),
+        super::backing_pages_witness(&state, &host, 999),
+        super::BackingWitness::Unwitnessed("no_mapping"),
     );
 
     // Policy is unchanged: the verdict still hands back a token, so the
@@ -243,7 +243,7 @@ fn a_mapping_with_nothing_to_check_is_not_counted_as_verified() {
 fn a_page_the_task_cannot_translate_is_not_reported_as_a_move() {
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
-    use crate::model::{DeviceId, Type4Walk, PAGE_SHIFT_X86};
+    use crate::model::{BackingWalk, DeviceId, PAGE_SHIFT_X86};
     use crate::runtime::host::{FakeHost, HostMemory};
 
     crate::observe::redirect_logs_for_tests();
@@ -272,13 +272,13 @@ fn a_page_the_task_cannot_translate_is_not_reported_as_a_move() {
         m.mapped = true;
         m.page_entries =
             vec![(((data0 >> PAGE_SHIFT_X86) as u32) << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID];
-        m.type4_walk = Some(Type4Walk {
+        m.backing_walk = Some(BackingWalk {
             task_id: 1,
             backing_pfn: 0,
             map_generation: m.map_generation,
         });
     }
-    assert!(super::type4_pages_witness(&state, &host, 6) != super::Type4Witness::Drifted);
+    assert!(super::backing_pages_witness(&state, &host, 6) != super::BackingWitness::Drifted);
 
     // The translation goes away rather than moving: the PTE is cleared, so
     // the walk fails outright.
@@ -288,7 +288,7 @@ fn a_page_the_task_cannot_translate_is_not_reported_as_a_move() {
     st32(&mut pte, 0);
     host.write_gpa(root_gpa, &pte).unwrap();
     assert!(
-        super::type4_pages_witness(&state, &host, 6) == super::Type4Witness::Drifted,
+        super::backing_pages_witness(&state, &host, 6) == super::BackingWitness::Drifted,
         "a page the table cannot translate must not vouch for a write"
     );
     let body = std::fs::read_to_string(crate::observe::fail_log_path()).unwrap_or_default();
@@ -323,7 +323,7 @@ fn a_page_the_task_cannot_translate_is_not_reported_as_a_move() {
 fn a_page_moved_in_the_middle_of_a_run_still_refuses_the_write() {
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
-    use crate::model::{DeviceId, Type4Walk, PAGE_SHIFT_X86};
+    use crate::model::{BackingWalk, DeviceId, PAGE_SHIFT_X86};
     use crate::runtime::host::{FakeHost, HostMemory};
 
     crate::observe::redirect_logs_for_tests();
@@ -361,15 +361,15 @@ fn a_page_moved_in_the_middle_of_a_run_still_refuses_the_write() {
         m.page_entries = (0..PAGES)
             .map(|i| (data_pfn(i) << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID)
             .collect();
-        m.type4_walk = Some(Type4Walk {
+        m.backing_walk = Some(BackingWalk {
             task_id: 1,
             backing_pfn: 0,
             map_generation: m.map_generation,
         });
     }
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 6),
-        super::Type4Witness::Verified,
+        super::backing_pages_witness(&state, &host, 6),
+        super::BackingWitness::Verified,
         "a run whose every page still translates where it was walked must vouch"
     );
 
@@ -380,8 +380,8 @@ fn a_page_moved_in_the_middle_of_a_run_still_refuses_the_write() {
         .len();
     write_pte(&mut host, 2, elsewhere_pfn);
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 6),
-        super::Type4Witness::Drifted,
+        super::backing_pages_witness(&state, &host, 6),
+        super::BackingWitness::Drifted,
         "a page re-pointed in the middle of the run must refuse the write"
     );
     let body = std::fs::read_to_string(crate::observe::fail_log_path()).unwrap_or_default();
@@ -410,7 +410,7 @@ fn a_page_moved_in_the_middle_of_a_run_still_refuses_the_write() {
 #[test]
 fn a_walk_that_visits_nothing_is_not_agreement() {
     use crate::contract::iosurface_pages::{PAGE_ENTRY_PFN_SHIFT, PAGE_ENTRY_VALID};
-    use crate::model::{DeviceId, Type4Walk, PAGE_SHIFT_X86};
+    use crate::model::{BackingWalk, DeviceId, PAGE_SHIFT_X86};
     use crate::runtime::host::FakeHost;
 
     crate::observe::redirect_logs_for_tests();
@@ -422,15 +422,15 @@ fn a_walk_that_visits_nothing_is_not_agreement() {
         let m = state.mappings.get_mut(&6).unwrap();
         m.mapped = true;
         m.page_entries = vec![(4u32 << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID; 3];
-        m.type4_walk = Some(Type4Walk {
+        m.backing_walk = Some(BackingWalk {
             task_id: 1,
             backing_pfn: 0,
             map_generation: m.map_generation,
         });
     }
     assert_eq!(
-        super::type4_pages_witness(&state, &host, 6),
-        super::Type4Witness::Drifted,
+        super::backing_pages_witness(&state, &host, 6),
+        super::BackingWitness::Drifted,
         "a page list nothing walked must not vouch for a write"
     );
 }
@@ -814,22 +814,22 @@ fn resolve_builds_page_entries() {
     );
 }
 
-/// The type-4 adoption site must not be able to silence this one.
+/// The backing adoption site must not be able to silence this one.
 ///
 /// Both emitters print `mapping_gpa_span` and both dedup on
 /// [`span_first_sight_key`], which is built from the mapping id and the span
 /// alone — so for any footprint both sites reach, they compute the *same*
 /// key. While they also shared one `first_sight` namespace, whichever
 /// arrived first claimed that footprint and the other went permanently
-/// quiet for it. The type-4 site wins in practice, so `src=type4` on every
+/// quiet for it. The backing site wins in practice, so `src=backing` on every
 /// line in a boot was a property of the latch, not a finding about where
 /// page lists arrive.
 ///
-/// This claims the footprint under the type-4 namespace first and then
+/// This claims the footprint under the backing namespace first and then
 /// requires the mapper's line anyway. With one shared namespace the claim
 /// below swallows it and `cap.one("OFF")` finds nothing to return.
 #[test]
-fn the_type4_span_latch_does_not_suppress_the_mapper_span() {
+fn the_backing_span_latch_does_not_suppress_the_mapper_span() {
     let pfn = 0x2c4d1_u32;
     let (mut state, host, page_gpa) = span_fixture(pfn);
 
@@ -844,7 +844,7 @@ fn the_type4_span_latch_does_not_suppress_the_mapper_span() {
     let key = span_first_sight_key(3, page_gpa, page_gpa, state.page_shift);
     assert!(
         crate::observe::first_sight(SPAN_SEEN_TYPE4, key),
-        "the type-4 latch must be unclaimed at the start of this test"
+        "the backing latch must be unclaimed at the start of this test"
     );
 
     assert!(resolve_mapping_backing(&mut state, &host, 3));
@@ -852,7 +852,7 @@ fn the_type4_span_latch_does_not_suppress_the_mapper_span() {
     assert!(
         span.contains("mapping_gpa_span mid=3") && span.contains("src=mapper"),
         "the mapper's own adoption must report its footprint even after the \
-         type-4 site has claimed the same one, got {span:?}"
+         backing site has claimed the same one, got {span:?}"
     );
     assert!(
         span.contains(&format!("pn_lo={pfn:#x}")),

--- a/crates/reims-vgpu/src/runtime/mapping_write/mod.rs
+++ b/crates/reims-vgpu/src/runtime/mapping_write/mod.rs
@@ -212,7 +212,7 @@ fn refuse(mapping_id: u32, why: SurfaceWriteRefusal) -> bool {
 /// - **The mapping has published no descriptor.** `MappingInternal.descriptor`
 ///   reads zero until the guest fills it, which `mapper::resolve` documents as a
 ///   real state rather than a failure, and the geometry then comes from the
-///   type-11 texture object instead. There are no plane records to confuse here;
+///   mapper-ref-texture object instead. There are no plane records to confuse here;
 ///   the single unknown is the pitch, and [`packed_span_estimate`]'s aligned row
 ///   stands in for it over a surface starting at offset 0.
 /// - **The descriptor is published and resolves nothing.** Here the guest *has*
@@ -232,7 +232,7 @@ fn refuse(mapping_id: u32, why: SurfaceWriteRefusal) -> bool {
 /// because a capable host takes the import for every guest window and leaves the
 /// copying rails at zero. With the gate closed
 /// (`host_pointer_import=disabled_by_env`, nothing reporting a bound import) the
-/// copying rails carried the whole workload — every type-5 view, every type-11
+/// copying rails carried the whole workload — every ref-texture view, every mapper-ref-texture
 /// resident rung and every surface flush of the drag — and **no window failed to
 /// resolve**. Every bind came from a published descriptor, so the estimate above
 /// is the state before the guest fills one rather than a rung this device leans
@@ -253,13 +253,13 @@ fn sample_window(
     sample_window_from_device_desc(Some(desc), plane_index, format, width, height)
 }
 
-/// Resolve the sample window for a type-11 texture binding on a mapping.
+/// Resolve the sample window for a mapper-ref-texture binding on a mapping.
 ///
-/// Type-11 is the case with **no wire plane index**: nothing on the wire names
+/// Mapper-ref-texture is the case with **no wire plane index**: nothing on the wire names
 /// which plane the texture wants, so a multi-plane surface is resolved by
 /// matching width, height and bytes-per-element, and the plane is taken only
 /// when exactly one matches. See [`sample_window`] for what each outcome means.
-pub fn type11_sample_window(
+pub fn mapper_ref_texture_sample_window(
     m: &MappingEntry,
     width: u32,
     height: u32,
@@ -268,17 +268,17 @@ pub fn type11_sample_window(
     sample_window(m, None, width, height, format)
 }
 
-/// Resolve the sample window for a type-5 serialized view, which — unlike
-/// type-11 — carries the IOSurface plane index on the wire (type-5 record
+/// Resolve the sample window for a ref-texture serialized view, which — unlike
+/// mapper-ref-texture — carries the IOSurface plane index on the wire (ref-texture record
 /// `+0x20`).
 ///
-/// Every type-5 consumer must come through here rather than through
-/// [`type11_sample_window`], and the distinction is not cosmetic: the wire index
+/// Every ref-texture consumer must come through here rather than through
+/// [`mapper_ref_texture_sample_window`], and the distinction is not cosmetic: the wire index
 /// names the plane record directly, and it is the only key that separates
-/// same-geometry planes. Handing a type-5 view's geometry to the type-11 scan
+/// same-geometry planes. Handing a ref-texture view's geometry to the mapper-ref-texture scan
 /// drops that index, so a bind the wire said was alpha resolves against
 /// whichever same-geometry plane the scan happens to reach.
-pub fn type5_sample_window(
+pub fn ref_texture_sample_window(
     m: &MappingEntry,
     plane_index: u32,
     width: u32,
@@ -378,7 +378,7 @@ fn vouch_for_write<M: HostMemory + HostOps>(
 /// PFNs, cached on the mapping and returned again on every later call. Its own
 /// doc states the contract — "always revalidate first so a cached contig never
 /// aliases PFNs after ReplacePhysical / guest recycle" — but the revalidation it
-/// names cannot deliver that for a type-4 surface: with no `MappingInternal` it
+/// names cannot deliver that for a backing record: with no `MappingInternal` it
 /// re-resolves nothing and answers "resolvable" on a non-empty list alone. So a
 /// writer holding this pointer is holding whatever those PFNs became, and a
 /// full white frame poked through it is the `0xff`-filled freed guest heap the
@@ -652,7 +652,7 @@ pub fn write_bgra8_uncached<M: HostMemory + HostOps>(
 /// plane itself, from the mapping's own declaration, through the same two steps
 /// this function performs. A caller that already holds its own idea of the
 /// destination plane — the blit rail resolves one out of the guest's texture
-/// descriptor, and a type-5 view carries a **wire plane index** this rail has no
+/// descriptor, and a ref-texture view carries a **wire plane index** this rail has no
 /// parameter for — must compare the two before routing a copy here, because a
 /// disagreement is not an error anywhere: the frame lands, in the wrong plane of
 /// the right surface, and the only symptom is the next plane's pixels.
@@ -666,7 +666,7 @@ pub fn resident_gpu_plane(m: &MappingEntry, width: u32, height: u32) -> Option<(
     if mw != width || mh != height {
         return None;
     }
-    let (base_off, bpr, _span_end) = type11_sample_window(m, mw, mh, format)?;
+    let (base_off, bpr, _span_end) = mapper_ref_texture_sample_window(m, mw, mh, format)?;
     Some((base_off, bpr, format))
 }
 
@@ -688,7 +688,7 @@ fn mapping_write_geometry(m: &MappingEntry, width: u32, height: u32) -> (u32, u3
 /// The Metal pixel format a Store into this mapping's plane must land in.
 ///
 /// A mapping that has declared its own geometry owns this, and a zero format
-/// there means guest scanout order — the format every type-11 plane had before
+/// there means guest scanout order — the format every mapper-ref-texture plane had before
 /// any of them declared otherwise, so it is the contract's default and not a
 /// guess. A mapping that has declared no geometry has declared no format either.
 ///
@@ -760,7 +760,8 @@ fn write_bgra8_inner<M: HostMemory + HostOps>(
             },
         );
     }
-    let Some((base_off, bpr_u32, span_end)) = type11_sample_window(m, mw, mh, format) else {
+    let Some((base_off, bpr_u32, span_end)) = mapper_ref_texture_sample_window(m, mw, mh, format)
+    else {
         return refuse(
             mapping_id,
             SurfaceWriteRefusal::WindowUnresolved {
@@ -1056,7 +1057,7 @@ fn write_bgra8_inner<M: HostMemory + HostOps>(
         // complete copy of this surface and no host-side copy of `src` is its
         // content any more. Both of them have to be told so.
         //
-        // The byte cache would answer the type-11 LOAD seed, which prefers it
+        // The byte cache would answer the mapper-ref-texture LOAD seed, which prefers it
         // over the surface's own pages, and hand back exactly the bytes the
         // guest's stores were preserved *from*.
         crate::runtime::surface_cache::forget(state, mapping_id);
@@ -1125,7 +1126,7 @@ fn write_bgra8_inner<M: HostMemory + HostOps>(
     );
     // This write just made the host copy and the guest pages agree, so it is the
     // moment the copy's currency can be pinned. Nothing else arms this mapping:
-    // the type-4 sampled ladder's first census read `gw_no_stamp` 14 092 against
+    // the backing sampled ladder's first census read `gw_no_stamp` 14 092 against
     // `gw_clean` 0 because only the Vulkan Store rails ever stamped, and the
     // copy that rung serves is written here. Unstamped, the reader cannot tell a
     // surface the guest has rewritten from one it has not, and must assume the
@@ -1134,9 +1135,9 @@ fn write_bgra8_inner<M: HostMemory + HostOps>(
     true
 }
 
-/// Write a tight RGBA8 image into a type-11 mapping, optionally as changed-spans.
+/// Write a tight RGBA8 image into a mapper-ref-texture mapping, optionally as changed-spans.
 ///
-/// Archive `apple_pv_gpu_write_type11_image_changed`: when `seed_rgba` is present
+/// Archive `apple_pv_gpu_write_mapper_ref_texture_image_changed`: when `seed_rgba` is present
 /// (same layout as `rgba`), only contiguous native-format spans that differ from
 /// the seed are written. Equivalent to a full `storeAction=Store` when the seed
 /// was the Metal Load attachment content (unchanged texels match guest), without
@@ -1195,7 +1196,8 @@ pub fn write_rgba8_image_changed<M: HostMemory + HostOps>(
             },
         );
     }
-    let Some((base_off, bpr_u32, span_end)) = type11_sample_window(m, mw, mh, format) else {
+    let Some((base_off, bpr_u32, span_end)) = mapper_ref_texture_sample_window(m, mw, mh, format)
+    else {
         return refuse(
             mapping_id,
             SurfaceWriteRefusal::WindowUnresolved {
@@ -1359,7 +1361,7 @@ pub fn write_rgba8_image_changed<M: HostMemory + HostOps>(
     crate::runtime::surface_cache::store(state, mapping_id, mw, mh, cache);
     // This write just made the host copy and the guest pages agree, so it is the
     // moment the copy's currency can be pinned. Nothing else arms this mapping:
-    // the type-4 sampled ladder's first census read `gw_no_stamp` 14 092 against
+    // the backing sampled ladder's first census read `gw_no_stamp` 14 092 against
     // `gw_clean` 0 because only the Vulkan Store rails ever stamped, and the
     // copy that rung serves is written here. Unstamped, the reader cannot tell a
     // surface the guest has rewritten from one it has not, and must assume the
@@ -1385,7 +1387,7 @@ fn rgba8_row_to_native(format: u16, rgba_row: &[u8], width: u32, native: &mut [u
     convert_rgba8_to_row(format, rgba_row, width, native)
 }
 
-/// Write rows already encoded as a type-11 mapping's native pixel format.
+/// Write rows already encoded as a mapper-ref-texture mapping's native pixel format.
 ///
 /// Unlike [`write_raw_rows`], this resolves the texture's sample window inside
 /// an IOSurface allocation: its base offset and row pitch come from the mapping
@@ -1471,7 +1473,9 @@ pub fn write_native_image<M: HostMemory + HostOps>(
             },
         );
     }
-    let Some((base_off, bpr, span_end)) = type11_sample_window(m, mw, mh, mapping_format) else {
+    let Some((base_off, bpr, span_end)) =
+        mapper_ref_texture_sample_window(m, mw, mh, mapping_format)
+    else {
         return refuse(
             mapping_id,
             SurfaceWriteRefusal::WindowUnresolved {
@@ -1702,11 +1706,11 @@ pub fn read_raw_rows<M: HostMemory + HostOps>(
 ///
 /// The resolution [`read_rect_raw`] and [`write_rect_raw`] share: the latched
 /// format (BGRA8 when the mapping never declared one), the plane window
-/// [`type11_sample_window`] decodes for it, and the texel size. Returns
+/// [`mapper_ref_texture_sample_window`] decodes for it, and the texel size. Returns
 /// `(base_offset, bytes_per_row, span_end, bytes_per_texel)`, or `None` when
 /// the mapping is gone, carries no latched geometry, has no decodable window,
 /// has an unknown format, or the rectangle leaves the surface.
-/// Where a mapped type-11 surface's texels sit, and how wide one is.
+/// Where a mapped mapper-ref-texture surface's texels sit, and how wide one is.
 ///
 /// `mapping_geom_window` used to return this as `Option<(u64, u32, u64, u32)>`,
 /// a shape whose meaning existed only in the destructuring patterns of the two
@@ -1754,7 +1758,7 @@ fn mapping_geom_window(state: &DeviceState, mapping_id: u32, rect: Rect) -> Opti
     } else {
         MTL_FORMAT_BGRA8_UNORM
     };
-    let (base_off, bpr, span_end) = type11_sample_window(m, m.width, m.height, format)?;
+    let (base_off, bpr, span_end) = mapper_ref_texture_sample_window(m, m.width, m.height, format)?;
     let bpp = pixel_format::bytes_per_pixel(format)?;
     if origin_x.saturating_add(width) > m.width || origin_y.saturating_add(height) > m.height {
         return None;
@@ -1767,7 +1771,7 @@ fn mapping_geom_window(state: &DeviceState, mapping_id: u32, rect: Rect) -> Opti
     })
 }
 
-/// Read a rectangular texel region from a mapped type-11 IOSurface.
+/// Read a rectangular texel region from a mapped mapper-ref-texture IOSurface.
 /// Contig HostOps view when possible; else multi-import.
 #[cfg(test)]
 pub fn read_rect_raw<M: HostMemory + HostOps>(
@@ -1822,10 +1826,10 @@ pub fn read_rect_raw_at<M: HostMemory + HostOps>(
     // paths below was ever covered. The fragmented path ends in
     // `read_mapping_bytes`, which flushes; the `contig_for_span` path is a raw
     // `copy_nonoverlapping` out of the mapped span and flushes nothing — so
-    // whether a type-11 surface read observed the deferred Store depended on
+    // whether a mapper-ref-texture surface read observed the deferred Store depended on
     // whether its guest pages happened to be contiguous. Three callers read
-    // guest pages through here with no flush of their own: the type-5 view
-    // loader, a blit reading a type-11 texture backing, and the compute sample
+    // guest pages through here with no flush of their own: the ref-texture view
+    // loader, a blit reading a mapper-ref-texture backing, and the compute sample
     // stage.
     //
     // `flush_intersecting` returns immediately when nothing is armed, so this
@@ -1873,7 +1877,7 @@ pub fn read_rect_raw_at<M: HostMemory + HostOps>(
     // arm was bounded anyway — which is true, but only by its own slice bounds:
     // that arm reads the window and then indexes rows into it, so an overrunning
     // rect came back as a bare `false` from a `get` that returned `None`. Both
-    // callers do name that (`rd_row_t11_io`, `Type5ViewDecline::Read`), so it was
+    // callers do name that (`rd_row_t11_io`, `RefTextureViewDecline::Read`), so it was
     // never a silent loss, but neither can say the rect left the window, and the
     // fragmented arm is the one a driven x86 boot actually takes. One check above
     // the split gives both arms the same refusal and the same line.
@@ -1989,9 +1993,9 @@ pub fn read_rect_raw_at<M: HostMemory + HostOps>(
     true
 }
 
-/// Write a rectangular texel region into a mapped type-11 IOSurface.
+/// Write a rectangular texel region into a mapped mapper-ref-texture IOSurface.
 ///
-/// Uses latched mapping geom + [`type11_sample_window`]. Prefer
+/// Uses latched mapping geom + [`mapper_ref_texture_sample_window`]. Prefer
 /// [`write_rect_raw_at`] for an explicit plane window.
 #[allow(
     clippy::too_many_arguments,

--- a/crates/reims-vgpu/src/runtime/mapping_write/tests.rs
+++ b/crates/reims-vgpu/src/runtime/mapping_write/tests.rs
@@ -1,4 +1,4 @@
-//! Tests for the type-11 mapped-surface writers.
+//! Tests for the mapper-ref-texture mapped-surface writers.
 //!
 //! Out of line for the reason the sibling `runtime/` modules that already do
 //! this have: colocated, these 2,291 lines were 48% of `mapping_write.rs` — the
@@ -19,7 +19,7 @@ use crate::runtime::host::FakeHost;
 ///
 /// The row pitch is asserted by its relationships, not as a number: a
 /// 4-wide BGRA8 surface reports `bpr = 128` against a tight row of 16,
-/// because `type11_sample_window` aligns the pitch up. Hard-coding either
+/// because `mapper_ref_texture_sample_window` aligns the pitch up. Hard-coding either
 /// value would make this a test of that alignment rather than of which
 /// field holds what.
 #[test]
@@ -268,7 +268,7 @@ fn a_writeback_lands_every_row_at_its_own_offset() {
 /// whichever guest allocation happens to be scattered.
 ///
 /// Dropping the host cache at the tail is half the test: it would otherwise
-/// answer the type-11 LOAD seed with the very bytes the guest's stores were
+/// answer the mapper-ref-texture LOAD seed with the very bytes the guest's stores were
 /// preserved from.
 #[test]
 fn a_skipping_writeback_leaves_the_guest_its_own_pages() {
@@ -687,7 +687,7 @@ fn write_bumps_generation() {
 ///
 /// This function writes the guest pages and then stores the host render
 /// cache, so at this instant the two agree — the one moment the copy's
-/// currency can be pinned. Nothing else armed it: the type-4 sampled
+/// currency can be pinned. Nothing else armed it: the backing sampled
 /// ladder's first census read `t11rung_host_cache_gw_no_stamp` 14 092
 /// against `gw_clean` 0, because only the Vulkan Store rails ever stamped
 /// while the copy that rung serves is written here. Unstamped, the reader
@@ -778,7 +778,7 @@ fn mapping_write_invalidates_intersecting_residency_windows_only() {
     assert!(state.compute_storage_residency.contains_key(&survivor));
 }
 
-/// A direct type-11 writeback must not land in a page the guest re-pointed
+/// A direct mapper-ref-texture writeback must not land in a page the guest re-pointed
 /// away, and this asserts it in the currency of the bug: the bytes of the
 /// page the surface moved to.
 ///
@@ -799,7 +799,7 @@ fn mapping_write_invalidates_intersecting_residency_windows_only() {
 #[test]
 fn a_repointed_surface_refuses_the_write_and_leaves_the_new_owner_alone() {
     use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
-    use crate::model::{Type4Walk, PAGE_SHIFT_X86};
+    use crate::model::{BackingWalk, PAGE_SHIFT_X86};
 
     let page = 1u64 << PAGE_SHIFT_X86;
     let mut host = FakeHost::new();
@@ -830,7 +830,7 @@ fn a_repointed_surface_refuses_the_write_and_leaves_the_new_owner_alone() {
         m.mapped = true;
         m.page_entries =
             vec![(((data0 >> PAGE_SHIFT_X86) as u32) << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID];
-        m.type4_walk = Some(Type4Walk {
+        m.backing_walk = Some(BackingWalk {
             task_id: 1,
             backing_pfn: 0,
             map_generation: m.map_generation,
@@ -1296,7 +1296,7 @@ fn read_rect_raw_fragmented_pages_with_padded_rows() {
 /// A sub-rectangle of a padded plane over scattered guest pages reads through
 /// one page-table walk, not through a plane-sized window.
 ///
-/// This is the source half of every type-11 to linear blit. Before the
+/// This is the source half of every mapper-ref-texture to linear blit. Before the
 /// rectangle shape reached this rail the arm below materialised the *whole*
 /// sample window into a fresh zeroed `Vec` and then copied the wanted rows out
 /// of it, so a rectangle covering a fraction of the plane still paid for all of
@@ -1584,11 +1584,11 @@ fn an_ambiguous_descriptor_declines_where_an_absent_one_still_sizes_a_window() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     state.map_surface(8);
 
-    // No descriptor yet: geometry came from the type-11 texture object and
+    // No descriptor yet: geometry came from the mapper-ref-texture object and
     // the aligned row stands in for the pitch. 4 R8 texels align to 128.
     let m = state.mappings.get(&8).expect("mapping");
     assert_eq!(
-        type11_sample_window(m, 4, 2, MTL_FORMAT_R8_UNORM),
+        mapper_ref_texture_sample_window(m, 4, 2, MTL_FORMAT_R8_UNORM),
         Some((0, 128, 256)),
         "with nothing published there are no planes to confuse"
     );
@@ -1613,23 +1613,26 @@ fn an_ambiguous_descriptor_declines_where_an_absent_one_still_sizes_a_window() {
 
     let m = state.mappings.get(&8).expect("mapping");
     assert_eq!(
-        type11_sample_window(m, 4, 2, MTL_FORMAT_R8_UNORM),
+        mapper_ref_texture_sample_window(m, 4, 2, MTL_FORMAT_R8_UNORM),
         None,
         "two planes match and neither is the answer, so nothing is bound"
     );
     // The wire index is the only thing that separates them, and it reaches
     // each of the two directly.
     assert_eq!(
-        type5_sample_window(m, 0, 4, 2, MTL_FORMAT_R8_UNORM).map(|w| w.0),
+        ref_texture_sample_window(m, 0, 4, 2, MTL_FORMAT_R8_UNORM).map(|w| w.0),
         Some(512)
     );
     assert_eq!(
-        type5_sample_window(m, 2, 4, 2, MTL_FORMAT_R8_UNORM).map(|w| w.0),
+        ref_texture_sample_window(m, 2, 4, 2, MTL_FORMAT_R8_UNORM).map(|w| w.0),
         Some(1536)
     );
     // An index past the plane count resolves nothing rather than falling
     // back onto plane 0's bytes.
-    assert_eq!(type5_sample_window(m, 7, 4, 2, MTL_FORMAT_R8_UNORM), None);
+    assert_eq!(
+        ref_texture_sample_window(m, 7, 4, 2, MTL_FORMAT_R8_UNORM),
+        None
+    );
 }
 
 /// qemu-shim: guest page write IS the surface content (unified memory) —

--- a/crates/reims-vgpu/src/runtime/mapping_write/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/mapping_write/vulkan.rs
@@ -1,5 +1,5 @@
 //! The Vulkan rail's half of the mapping write: a resident's pixels straight
-//! into a type-11 mapping's guest pages, with the frame never existing on the
+//! into a mapper-ref-texture mapping's guest pages, with the frame never existing on the
 //! host.
 //!
 //! [`super`] owns the neutral half — where a mapping's plane is, what geometry
@@ -9,7 +9,7 @@
 //!
 //! This half is the GPU copy, and it is Vulkan's alone because the thing being
 //! copied is: `write_bgra8_from_resident_gpu` takes a `TargetIdentity`, and
-//! `licence_type11_surface` hands back a
+//! `licence_mapper_ref_texture_surface` hands back a
 //! [`crate::backend::vulkan::engine::GuestPageTarget`] — a permission to write
 //! guest pages that only a rail holding an import of them can grant.
 //!
@@ -280,7 +280,7 @@ fn plan_guest_window(
 /// ([`DeviceState::note_host_wrote_mapping`]) and the page footprint: a rail that
 /// lands frames without recording that it did makes
 /// [`crate::runtime::gather_witness`] attribute its own writes to the guest, and
-/// the type-11 resident rung above it then refuses residents and gathers whole
+/// the mapper-ref-texture resident rung above it then refuses residents and gathers whole
 /// surfaces per bind. That failure is measured and it costs more than this rail
 /// saves.
 ///
@@ -300,7 +300,7 @@ pub fn write_bgra8_from_resident_gpu<M: HostMemory + HostOps>(
     // This rail's own window, and the reason the licence does not resolve one:
     // a Store's destination *is* the surface, so a frame whose extent is not
     // the mapping's latched geometry is a frame for a mapping that has moved
-    // under it. That is a scanout rule and not a property of a type-11
+    // under it. That is a scanout rule and not a property of a mapper-ref-texture
     // destination — a compute dispatch writing a sub-rectangle is ordinary — so
     // it is asked here, by the caller it belongs to.
     if !scanout_extent_ok(width, height) {
@@ -321,18 +321,19 @@ pub fn write_bgra8_from_resident_gpu<M: HostMemory + HostOps>(
             frame_height: height,
         });
     }
-    let Some((base_off, bpr, span_end)) = type11_sample_window(m, mw, mh, format) else {
+    let Some((base_off, bpr, span_end)) = mapper_ref_texture_sample_window(m, mw, mh, format)
+    else {
         return Err(GpuWritebackDecline::WindowUnresolved {
             width: mw,
             height: mh,
             format,
         });
     };
-    let licence = licence_type11_surface(
+    let licence = licence_mapper_ref_texture_surface(
         state,
         host,
         identity.resident_format(),
-        &Type11SurfaceDestination {
+        &MapperRefTextureSurfaceDestination {
             mapping_id,
             base_off,
             bpr,
@@ -348,27 +349,27 @@ pub fn write_bgra8_from_resident_gpu<M: HostMemory + HostOps>(
         &licence.gpas,
     )
     .map_err(|inner| GpuWritebackDecline::Engine { inner })?;
-    note_type11_landed(state, mapping_id, licence.base_off, licence.span_end);
+    note_mapper_ref_texture_landed(state, mapping_id, licence.base_off, licence.span_end);
     Ok(licence.span_end - licence.base_off)
 }
 
-/// A window of a type-11 surface mapping the GPU is asked to write.
+/// A window of a mapper-ref-texture surface mapping the GPU is asked to write.
 ///
-/// The type-11 counterpart of
+/// The mapper-ref-texture counterpart of
 /// [`crate::runtime::render_writeback::vulkan::GvaPlaneDestination`], and it exists for
 /// the same reason: the licence must not resolve its own destination. Which
 /// window of which plane a copy lands in is the *caller's* knowledge, and the
 /// two callers here come by it differently — a render Store's destination is the
 /// whole surface, while a compute bind resolves a window at stage time, which
-/// may be a sub-rectangle and, for a type-5 view, names its IOSurface plane on
+/// may be a sub-rectangle and, for a ref-texture view, names its IOSurface plane on
 /// the wire.
 ///
 /// Resolving it inside the licence instead served the Store and silently
 /// mis-served everything else. It refused every sub-rectangle — 15 of the 19
 /// remaining compute readbacks on a driven macos-13 boot, all
 /// [`GpuWritebackDecline::GeometryMoved`] — and behind that refusal sat a worse
-/// failure it was hiding: [`type11_sample_window`] takes no plane index and
-/// matches by geometry, so a type-5 bind's frame would have landed in whichever
+/// failure it was hiding: [`mapper_ref_texture_sample_window`] takes no plane index and
+/// matches by geometry, so a ref-texture bind's frame would have landed in whichever
 /// plane happened to share its dimensions. [`resident_gpu_plane`]'s doc states
 /// the cost of exactly that disagreement, which is that there is no error — the
 /// frame lands in the wrong plane of the right surface and the symptom is the
@@ -377,7 +378,7 @@ pub fn write_bgra8_from_resident_gpu<M: HostMemory + HostOps>(
 /// `format` is what the guest will read these bytes back as, and must be the
 /// format the window was resolved against; the licence derives the bytes per
 /// texel from it rather than taking one, so there is no second answer to carry.
-pub(crate) struct Type11SurfaceDestination {
+pub(crate) struct MapperRefTextureSurfaceDestination {
     pub mapping_id: u32,
     /// Byte offset of the window's first texel within the mapping.
     pub base_off: u64,
@@ -390,9 +391,9 @@ pub(crate) struct Type11SurfaceDestination {
     pub format: u16,
 }
 
-/// A licensed direct-to-guest-pages destination over a type-11 surface mapping.
+/// A licensed direct-to-guest-pages destination over a mapper-ref-texture surface mapping.
 ///
-/// The type-11 counterpart of
+/// The mapper-ref-texture counterpart of
 /// [`crate::runtime::render_writeback::vulkan::GvaPlaneLicence`], and it exists for the
 /// same reason: the two rails that write a guest surface from the GPU — a render
 /// Store and a compute storage-image output — differ only in the image they copy
@@ -402,8 +403,8 @@ pub(crate) struct Type11SurfaceDestination {
 ///
 /// `base_off` and `span_end` are carried because the landing note needs them and
 /// deriving them a second time would be a second answer to a question the
-/// licence already asked. See [`note_type11_landed`].
-pub(crate) struct Type11SurfaceLicence {
+/// licence already asked. See [`note_mapper_ref_texture_landed`].
+pub(crate) struct MapperRefTextureSurfaceLicence {
     pub target: crate::backend::vulkan::engine::GuestPageTarget,
     /// The pages walked, in the surface's own order — what the copy is licensed
     /// over and what every witness on this path is armed against.
@@ -413,11 +414,11 @@ pub(crate) struct Type11SurfaceLicence {
     pub span_end: u64,
 }
 
-/// Licence a caller's type-11 surface window as a destination the GPU may copy
+/// Licence a caller's mapper-ref-texture surface window as a destination the GPU may copy
 /// into, or give the typed reason it may not.
 ///
 /// Takes the window rather than resolving one — see
-/// [`Type11SurfaceDestination`] for why that division is where it is. What is
+/// [`MapperRefTextureSurfaceDestination`] for why that division is where it is. What is
 /// shared between the two rails, and therefore lives here, is the format rule,
 /// the page-list plan, the page walk, the guest-RAM references and the two
 /// guest-write witnesses.
@@ -439,19 +440,19 @@ pub(crate) struct Type11SurfaceLicence {
 /// pages itself, so there is no second pair to compare and this is the only
 /// place the question can be asked. A storage image takes its format from the
 /// specialized SPIR-V texel format, which has no reason to match the format the
-/// bind staged its window against — banded at 3 of 35 type-11 windows on a
+/// bind staged its window against — banded at 3 of 35 mapper-ref-texture windows on a
 /// driven macos-13 boot — so on that rail it is not a healthy zero either.
 ///
 /// Asking it for both callers rather than for the one that needs it keeps the
 /// rule in the licence, where a third writer of a guest surface would meet it
 /// without knowing to look.
-pub(crate) fn licence_type11_surface<M: HostMemory + HostOps>(
+pub(crate) fn licence_mapper_ref_texture_surface<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,
     held: ash::vk::Format,
-    dst: &Type11SurfaceDestination,
-) -> Result<Type11SurfaceLicence, GpuWritebackDecline> {
-    let &Type11SurfaceDestination {
+    dst: &MapperRefTextureSurfaceDestination,
+) -> Result<MapperRefTextureSurfaceLicence, GpuWritebackDecline> {
+    let &MapperRefTextureSurfaceDestination {
         mapping_id,
         base_off,
         bpr,
@@ -542,7 +543,7 @@ pub(crate) fn licence_type11_surface<M: HostMemory + HostOps>(
     //
     // What used to stand here was the deferred rail's flush-on-access, whose
     // justification was that landing a pending window "can invalidate the
-    // mapping". There are no windows: a type-11 render Store lands its frame at
+    // mapping". There are no windows: a mapper-ref-texture render Store lands its frame at
     // the Store (see `render_writeback`'s module doc). Measured at **5 204
     // settles and 7.29 s blocked** on a driven Safari-drag boot — 42 % of every
     // wait in the device — for an ordering the queue already had.
@@ -650,7 +651,7 @@ pub(crate) fn licence_type11_surface<M: HostMemory + HostOps>(
         ReadbackPhase::Resolve,
         resolve_started.elapsed().as_micros() as u64,
     );
-    Ok(Type11SurfaceLicence {
+    Ok(MapperRefTextureSurfaceLicence {
         target,
         gpas,
         base_off,
@@ -658,7 +659,7 @@ pub(crate) fn licence_type11_surface<M: HostMemory + HostOps>(
     })
 }
 
-/// What a landed type-11 GPU write owes the rest of the device.
+/// What a landed mapper-ref-texture GPU write owes the rest of the device.
 ///
 /// Called once the copy is *issued*, not once it has completed, and by both
 /// rails that issue one — the render Store, which submits and waits, and the
@@ -670,8 +671,8 @@ pub(crate) fn licence_type11_surface<M: HostMemory + HostOps>(
 /// Every one of these errs in the same direction on purpose: a cache forgotten
 /// early costs a re-read of bytes that are about to change anyway, while one
 /// forgotten late hands out a stale frame as fresh. The same argument the
-/// witnesses in [`licence_type11_surface`] are armed on.
-pub(crate) fn note_type11_landed(
+/// witnesses in [`licence_mapper_ref_texture_surface`] are armed on.
+pub(crate) fn note_mapper_ref_texture_landed(
     state: &mut DeviceState,
     mapping_id: u32,
     base_off: u64,
@@ -720,7 +721,8 @@ pub fn synchronize_guest_backed_resident(
             frame_height: height,
         });
     }
-    let Some((base_off, _bpr, span_end)) = type11_sample_window(m, mw, mh, format) else {
+    let Some((base_off, _bpr, span_end)) = mapper_ref_texture_sample_window(m, mw, mh, format)
+    else {
         return Err(GpuWritebackDecline::WindowUnresolved {
             width: mw,
             height: mh,
@@ -1008,7 +1010,7 @@ mod tests {
         assert_ne!(via(&not_in_import), via(&scattered));
     }
 
-    /// The type-11 licence judges the window it is given, not the surface's extent.
+    /// The mapper-ref-texture licence judges the window it is given, not the surface's extent.
     ///
     /// A render Store's destination *is* the surface, so that caller refuses a frame
     /// whose rect is not the mapping's latched geometry — the test above drives
@@ -1025,7 +1027,7 @@ mod tests {
     /// so both stop at the reference gate — which is downstream of every rule the
     /// licence still owns, and therefore says both got through all of them.
     #[test]
-    fn a_type11_licence_judges_the_callers_window_and_not_the_surfaces_extent() {
+    fn a_mapper_ref_texture_licence_judges_the_callers_window_and_not_the_surfaces_extent() {
         use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
         use crate::model::PAGE_SHIFT_X86;
         const PAGE: u64 = 1 << PAGE_SHIFT_X86;
@@ -1051,7 +1053,7 @@ mod tests {
             pixel_format::store_texel_order(MTL_FORMAT_BGRA8_UNORM)
                 .expect("BGRA8 has a linear texel"),
         );
-        let dest = |width, height| Type11SurfaceDestination {
+        let dest = |width, height| MapperRefTextureSurfaceDestination {
             mapping_id: 7,
             base_off: 0,
             bpr: 64 * 4,
@@ -1061,8 +1063,8 @@ mod tests {
             format: MTL_FORMAT_BGRA8_UNORM,
         };
 
-        let whole = licence_type11_surface(&mut state, &mut host, held, &dest(64, 64));
-        let part = licence_type11_surface(&mut state, &mut host, held, &dest(44, 26));
+        let whole = licence_mapper_ref_texture_surface(&mut state, &mut host, held, &dest(64, 64));
+        let part = licence_mapper_ref_texture_surface(&mut state, &mut host, held, &dest(44, 26));
         for (what, got) in [("the whole surface", whole), ("a sub-rectangle", part)] {
             match got {
                 Err(GpuWritebackDecline::GuestRefRefused { .. }) => {}

--- a/crates/reims-vgpu/src/runtime/mipmap.rs
+++ b/crates/reims-vgpu/src/runtime/mipmap.rs
@@ -1,8 +1,8 @@
-//! `generateMipmaps` (blit opcode `0x133`) for multi-mip type-2/3 linear textures.
+//! `generateMipmaps` (blit opcode `0x133`) for multi-mip normal-texture linear textures.
 //!
-//! Type-11 IOSurface textures are out of scope: Metal forbids mipmapped
-//! IOSurface textures, so there is no legal multi-mip type-11 body to generate
-//! into. Non-type-2/3 refs fail as missing/unsupported at resolve.
+//! Mapper-ref-texture IOSurface textures are out of scope: Metal forbids mipmapped
+//! IOSurface textures, so there is no legal multi-mip mapper-ref-texture body to generate
+//! into. Non-normal-texture refs fail as missing/unsupported at resolve.
 //!
 //! Primary path: host Metal `generateMipmapsForTexture:` on a temporary Shared
 //! multi-level texture (native guest pixel format). CPU box-filter remains as a
@@ -13,7 +13,7 @@ use crate::backend::Backend as _;
 use crate::contract::pixel_format::{self, RGBA8_BPP};
 use crate::model::DeviceState;
 use crate::runtime::decode::resource::{
-    decode_texture_descriptor, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT,
+    decode_texture_descriptor, OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS,
     TEXTURE_MAX_MIP_LEVELS,
 };
 use crate::runtime::draw::host_alloc_len;
@@ -182,7 +182,7 @@ fn resolve_multi_mip_texture<M: HostMemory + HostOps>(
         host,
         task_id,
         texture_ref,
-        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_VARIANT],
+        &[OBJECT_TYPE_TEXTURE, OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS],
     )
     .map_err(|rung| {
         crate::observe::RungReport::new("mipmap_resolve", "tex_ref").rung(
@@ -439,7 +439,7 @@ fn generate_via_box_filter(
     Ok(out)
 }
 
-/// Execute blit `0x133 generateMipmaps` for a type-2/3 multi-mip linear texture.
+/// Execute blit `0x133 generateMipmaps` for a normal-texture multi-mip linear texture.
 pub fn generate_mipmaps_linear<M: HostMemory + HostOps>(
     state: &mut DeviceState,
     host: &mut M,

--- a/crates/reims-vgpu/src/runtime/mod.rs
+++ b/crates/reims-vgpu/src/runtime/mod.rs
@@ -37,7 +37,7 @@ pub mod decode;
 pub mod drain;
 /// The always-on log sink every decline and census writes to
 /// (`/tmp/reims-vgpu-fail.log`); `line()` is the `REIMS_VGPU_DRAW_LOG=1`-gated tier.
-/// CmdExecIndirect2 stream walk + type-11 resolve.
+/// CmdExecIndirect2 stream walk + mapper-ref-texture resolve.
 pub mod exec;
 /// Product-path event + encoder fence sync (event/blit/compute/render domains).
 pub mod fence_exec;
@@ -61,7 +61,7 @@ pub mod guest_ram_map;
 /// Task GVA → guest RAM reads.
 pub mod gva_mem;
 /// Gated with the `GuestWriteVerdict` it reuses and the `TargetIdentity` it
-/// keys on, both of which are Vulkan-side; the type-11 twin this mirrors
+/// keys on, both of which are Vulkan-side; the mapper-ref-texture twin this mirrors
 /// (`mapper::mapping_guest_write_verdict`) carries the same gate.
 #[cfg(feature = "backend-vulkan")]
 pub mod gva_store_witness;
@@ -73,7 +73,7 @@ pub mod host;
 /// Which guest pages this device has written, and when — the half of the
 /// guest-write witness the hypervisor's dirty bitmap cannot supply.
 pub mod host_writes;
-/// Type-7 ICB (0x36) materialization, host command fills, execute writeback.
+/// Serializer-object ICB (0x36) materialization, host command fills, execute writeback.
 pub mod icb;
 
 /// Metal draw encode + writeback when MTLBs resolve.
@@ -90,19 +90,19 @@ pub mod map_audit;
 pub mod mapper;
 /// Write host BGRA into guest mapping pages (render writeback).
 pub mod mapping_write;
-/// generateMipmaps for multi-mip type-2/3 linear textures.
+/// generateMipmaps for multi-mip normal-texture linear textures.
 pub mod mipmap;
 pub mod mmio;
 /// MTLB container → wrapped-AIR carve for metal2vulkan.
 pub mod mtlb;
 pub mod node_guard;
-/// Object-list lookup and type-11 registration.
+/// Object-list lookup and mapper-ref-texture registration.
 pub mod objects;
 /// A draw's pipeline and both its shaders, resolved once per pipeline object.
 #[cfg(feature = "backend-vulkan")]
 pub mod pipeline_resolve;
 pub mod plan;
-/// The resident identity a type-11 guest surface renders into.
+/// The resident identity a mapper-ref-texture guest surface renders into.
 #[cfg(feature = "backend-vulkan")]
 pub mod present_identity;
 /// Whether a range's page-table entries are in the state the guest's own next
@@ -127,7 +127,7 @@ pub mod spirv_vertex_input;
 pub mod surface_cache;
 /// The wire task word a command payload carries → a live task slot.
 pub mod task_slot;
-/// Texture / type-11 geometry registration.
+/// Texture / mapper-ref-texture geometry registration.
 pub mod texture;
 /// Track host-authoritative surface and GVA frames, and transfer them on demand.
 pub mod writeback_debt;

--- a/crates/reims-vgpu/src/runtime/mtlb.rs
+++ b/crates/reims-vgpu/src/runtime/mtlb.rs
@@ -1,7 +1,7 @@
-//! Guest type-6 function objects: loading the MTLB container, and carving the
+//! Guest function objects: loading the MTLB container, and carving the
 //! wrapped AIR out of it.
 //!
-//! Each type-6 object's descriptor names an MTLB container in guest memory;
+//! Each function object's descriptor names an MTLB container in guest memory;
 //! metal2vulkan consumes the LLVM BitcodeWrapper (`0x0b17c0de`) record inside.
 //! [`load_mtlb`](crate::runtime::mtlb::load_mtlb) does the first half
 //! (object list → container bytes) and
@@ -126,7 +126,7 @@ impl AirLoadRail {
     }
 }
 
-/// Load a type-6 function object's MTLB container out of guest memory.
+/// Load a function object's MTLB container out of guest memory.
 ///
 /// `None` means the caller gets no shader; every reason for it but one is
 /// written to the fail log under [`AirLoadRail::event`], because the callers all
@@ -298,7 +298,7 @@ mod tests {
     fn both_rails_name_the_rung_that_refused_under_their_own_event() {
         let mut host = FakeHost::new();
         let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
-        // Object type 11 is an IOSurface, not the type-6 function this loads.
+        // Object mapper-ref-texture is an IOSurface, not the function this loads.
         task_with_one_object(&mut host, &mut state, 11, &[0u8; 0x20]);
 
         let cap = crate::observe::FailCapture::start();

--- a/crates/reims-vgpu/src/runtime/objects/mod.rs
+++ b/crates/reims-vgpu/src/runtime/objects/mod.rs
@@ -1,10 +1,10 @@
-//! Object-list lookup, type-11 registration, and x86 type-4 surface backing.
+//! Object-list lookup, mapper-ref-texture registration, and x86 backing records.
 //!
 //! Live layout (reims-vgpu-resource-format): entry `ref` is at
 //! `(object_list_pfn << PAGE_SHIFT) + ref * 12` in the task GVA space —
 //! `[type|desc_len packed u32][desc_gva u64]`.
 //!
-//! **x86 type-4 present path (Ventura 13.7 RE):**
+//! **x86 backing present path (Ventura 13.7 RE):**
 //! `AppleParavirtResource::allocateBackingHandle` calls
 //! `ResourceHeap::addObject(type=4, objectId=IOSurface::getSurfaceID(), …)` so
 //! the object-list index for a surface-backed resource **is** the present
@@ -23,7 +23,7 @@ use crate::contract::iosurface_pages::{
 use crate::model::{DeviceState, MappingEntry, TaskResource, TaskTable};
 use crate::runtime::decode::resource::{
     decode_list_object_entry, list_object_entry_offset, ListObjectEntry, OBJECT_LIST_ENTRY_LEN,
-    OBJECT_TYPE_IOSURFACE,
+    OBJECT_TYPE_MAPPER_REF_TEXTURE,
 };
 use crate::runtime::gva_mem;
 use crate::runtime::host::HostMemory;
@@ -32,28 +32,28 @@ use std::sync::Arc;
 
 pub mod slot_recheck;
 
-/// Fail-visible, de-duplicated per `(task_id, ref)`, for the type-11 resolve
-/// blind spot: an object ref that IS a type-11 IOSurface texture but whose
+/// Fail-visible, de-duplicated per `(task_id, ref)`, for the mapper-ref-texture resolve
+/// blind spot: an object ref that IS a mapper-ref-texture IOSurface texture but whose
 /// descriptor cannot be read, cannot register a Metal/Vulkan texture, or carries
 /// `mapping_id==0` used to collapse into a bare `None` → a coarse
-/// `MissingTexture` at the draw site with no reason. `resolve_type11_ref` runs
+/// `MissingTexture` at the draw site with no reason. `resolve_mapper_ref_texture` runs
 /// per-draw per-ref (very hot), so a bare fail line would flood; the latch logs
 /// each `(task,ref,reason)` once and is cleared when the ref resolves
-/// ([`clear_type11_fail`]). Only genuine failures for a *confirmed IOSurface*
+/// ([`clear_mapper_ref_texture_fail`]). Only genuine failures for a *confirmed IOSurface*
 /// ref are routed here — the legitimate "ref is a different object type" and
 /// unbound-slot returns stay silent. Runs on the drain worker (off the QEMU main
 /// core).
-type Type11Failure = (u32, u32, &'static str);
-type Type11FailureSet = std::collections::HashSet<Type11Failure>;
+type MapperRefTextureFailure = (u32, u32, &'static str);
+type MapperRefTextureFailureSet = std::collections::HashSet<MapperRefTextureFailure>;
 
-fn type11_fail_latch() -> &'static std::sync::Mutex<Type11FailureSet> {
+fn mapper_ref_texture_fail_latch() -> &'static std::sync::Mutex<MapperRefTextureFailureSet> {
     use std::sync::{Mutex, OnceLock};
-    static SEEN: OnceLock<Mutex<Type11FailureSet>> = OnceLock::new();
-    SEEN.get_or_init(|| Mutex::new(Type11FailureSet::new()))
+    static SEEN: OnceLock<Mutex<MapperRefTextureFailureSet>> = OnceLock::new();
+    SEEN.get_or_init(|| Mutex::new(MapperRefTextureFailureSet::new()))
 }
 
-fn note_type11_fail(task_id: u32, ref_: u32, reason: &'static str, detail: String) {
-    let mut guard = type11_fail_latch()
+fn note_mapper_ref_texture_fail(task_id: u32, ref_: u32, reason: &'static str, detail: String) {
+    let mut guard = mapper_ref_texture_fail_latch()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     if guard.insert((task_id, ref_, reason)) {
@@ -63,22 +63,22 @@ fn note_type11_fail(task_id: u32, ref_: u32, reason: &'static str, detail: Strin
 
 /// Re-arm the fail latch for a ref that just resolved, so a later genuine
 /// failure on the same ref is logged again (catches flapping).
-fn clear_type11_fail(task_id: u32, ref_: u32) {
-    let mut guard = type11_fail_latch()
+fn clear_mapper_ref_texture_fail(task_id: u32, ref_: u32) {
+    let mut guard = mapper_ref_texture_fail_latch()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     guard.retain(|(t, r, _)| !(*t == task_id && *r == ref_));
 }
 
-/// Fail-visible, de-duplicated per `(surface_id, reason)`, for the type-4
+/// Fail-visible, de-duplicated per `(surface_id, reason)`, for the backing
 /// backing blind spot: a surface whose object-list descriptor decoded fine (an
-/// active task, a valid `Type4Surface`) but whose page-backing construction then
+/// active task, a valid `BackingRecord`) but whose page-backing construction then
 /// failed — every downstream present/Store for that surface paints **stale or
-/// black** with no reason. `apply_type4_backing` is reached from the per-present
+/// black** with no reason. `apply_backing` is reached from the per-present
 /// scanout path (`ensure_surface_for_present`, ~48/s under scroll), so a persistent
 /// backing failure would flood; the latch logs each `(surface_id, reason)` once
-/// and re-arms when the surface next resolves cleanly ([`clear_type4_fail`]), so a
-/// flapping backing is re-logged. Only genuine type-4 candidate failures are
+/// and re-arms when the surface next resolves cleanly ([`clear_backing_fail`]), so a
+/// flapping backing is re-logged. Only genuine backing candidate failures are
 /// routed here — the caller's speculative per-task `continue`s (surface absent
 /// from this task or a non-surface object type) stay silent. Runs on the drain
 /// worker (off the QEMU main core).
@@ -89,16 +89,16 @@ fn clear_type11_fail(task_id: u32, ref_: u32) {
 /// frequently **transient** — the guest had not finished mapping the surface
 /// when the per-present path first walked it, and the next attach resolves the
 /// same pages — and the log gave no way to tell that from a surface this device
-/// never managed to back. See [`clear_type4_fail`] for what the pair enables and
+/// never managed to back. See [`clear_backing_fail`] for what the pair enables and
 /// what it measured.
 ///
 /// `gva` is the backing base the refusal named, or `None` for the refusals
 /// raised before one can be computed (`sid_zero`, `page_size_zero`). It is the
 /// backing and not `surface_id` that identifies a recovery, because surface ids
 /// recycle within a boot and across geometries — the same caveat
-/// `apply_type4_backing`'s census line carries `gva0` for.
+/// `apply_backing`'s census line carries `gva0` for.
 #[derive(Clone, Copy)]
-struct ReportedType4Fail {
+struct ReportedBackingFail {
     gva: Option<u64>,
     /// When this refusal was first raised. **Never refreshed**, so its age is
     /// how long the surface has been unbacked.
@@ -108,25 +108,27 @@ struct ReportedType4Fail {
     last_at_ms: u64,
     /// How many times the device has asked and been refused, the first
     /// included. The whole point of the pair: see
-    /// [`type4_backing_outstanding_census`].
+    /// [`backing_outstanding_census`].
     attempts: u32,
 }
 
-type Type4FailLatch = std::collections::HashMap<(u32, &'static str), ReportedType4Fail>;
+type BackingFailLatch = std::collections::HashMap<(u32, &'static str), ReportedBackingFail>;
 
-fn type4_fail_latch() -> &'static std::sync::Mutex<Type4FailLatch> {
+fn backing_fail_latch() -> &'static std::sync::Mutex<BackingFailLatch> {
     use std::sync::{Mutex, OnceLock};
-    static SEEN: OnceLock<Mutex<Type4FailLatch>> = OnceLock::new();
-    SEEN.get_or_init(|| Mutex::new(Type4FailLatch::new()))
+    static SEEN: OnceLock<Mutex<BackingFailLatch>> = OnceLock::new();
+    SEEN.get_or_init(|| Mutex::new(BackingFailLatch::new()))
 }
 
-fn note_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, detail: String) {
+fn note_backing_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, detail: String) {
     let at_ms = crate::observe::elapsed_ms() as u64;
-    let mut guard = type4_fail_latch().lock().unwrap_or_else(|e| e.into_inner());
+    let mut guard = backing_fail_latch()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     match guard.entry((surface_id, reason)) {
         std::collections::hash_map::Entry::Occupied(mut slot) => {
             // A repeat is the retry the design asks for, and it stays quiet on
-            // the fail channel — `apply_type4_backing` is the per-present path
+            // the fail channel — `apply_backing` is the per-present path
             // and one line per frame would flood. It is counted instead, which
             // is what makes the silence readable.
             let held = slot.get_mut();
@@ -135,7 +137,7 @@ fn note_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, deta
             held.attempts = held.attempts.saturating_add(1);
         }
         std::collections::hash_map::Entry::Vacant(slot) => {
-            slot.insert(ReportedType4Fail {
+            slot.insert(ReportedBackingFail {
                 gva,
                 first_at_ms: at_ms,
                 last_at_ms: at_ms,
@@ -151,7 +153,7 @@ fn note_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, deta
 /// A surface lives in exactly one task's object list, so a search that walks
 /// tasks in order meets non-owners before it meets the owner. Those misses are
 /// the search working, not a backing failure, and reporting them as one is what
-/// put ~95 `type4_backing_fail reason=translate` lines on a driven boot's
+/// put ~95 `backing_fail reason=translate` lines on a driven boot's
 /// always-on channel for surfaces that then backed perfectly — the resolve
 /// succeeded on a later task and the line stayed behind to be read as a defect.
 ///
@@ -159,18 +161,18 @@ fn note_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, deta
 /// runs out of tasks. The first reason is kept rather than the last: it is the
 /// most specific one available, and the tail of a search is dominated by tasks
 /// that simply do not list the surface.
-struct PendingType4Fail {
+struct PendingBackingFail {
     reason: &'static str,
     gva: Option<u64>,
     detail: String,
 }
 
-type Type4PendingLatch = std::collections::HashMap<u32, PendingType4Fail>;
+type BackingPendingLatch = std::collections::HashMap<u32, PendingBackingFail>;
 
-fn type4_pending_latch() -> &'static std::sync::Mutex<Type4PendingLatch> {
+fn backing_pending_latch() -> &'static std::sync::Mutex<BackingPendingLatch> {
     use std::sync::{Mutex, OnceLock};
-    static PENDING: OnceLock<Mutex<Type4PendingLatch>> = OnceLock::new();
-    PENDING.get_or_init(|| Mutex::new(Type4PendingLatch::new()))
+    static PENDING: OnceLock<Mutex<BackingPendingLatch>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(BackingPendingLatch::new()))
 }
 
 /// Record why one task's probe refused, to be reported only if none succeeds.
@@ -179,11 +181,11 @@ fn type4_pending_latch() -> &'static std::sync::Mutex<Type4PendingLatch> {
 /// clean attach on the *same* backing can be recognised as a recovery rather
 /// than guessed at from `surface_id`. `None` where the refusal precedes any
 /// computable address.
-fn defer_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, detail: String) {
-    let mut guard = type4_pending_latch()
+fn defer_backing_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, detail: String) {
+    let mut guard = backing_pending_latch()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    guard.entry(surface_id).or_insert(PendingType4Fail {
+    guard.entry(surface_id).or_insert(PendingBackingFail {
         reason,
         gva,
         detail,
@@ -192,25 +194,25 @@ fn defer_type4_fail(surface_id: u32, reason: &'static str, gva: Option<u64>, det
 
 /// The search found no task that could back this surface: report the first
 /// probe's reason through the flood latch.
-fn flush_type4_fail(surface_id: u32) {
+fn flush_backing_fail(surface_id: u32) {
     let pending = {
-        let mut guard = type4_pending_latch()
+        let mut guard = backing_pending_latch()
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         guard.remove(&surface_id)
     };
     if let Some(pending) = pending {
-        note_type4_fail(surface_id, pending.reason, pending.gva, pending.detail);
+        note_backing_fail(surface_id, pending.reason, pending.gva, pending.detail);
     }
 }
 
-/// Re-arm the type-4 fail latch for a surface that just backed cleanly, drop the
+/// Re-arm the backing fail latch for a surface that just backed cleanly, drop the
 /// probe reasons the successful search left behind, and — when the backing that
 /// landed is the one a refusal named — say so.
 ///
 /// # A refusal here is usually a retry that then worked, and the log did not say
 ///
-/// `type4_backing_fail reason=translate` reads as lost guest work: the surface
+/// `backing_fail reason=translate` reads as lost guest work: the surface
 /// could not be backed, so every present for it paints stale or black. It is
 /// frequently nothing of the sort. `st=zero-pfn pte=0x0` means the guest had not
 /// filled the leaf PTE when the per-present path walked it, and the refusal is
@@ -248,23 +250,25 @@ fn flush_type4_fail(surface_id: u32) {
 /// backing:
 ///
 /// ```text
-///   type4_backing_recovered sid=25 reason=translate gva=0x42ab000 after_ms=5
-///   type4_backing_recovered sid=25 reason=translate gva=0x4282000 after_ms=7
-///   type4_backing_recovered sid=46 reason=translate gva=0x93b1000 after_ms=20
+///   backing_recovered sid=25 reason=translate gva=0x42ab000 after_ms=5
+///   backing_recovered sid=25 reason=translate gva=0x4282000 after_ms=7
+///   backing_recovered sid=46 reason=translate gva=0x93b1000 after_ms=20
 /// ```
 ///
 /// Note the two `sid=25` at different backings: the id really does get reused
 /// inside one boot, and matching on it would have paired the second refusal with
-/// the first attach. `type4_translate_refused` and `type4_backing_recovered` sum
+/// the first attach. `backing_translate_refused` and `backing_recovered` sum
 /// to 3 and 3 across the census windows, so the counters agree with the lines.
-fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
-    type4_pending_latch()
+fn clear_backing_fail(surface_id: u32, backed_gva: u64) {
+    backing_pending_latch()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .remove(&surface_id);
     let mut superseded = 0usize;
     let recovered: Vec<(&'static str, u64)> = {
-        let mut guard = type4_fail_latch().lock().unwrap_or_else(|e| e.into_inner());
+        let mut guard = backing_fail_latch()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Every entry for this surface is dropped, exactly as before: the latch
         // must re-arm or a later genuine failure on a recycled id goes unlogged.
         // Only the ones whose backing matches are *claimed* as recoveries.
@@ -281,7 +285,7 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
                 // re-pointed it, so the refusal is moot rather than repaired.
                 // Counted because it used to be the *third* way a refusal could
                 // leave the latch and the only one that said nothing, which made
-                // an unpaired `type4_backing_fail` unreadable: a reader diffing
+                // an unpaired `backing_fail` unreadable: a reader diffing
                 // the two line counts could not tell a refusal the guest walked
                 // away from apart from one that never came back.
                 superseded += 1;
@@ -291,7 +295,7 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
         out
     };
     if superseded > 0 {
-        crate::runtime::drain::note_store_route_n("type4_backing_superseded", superseded as u64);
+        crate::runtime::drain::note_store_route_n("backing_superseded", superseded as u64);
     }
     // After the early return, not before it: this runs on every clean attach
     // (the per-present scanout path) and almost every one of those has nothing
@@ -301,9 +305,9 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
     }
     let now = crate::observe::elapsed_ms() as u64;
     for (reason, at_ms) in recovered {
-        crate::runtime::drain::note_store_route("type4_backing_recovered");
+        crate::runtime::drain::note_store_route("backing_recovered");
         crate::observe::fail(format!(
-            "type4_backing_recovered sid={surface_id} reason={reason} gva={backed_gva:#x} \
+            "backing_recovered sid={surface_id} reason={reason} gva={backed_gva:#x} \
              after_ms={} (the earlier refusal for this backing was a retry; the guest \
              finished mapping and it landed)",
             now.saturating_sub(at_ms)
@@ -311,21 +315,21 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
     }
 }
 
-/// The type-4 refusals still latched, for the census — or `None` if there are
+/// The backing refusals still latched, for the census — or `None` if there are
 /// none.
 ///
 /// # The reading this exists to make possible
 ///
-/// A refusal leaves [`type4_fail_latch`] exactly three ways, and until this
+/// A refusal leaves [`backing_fail_latch`] exactly three ways, and until this
 /// existed only one of them said so. It is *recovered* when the surface backs at
-/// the address the refusal named, which emits `type4_backing_recovered`. It is
+/// the address the refusal named, which emits `backing_recovered`. It is
 /// *superseded* when the surface backs somewhere else — the guest re-pointed it,
-/// so the refusal is moot — which [`clear_type4_fail`] now counts. Or it is
+/// so the refusal is moot — which [`clear_backing_fail`] now counts. Or it is
 /// still here, which is the only one that can be lost guest work, and it was the
 /// silence the other two were mistaken for.
 ///
-/// The three add up: `type4_backing_fail` lines equal
-/// `type4_backing_recovered + type4_backing_superseded + n` from the last
+/// The three add up: `backing_fail` lines equal
+/// `backing_recovered + backing_superseded + n` from the last
 /// census window. That identity is the point — a reader who finds fewer
 /// recoveries than refusals now has a line to check instead of a hand-matched
 /// diff of backing GVAs, which is how this hole was found.
@@ -341,13 +345,13 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
 ///   frame and being refused every frame. **This is the one that is lost guest
 ///   work**, and every present for that surface is painting stale or black.
 /// - `attempts=1`, `since_last_ms` tracking `oldest_ms` — the device asked once,
-///   was refused, and **nothing has asked since**. `apply_type4_backing` is
+///   was refused, and **nothing has asked since**. `apply_backing` is
 ///   reached from the per-present path, so nothing asking means nothing is
 ///   presenting that surface: the guest is done with it. Nothing is lost.
 ///
 /// This carried one number, `oldest_ms`, and its doc read it exactly backwards —
 /// "`oldest_ms=12` is a refusal caught mid-retry; `oldest_ms=83000` is a surface
-/// this device never backed". [`note_type4_fail`] used a plain `insert`, so a
+/// this device never backed". [`note_backing_fail`] used a plain `insert`, so a
 /// retry *overwrote* the timestamp: an actively-retried refusal pins that age
 /// near zero forever, and a large one means the retries stopped. The sentence
 /// had it the wrong way round for both states, which is why the reading below
@@ -362,9 +366,9 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
 /// The identity closes exactly:
 ///
 /// ```text
-///   type4_backing_fail        8
-///   type4_backing_recovered   7
-///   type4_backing_superseded  0
+///   backing_fail        8
+///   backing_recovered   7
+///   backing_superseded  0
 ///   outstanding n             1      8 = 7 + 0 + 1
 /// ```
 ///
@@ -383,7 +387,7 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
 ///
 /// **Abandoned.** It is answerable from the third boot's own census series
 /// without any new signal, once `insert`'s refresh is accounted for. The 23
-/// `type4_backing_outstanding` lines run `oldest_ms` 204 → 22242 while `t` runs
+/// `backing_outstanding` lines run `oldest_ms` 204 → 22242 while `t` runs
 /// 401037 → 423075: the two deltas are **equal at every sample**, 22038 apiece.
 /// A timestamp that tracks wall clock exactly is a timestamp nothing refreshed,
 /// so the device asked once, at t=400833, and never again.
@@ -397,9 +401,11 @@ fn clear_type4_fail(surface_id: u32, backed_gva: u64) {
 /// and so the *other* state — a surface retried every frame and refused every
 /// frame — is not mistaken for it. That one is real lost work and this boot does
 /// not contain one.
-pub(crate) fn type4_backing_outstanding_census() -> Option<String> {
+pub(crate) fn backing_outstanding_census() -> Option<String> {
     let now = crate::observe::elapsed_ms() as u64;
-    let guard = type4_fail_latch().lock().unwrap_or_else(|e| e.into_inner());
+    let guard = backing_fail_latch()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     // The oldest entry is the one worth naming: it is the one least likely to
     // be a retry still in flight, and a single line cannot carry them all.
     let oldest = guard
@@ -408,7 +414,7 @@ pub(crate) fn type4_backing_outstanding_census() -> Option<String> {
         .map(|((sid, reason), reported)| (*sid, *reason, *reported))?;
     let (sid, reason, held) = oldest;
     Some(format!(
-        "type4_backing_outstanding n={} oldest_ms={} since_last_ms={} attempts={} \
+        "backing_outstanding n={} oldest_ms={} since_last_ms={} attempts={} \
          sid={sid} reason={reason} gva={}",
         guard.len(),
         now.saturating_sub(held.first_at_ms),
@@ -423,22 +429,22 @@ fn gva_text(gva: Option<u64>) -> String {
 }
 
 /// Wire object type for surface / IOSurface backing (x86 Tahoe/Ventura).
-pub const OBJECT_TYPE_SURFACE: u8 = 4;
+pub const OBJECT_TYPE_BACKING: u8 = 4;
 /// RefTextureHandle: surfaceID@0 + cookie@4 + guest blob@8 (texture-ref 28-06-26).
 pub const OBJECT_TYPE_REF_TEXTURE: u8 = 5;
-/// Type-5 RefTexture descriptor (RE `allocateRefTextureHandle` + Metal
+/// Ref-texture RefTexture descriptor (RE `allocateRefTextureHandle` + Metal
 /// `initWithDevice:descriptor:iosurface:plane:field:`):
-/// - `surfaceID@0` = `IOSurface::getSurfaceID()` = type-4 heap object id / mid
+/// - `surfaceID@0` = `IOSurface::getSurfaceID()` = backing heap object id / mid
 /// - `ownerTask@4` = the task whose object list holds that surface
 /// - `args@8..` = **serialized texture args** length `desc_len-8` (MTLTextureDescriptor
 ///   stream for the **plane** view; plane is applied guest-side before serialize)
 ///
-/// See [[reims-vgpu-resource-paging]] type-5 section.
-/// Type-5 descriptor geometry, from the wire crate's Tier-2 view of it.
+/// See [[reims-vgpu-resource-paging]] ref-texture section.
+/// Ref-texture descriptor geometry, from the wire crate's Tier-2 view of it.
 ///
 /// The ten offsets these used to be are `offset_of!` on
-/// [`reims_vgpu_wire::device_desc::Type5Header`], `Type5ArgsHeader` and
-/// `Type5TextureRecord`, asserted there against the numbers this module used to
+/// [`reims_vgpu_wire::device_desc::RefTextureHeader`], `RefTextureArgsHeader` and
+/// `RefTextureRecord`, asserted there against the numbers this module used to
 /// state. The two record tags come with them, since a tag is part of the
 /// layout's identity and not of this device's policy.
 pub(crate) use reims_vgpu_wire::device_desc::TYPE5_ARGS;
@@ -446,7 +452,7 @@ pub(crate) use reims_vgpu_wire::device_desc::TYPE5_ARGS;
 // rest through the wire views. These five are named only by the tests that
 // assert the layout, so they are gated with those tests rather than left
 // reachable from the staticlib. `TYPE5_RECORD_TAG_PLANE` is not among them:
-// its one caller builds the descriptor with `wire::device_desc::Type5Builder`
+// its one caller builds the descriptor with `wire::device_desc::RefTextureBuilder`
 // on the line above and now names the tag from the same module.
 #[cfg(test)]
 pub(crate) use reims_vgpu_wire::device_desc::{
@@ -454,16 +460,16 @@ pub(crate) use reims_vgpu_wire::device_desc::{
     TYPE5_SURFACE_ID,
 };
 
-/// Shortest type-5 descriptor: the header, with no args blob behind it.
+/// Shortest ref-texture descriptor: the header, with no args blob behind it.
 pub const TYPE5_MIN_LEN: usize = TYPE5_ARGS;
 
-/// Texture view named by a type-5 descriptor's serialized args record.
+/// Texture view named by a ref-texture descriptor's serialized args record.
 ///
 /// This is not limited to IOSurface planes. The live desktop also uses
 /// row-byte-equivalent reinterpretations such as a 480-wide RGBA32Uint view
 /// over a 1920-wide BGRA8 surface.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Type5TextureView {
+pub struct RefTextureView {
     pub pixel_format: u16,
     pub width: u32,
     pub height: u32,
@@ -473,10 +479,10 @@ pub struct Type5TextureView {
     pub plane_index: u32,
 }
 
-/// Report the owner task a type-5 descriptor names, once per distinct value.
+/// Report the owner task a ref-texture descriptor names, once per distinct value.
 ///
-/// Every type-4 surface this device has resolved lived in task 0 — measured
-/// (`type4_claimants`: `claims=1 winner=0` on every surface id of two driven
+/// Every backing record this device has resolved lived in task 0 — measured
+/// (`backing_claimants`: `claims=1 winner=0` on every surface id of two driven
 /// boots) and structural, since the guest registers IOSurface backings in the
 /// accelerator's kernel task whose id is a hardcoded 0.
 /// [`reims_vgpu_wire::device_desc::TYPE5_OWNER_TASK`] is
@@ -484,38 +490,38 @@ pub struct Type5TextureView {
 /// stays on the quiet channel.
 ///
 /// A non-zero value is the one reading that matters, and it is a failure line
-/// because two things would follow from it at once: the type-4 search's "task 0
+/// because two things would follow from it at once: the backing search's "task 0
 /// first" probe order is no longer the guest's answer, and the field's decoded
 /// meaning is wrong. `first_sight` is keyed on the value alone, so the whole
 /// boot costs one line whichever way it goes.
-fn note_type5_owner_task(desc: &[u8]) {
-    let Ok(h) = reims_vgpu_wire::device_desc::type5_header(desc) else {
+fn note_ref_texture_owner_task(desc: &[u8]) {
+    let Ok(h) = reims_vgpu_wire::device_desc::ref_texture_header(desc) else {
         return;
     };
     let task = h.owner_task.get();
-    if !crate::observe::first_sight("type5_owner_task", task as u64) {
+    if !crate::observe::first_sight("ref_texture_owner_task", task as u64) {
         return;
     }
-    let line = format!("type5_owner_task task={task}");
+    let line = format!("ref_texture_owner_task task={task}");
     if task == 0 {
         crate::observe::off(line);
     } else {
         crate::observe::fail(format!(
-            "{line} (a type-5 view names a surface owner other than the kernel task; \
-             the type-4 search probes task 0 first on the reading that this is always 0)"
+            "{line} (a ref-texture view names a surface owner other than the kernel task; \
+             the backing search probes task 0 first on the reading that this is always 0)"
         ));
     }
 }
 
-/// Decode the serialized texture-view record from a full type-5 descriptor.
+/// Decode the serialized texture-view record from a full ref-texture descriptor.
 ///
 /// Fail-closed: `None` unless the record tag matches and geometry is sane
 /// (2D, nonzero). The record names the exact Metal view (format + geometry)
 /// over the IOSurface bytes; callers must not replace it with base mapping
 /// geometry merely because the surface itself is otherwise stageable.
-pub fn decode_type5_texture_view(desc: &[u8]) -> Option<Type5TextureView> {
-    note_type5_owner_task(desc);
-    let rec = reims_vgpu_wire::device_desc::type5_texture_record(desc).ok()?;
+pub fn decode_ref_texture_view(desc: &[u8]) -> Option<RefTextureView> {
+    note_ref_texture_owner_task(desc);
+    let rec = reims_vgpu_wire::device_desc::ref_texture_record(desc).ok()?;
     // Both the biplanar-plane tag and the full-colour view variant share the
     // field layout; any other tag stays unknown → fail closed (no invented
     // geometry).
@@ -529,28 +535,29 @@ pub fn decode_type5_texture_view(desc: &[u8]) -> Option<Type5TextureView> {
     if pixel_format == 0 || width == 0 || height == 0 || depth != 1 {
         return None;
     }
-    Some(Type5TextureView {
+    Some(RefTextureView {
         pixel_format,
         width,
         height,
         depth,
         // `None` is a blob that stops before the field — pre-plane descriptors
         // and fixtures — which this rail reads as plane 0.
-        plane_index: reims_vgpu_wire::device_desc::type5_record_plane_index(desc).unwrap_or(0),
+        plane_index: reims_vgpu_wire::device_desc::ref_texture_record_plane_index(desc)
+            .unwrap_or(0),
     })
 }
 
 /// The stride is named only by the tests that walk a plane table by hand.
 #[cfg(test)]
 pub(crate) use reims_vgpu_wire::device_desc::TYPE4_PLANE_STRIDE;
-/// Type-4 descriptor geometry, from the wire crate's Tier-2 view of it.
+/// Backing descriptor geometry, from the wire crate's Tier-2 view of it.
 ///
 /// The eight offsets these used to be are now `offset_of!` on
-/// [`reims_vgpu_wire::device_desc::Type4SurfaceHeader`] and
-/// [`reims_vgpu_wire::device_desc::Type4PlaneRecord`], asserted there. Only the
+/// [`reims_vgpu_wire::device_desc::BackingHeader`] and
+/// [`reims_vgpu_wire::device_desc::BackingPlaneRecord`], asserted there. Only the
 /// four the device still computes with are re-exported.
 pub(crate) use reims_vgpu_wire::device_desc::{
-    type4_len_for, TYPE4_MIN_LEN, TYPE4_PLANES, TYPE4_PLANE_CAP,
+    backing_len_for, TYPE4_MIN_LEN, TYPE4_PLANES, TYPE4_PLANE_CAP,
 };
 
 /// CoreVideo / IOSurface biplanar 420 full-range (`'420f'`).
@@ -558,9 +565,9 @@ pub const IOSURFACE_FOURCC_420F: u32 = 0x3432_3066;
 /// CoreVideo / IOSurface biplanar 420 video-range (`'420v'`).
 pub const IOSURFACE_FOURCC_420V: u32 = 0x3432_3076;
 
-/// One type-4 plane record (stride 0x10 @ +0x14): offset, w, h, bpr|bpe<<24.
+/// One backing plane record (stride 0x10 @ +0x14): offset, w, h, bpr|bpe<<24.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Type4Plane {
+pub struct BackingPlane {
     pub offset: u32,
     pub width: u32,
     pub height: u32,
@@ -569,15 +576,15 @@ pub struct Type4Plane {
     pub bytes_per_element: u8,
 }
 
-/// Decoded type-4 surface backing descriptor.
+/// Decoded backing descriptor.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Type4Surface {
+pub struct BackingRecord {
     pub length: u64,
     pub backing_pfn: u32,
     /// Wire `pixelFormat@0xc` — OSType FourCC or small MTL ordinal.
     pub pixel_format: u32,
     pub plane_count: u8,
-    pub planes: [Type4Plane; TYPE4_PLANE_CAP],
+    pub planes: [BackingPlane; TYPE4_PLANE_CAP],
     /// Plane0 convenience (present / single-plane geom).
     pub width: u32,
     pub height: u32,
@@ -593,9 +600,9 @@ pub fn iosurface_fourcc_is_biplanar(pixel_format: u32) -> bool {
     matches!(pixel_format, IOSURFACE_FOURCC_420F | IOSURFACE_FOURCC_420V)
 }
 
-/// True when type-4 / mapping cannot be staged as one linear color texture.
+/// True when backing / mapping cannot be staged as one linear color texture.
 #[inline]
-pub fn type4_is_multiplanar(surf: &Type4Surface) -> bool {
+pub fn backing_is_multiplanar(surf: &BackingRecord) -> bool {
     surf.plane_count > 1 || iosurface_fourcc_is_biplanar(surf.pixel_format)
 }
 
@@ -616,7 +623,7 @@ pub fn mapping_is_multiplanar(m: &MappingEntry) -> bool {
 /// The device descriptor's `pixelFormat` word as a Metal format.
 ///
 /// That field carries **two** encodings and always has. On x86 this device
-/// synthesizes the descriptor and [`synthesize_device_desc_from_type4`] writes
+/// synthesizes the descriptor and [`synthesize_device_desc_from_backing`] writes
 /// the MTL ordinal for a known single-plane surface and the raw OSType FourCC
 /// otherwise. On arm64 the descriptor is the guest's own and the field holds
 /// whatever `getPixelFormat()` returned, which is a FourCC for media surfaces.
@@ -637,7 +644,7 @@ pub fn mapping_is_multiplanar(m: &MappingEntry) -> bool {
 /// through the FourCC table; a value that does fit is the ordinal it is.
 ///
 /// Unknown FourCCs and multi-plane OSTypes come back 0 — the same fail-closed
-/// refusal the type-4 path latches, never an invented BGRA8.
+/// refusal the backing path latches, never an invented BGRA8.
 pub fn device_desc_format_to_mtl(raw: u32) -> u16 {
     if raw <= u16::MAX as u32 {
         return raw as u16;
@@ -647,7 +654,7 @@ pub fn device_desc_format_to_mtl(raw: u32) -> u16 {
 
 /// Map IOSurface OSType FourCC (or MTL raw) to a **single-plane** MTL pixel format.
 ///
-/// Live x86 type-4 carries IOSurface `pixelFormat` as a FourCC (e.g. `'BGRA'` =
+/// Live x86 backing carries IOSurface `pixelFormat` as a FourCC (e.g. `'BGRA'` =
 /// `0x42475241`). Truncating to u16 yields `0x5241` which is not a Metal format.
 ///
 /// Returns **0** when:
@@ -671,9 +678,9 @@ pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
     // u16` for anything at or below 0x200, on the reading that such a value was
     // "already an MTLPixelFormat ordinal". That decided which *encoding* a field
     // was in from the field's magnitude, and the caller already knows: every
-    // caller here passes a type-4 `pixelFormat` (+0x0c), which is an IOSurface
-    // OSType — a four-character code, so never below 0x20202020. The type-11 and
-    // type-5 rails carry their MTL ordinal in a `u16` field of their own and do
+    // caller here passes a backing `pixelFormat` (+0x0c), which is an IOSurface
+    // OSType — a four-character code, so never below 0x20202020. The mapper-ref-texture and
+    // ref-texture rails carry their MTL ordinal in a `u16` field of their own and do
     // not route through this function.
     //
     // The magnitude test was also wrong at its own boundary: MTLPixelFormat
@@ -697,21 +704,21 @@ pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
         // Two independent sources agree on it, which is why it is stated rather
         // than proposed. A driven macos-13 x86/Vulkan boot running Asphalt 8
         // declares its 1280x720 render surface with this FourCC and then binds a
-        // **type-5 reference-texture view** over the same allocation whose own
+        // **ref-texture view** over the same allocation whose own
         // `pixel_format` field reads `0x5e` — the guest naming `BGR10A2Unorm`
-        // itself, reported as `rt_type5_view_differs sid=117 view=1280x720
-        // fmt=0x5e ... base fmt=0x0`. The surface geometry closes it: the type-4
+        // itself, reported as `rt_ref_texture_view_differs sid=117 view=1280x720
+        // fmt=0x5e ... base fmt=0x0`. The surface geometry closes it: the backing
         // record's `bytes_per_row` is 5120 over a width of 1280, which is four
         // bytes a texel, and its `length` 0x384000 is that stride times 720.
         //
         // Before this arm the surface reached `draw::render_target`'s
-        // `rt_type4_base_format` as a zero — that resolve's typed refusal for a
+        // `rt_backing_base_format` as a zero — that resolve's typed refusal for a
         // multi-plane or unknown-FourCC surface — so **every** draw of the frame
         // failed and the game's window was black. One 100 s capture of it held
         // 20 822 `draw_fail_clear_fallback` records and 0 successful draws.
         0x6c31_3072 => MTL_FORMAT_BGR10A2_UNORM,
         // Single-plane R8 / RG8 OSTypes used as plane textures (not biplanar media fourcc).
-        // 'L008' / common R8 fourccs are rare on type-4; MTL ordinals already handled above.
+        // 'L008' / common R8 fourccs are rare on backing; MTL ordinals already handled above.
         // 'R8  ' / 'RG08' if ever seen as OSType:
         0x5238_2020 => MTL_FORMAT_R8_UNORM,
         0x5247_3038 => MTL_FORMAT_RG8_UNORM,
@@ -720,10 +727,10 @@ pub fn iosurface_pixel_format_to_mtl(pixel_format: u32) -> u16 {
     }
 }
 
-/// Decode one type-4 plane record.
-fn decode_type4_plane(desc: &[u8], plane_index: usize) -> Option<Type4Plane> {
-    let r = reims_vgpu_wire::device_desc::type4_plane(desc, plane_index).ok()?;
-    Some(Type4Plane {
+/// Decode one backing plane record.
+fn decode_backing_plane(desc: &[u8], plane_index: usize) -> Option<BackingPlane> {
+    let r = reims_vgpu_wire::device_desc::backing_plane(desc, plane_index).ok()?;
+    Some(BackingPlane {
         offset: r.offset.get(),
         width: r.width.get(),
         height: r.height.get(),
@@ -732,7 +739,7 @@ fn decode_type4_plane(desc: &[u8], plane_index: usize) -> Option<Type4Plane> {
     })
 }
 
-/// The bytes of a type-4 surface descriptor that [`decode_type4_surface`] does
+/// The bytes of a backing record descriptor that [`decode_backing`] does
 /// **not** read: `+0x11..0x14` and everything past the plane records it
 /// consumed (`TYPE4_PLANES + plane_count * TYPE4_PLANE_STRIDE ..`).
 ///
@@ -752,8 +759,9 @@ fn decode_type4_plane(desc: &[u8], plane_index: usize) -> Option<Type4Plane> {
 /// content tiles alike:
 ///
 /// ```text
-/// type4_desc_shape distinct=1 1920x1080 fmt=0x42475241 planes=1 len=36 undecoded_len=3 undecoded_nz=0
-/// type4_desc_shape distinct=2   320x320 fmt=0x34323066 planes=2 len=52 undecoded_len=3 undecoded_nz=0
+/// backing_desc_shape distinct=1 1920x1080 fmt=0x42475241 planes=1 len=36 undecoded_len=3
+/// undecoded_nz=0 backing_desc_shape distinct=2 320x320 fmt=0x34323066 planes=2 len=52
+/// undecoded_len=3 undecoded_nz=0
 /// ```
 ///
 /// `len` is `TYPE4_PLANES + plane_count * TYPE4_PLANE_STRIDE` exactly, and it is
@@ -763,8 +771,8 @@ fn decode_type4_plane(desc: &[u8], plane_index: usize) -> Option<Type4Plane> {
 /// descriptor for a usage, bind, scanout or role hint to be, so no rule over
 /// surface identity can classify a brand-new buffer before its first draw.
 ///
-/// Narrow: this is the type-4 record on the x86 PCI pathway. It says nothing
-/// about type-11 (`decode_iosurface_texture_descriptor`, which does not run
+/// Narrow: this is the backing record on the x86 PCI pathway. It says nothing
+/// about mapper-ref-texture (`decode_iosurface_texture_descriptor`, which does not run
 /// here and whose 0x38/0x58 blobs are still read only to 0x20), and a
 /// create-time record we never read at all would be invisible to it.
 ///
@@ -774,20 +782,19 @@ fn decode_type4_plane(desc: &[u8], plane_index: usize) -> Option<Type4Plane> {
 ///
 /// Public so the probe's notion of "undecoded" is pinned by a test rather than
 /// restated in a log format string.
-pub fn undecoded_type4_surface_bytes(desc: &[u8]) -> Vec<u8> {
+pub fn undecoded_backing_bytes(desc: &[u8]) -> Vec<u8> {
     if desc.len() < TYPE4_MIN_LEN {
         return Vec::new();
     }
-    let Ok(h) = reims_vgpu_wire::device_desc::type4_header(desc) else {
+    let Ok(h) = reims_vgpu_wire::device_desc::backing_header(desc) else {
         return Vec::new();
     };
     let plane_count = (h.plane_count as usize).min(TYPE4_PLANE_CAP);
-    let planes_end = type4_len_for(plane_count);
+    let planes_end = backing_len_for(plane_count);
     let mut out = Vec::new();
     // The header's undecoded interior, named by the field rather than by the
     // literal it used to be: a field added before it moves this with it.
-    let reserved =
-        core::mem::offset_of!(reims_vgpu_wire::device_desc::Type4SurfaceHeader, reserved);
+    let reserved = core::mem::offset_of!(reims_vgpu_wire::device_desc::BackingHeader, reserved);
     out.extend_from_slice(&desc[reserved..TYPE4_PLANES]);
     if planes_end < desc.len() {
         out.extend_from_slice(&desc[planes_end..]);
@@ -804,7 +811,7 @@ pub fn undecoded_type4_surface_bytes(desc: &[u8]) -> Vec<u8> {
 /// new *value* is the interesting event here, so that is the key.
 ///
 /// Runs before the decoder's own validity checks, so a record that fails to
-/// decode still reports. An earlier version of this probe on the type-11
+/// decode still reports. An earlier version of this probe on the mapper-ref-texture
 /// descriptor sat after its length check and emitted nothing at all on a live
 /// boot; "the decoder never ran" and "the tail is constant" produced the same
 /// silence, which is the reading the probe exists to rule out.
@@ -812,14 +819,14 @@ pub fn undecoded_type4_surface_bytes(desc: &[u8]) -> Vec<u8> {
 /// Hitting the cap is reported once. A silent truncation would read like "we
 /// saw everything", which is the same class of error as a probe reporting a
 /// confident constant.
-fn note_type4_surface_shape(desc: &[u8]) {
+fn note_backing_shape(desc: &[u8]) {
     const MAX_SHAPES: usize = 24;
     const HEX_MAX: usize = 128;
     use std::sync::Mutex;
     type ShapeKey = (usize, Vec<u8>);
     static SEEN: Mutex<Option<std::collections::BTreeSet<ShapeKey>>> = Mutex::new(None);
 
-    let undecoded = undecoded_type4_surface_bytes(desc);
+    let undecoded = undecoded_backing_bytes(desc);
     let (fresh, distinct) = {
         let mut guard = SEEN.lock().unwrap_or_else(|p| p.into_inner());
         let seen = guard.get_or_insert_with(Default::default);
@@ -833,7 +840,7 @@ fn note_type4_surface_shape(desc: &[u8]) {
     }
     if distinct > MAX_SHAPES {
         crate::observe::fail(format!(
-            "type4_desc_shape outcome=cap_reached distinct={distinct} \
+            "backing_desc_shape outcome=cap_reached distinct={distinct} \
              (the undecoded span varies per surface; it is not a constant tail)"
         ));
         return;
@@ -843,8 +850,8 @@ fn note_type4_surface_shape(desc: &[u8]) {
     // restated at a second site, so the stride was declared once and its
     // contents twice.
     let (w, h, fmt, pc) = match (
-        reims_vgpu_wire::device_desc::type4_header(desc),
-        decode_type4_plane(desc, 0),
+        reims_vgpu_wire::device_desc::backing_header(desc),
+        decode_backing_plane(desc, 0),
     ) {
         (Ok(h), Some(p0)) => (p0.width, p0.height, h.pixel_format.get(), h.plane_count),
         _ => (0, 0, 0, 0),
@@ -855,7 +862,7 @@ fn note_type4_surface_shape(desc: &[u8]) {
         .map(|b| format!("{b:02x}"))
         .collect();
     crate::observe::fail(format!(
-        "type4_desc_shape distinct={distinct} {w}x{h} fmt={fmt:#x} planes={pc} len={} \
+        "backing_desc_shape distinct={distinct} {w}x{h} fmt={fmt:#x} planes={pc} len={} \
          undecoded_len={} undecoded_nz={} hex={hex}{}",
         desc.len(),
         undecoded.len(),
@@ -864,26 +871,27 @@ fn note_type4_surface_shape(desc: &[u8]) {
     ));
 }
 
-/// Report, once per reason, that the type-4 decoder dropped something the guest
+/// Report, once per reason, that the backing decoder dropped something the guest
 /// declared.
 ///
 /// Deduped rather than sampled: each reason names a distinct shape of blob, and
 /// a surface stream re-decodes the same descriptor thousands of times a boot, so
 /// an undeduped line would flood while adding nothing. The first occurrence is
-/// what a reader needs — after it, `type4_desc_shape` carries the geometry.
-fn type4_decode_drop_latch() -> &'static std::sync::Mutex<std::collections::HashSet<&'static str>> {
+/// what a reader needs — after it, `backing_desc_shape` carries the geometry.
+fn backing_decode_drop_latch() -> &'static std::sync::Mutex<std::collections::HashSet<&'static str>>
+{
     use std::sync::{Mutex, OnceLock};
     static SEEN: OnceLock<Mutex<std::collections::HashSet<&'static str>>> = OnceLock::new();
     SEEN.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
 }
 
-fn note_type4_decode_drop(reason: &'static str, detail: String) {
+fn note_backing_decode_drop(reason: &'static str, detail: String) {
     // The latch is flood protection, so the magnitude has to live somewhere it
     // survives: without this, a second malformed descriptor and a thousand of
     // them read identically — one line, and nothing to ask.
-    crate::runtime::drain::census::note_store_route("type4_desc_refused");
+    crate::runtime::drain::census::note_store_route("backing_desc_refused");
     let fresh = {
-        let mut guard = type4_decode_drop_latch()
+        let mut guard = backing_decode_drop_latch()
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         guard.insert(reason)
@@ -897,20 +905,20 @@ fn note_type4_decode_drop(reason: &'static str, detail: String) {
 /// occurrence rather than whatever an earlier test in the same process left
 /// behind.
 #[cfg(test)]
-fn reset_type4_decode_drops() {
-    type4_decode_drop_latch()
+fn reset_backing_decode_drops() {
+    backing_decode_drop_latch()
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .clear();
 }
 
-/// Decode a type-4 surface descriptor blob.
-pub fn decode_type4_surface(desc: &[u8]) -> Option<Type4Surface> {
-    note_type4_surface_shape(desc);
+/// Decode a backing record descriptor blob.
+pub fn decode_backing(desc: &[u8]) -> Option<BackingRecord> {
+    note_backing_shape(desc);
     if desc.len() < TYPE4_MIN_LEN {
         return None;
     }
-    let h = reims_vgpu_wire::device_desc::type4_header(desc).ok()?;
+    let h = reims_vgpu_wire::device_desc::backing_header(desc).ok()?;
     let length = h.length.get();
     let backing_pfn = h.backing_pfn.get();
     let pixel_format = h.pixel_format.get();
@@ -929,29 +937,29 @@ pub fn decode_type4_surface(desc: &[u8]) -> Option<Type4Surface> {
     // reader sees a well-formed surface — so the loss surfaces as a layer that
     // samples blank, which is indistinguishable from content that is genuinely
     // empty. `None` reaches the caller's existing
-    // `type4_backing_fail reason=desc_decode`, so the refusal is attributable to
+    // `backing_fail reason=desc_decode`, so the refusal is attributable to
     // the surface id that could not be decoded.
     if plane_count_raw as usize > TYPE4_PLANE_CAP {
         // The bound itself is right — IOSurface's own `getPlaneCount` caps at
         // eight — so a descriptor declaring more is malformed rather than
         // merely large, and there is no correct prefix of it to keep.
-        note_type4_decode_drop(
+        note_backing_decode_drop(
             "plane_count_over_cap",
             format!(
-                "type4_decode_drop reason=plane_count_over_cap declared={plane_count_raw} \
+                "backing_decode_drop reason=plane_count_over_cap declared={plane_count_raw} \
                  cap={TYPE4_PLANE_CAP} fmt={pixel_format:#x}"
             ),
         );
         return None;
     }
     let plane_count = plane_count_raw;
-    let mut planes = [Type4Plane::default(); TYPE4_PLANE_CAP];
+    let mut planes = [BackingPlane::default(); TYPE4_PLANE_CAP];
     for (i, plane) in planes.iter_mut().enumerate().take(plane_count as usize) {
-        let Some(p) = decode_type4_plane(desc, i) else {
-            note_type4_decode_drop(
+        let Some(p) = decode_backing_plane(desc, i) else {
+            note_backing_decode_drop(
                 "plane_record_short",
                 format!(
-                    "type4_decode_drop reason=plane_record_short plane={i} \
+                    "backing_decode_drop reason=plane_record_short plane={i} \
                      planes={plane_count} desc_len={} fmt={pixel_format:#x}",
                     desc.len()
                 ),
@@ -966,7 +974,7 @@ pub fn decode_type4_surface(desc: &[u8]) -> Option<Type4Surface> {
     } else {
         (0, 0, 0)
     };
-    Some(Type4Surface {
+    Some(BackingRecord {
         length,
         backing_pfn,
         pixel_format,
@@ -978,14 +986,14 @@ pub fn decode_type4_surface(desc: &[u8]) -> Option<Type4Surface> {
     })
 }
 
-/// Build `sIOSurfaceDeviceDescriptor` geometry from type-4 wire (no invent).
+/// Build `sIOSurfaceDeviceDescriptor` geometry from backing wire (no invent).
 ///
-/// Multi-plane: plane records from type-4 planes; sample path selects by
+/// Multi-plane: plane records from backing planes; sample path selects by
 /// geometry. Single-plane: surface-level fields only
 /// (`plane_count==0` path in `sample_window_from_device_desc`).
-fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
+fn synthesize_device_desc_from_backing(surf: &BackingRecord) -> Vec<u8> {
     let mut device_desc = vec![0u8; DEVICE_DESC_LEN];
-    let multi = type4_is_multiplanar(surf);
+    let multi = backing_is_multiplanar(surf);
     let mtl = iosurface_pixel_format_to_mtl(surf.pixel_format);
     // Device desc pixelFormat field: guest stores getPixelFormat() (FourCC for
     // biplanar media). Single-plane product sample uses MTL ordinal when known.
@@ -1004,10 +1012,10 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
     // than walking past the end — but it is still a size the guest did not ask
     // for, and it must not be published as though it were.
     let alloc = if surf.length > u32::MAX as u64 {
-        note_type4_decode_drop(
+        note_backing_decode_drop(
             "alloc_size_over_u32",
             format!(
-                "type4_decode_drop reason=alloc_size_over_u32 length={} \
+                "backing_decode_drop reason=alloc_size_over_u32 length={} \
                  published={} (device-descriptor allocSize is 32-bit)",
                 surf.length,
                 u32::MAX
@@ -1018,7 +1026,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
         surf.length as u32
     };
     st32(&mut device_desc[DEVICE_DESC_ALLOC_SIZE..], alloc);
-    // Surface-level dims/bpr from plane0 (same as type-4 plane0 convenience).
+    // Surface-level dims/bpr from plane0 (same as backing plane0 convenience).
     let dims = ((surf.width as u64) << 8) | ((surf.height as u64) << 40);
     st64(&mut device_desc[DEVICE_DESC_DIMS..], dims);
     if surf.bytes_per_row > 0 {
@@ -1026,7 +1034,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
     }
     if multi && surf.plane_count > 0 {
         // Multi-plane: publish plane records; sample_window_from_device_desc
-        // matches type-11 R8/RG8 binds by (w,h,bpe), and declines when two
+        // matches mapper-ref-texture R8/RG8 binds by (w,h,bpe), and declines when two
         // planes share all three. Do not invent bases from format alone.
         let n = (surf.plane_count as usize).min(TYPE4_PLANE_CAP);
         device_desc[DEVICE_DESC_PLANE_COUNT] = n as u8;
@@ -1040,7 +1048,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
             let base = DEVICE_DESC_PLANES + i * DEVICE_PLANE_DESC_LEN;
             st32(&mut device_desc[base + DEVICE_PLANE_OFFSET..], p.offset);
             // plane_size: 0 = skip size check in sample_window_from_device_plane
-            // (type-4 wire has offset/w/h/bpr, not a separate size field).
+            // (backing wire has offset/w/h/bpr, not a separate size field).
             st32(&mut device_desc[base + DEVICE_PLANE_SIZE..], 0);
             let pdims = ((p.width as u64) << 8) | ((p.height as u64) << 40);
             st64(&mut device_desc[base + DEVICE_PLANE_DIMS..], pdims);
@@ -1063,7 +1071,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
         device_desc[DEVICE_DESC_PLANE_COUNT] = 0;
         // Plane 0's offset, which this arm used to decode and then drop.
         //
-        // `decode_type4_plane` reads four fields per plane; the surface-level
+        // `decode_backing_plane` reads four fields per plane; the surface-level
         // convenience copies took three of them (width, height, bytes-per-row)
         // and left the offset behind, so a single-plane surface whose pixels
         // start past the base of its allocation was read and written at 0. The
@@ -1076,7 +1084,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
         // made the two pathways describe one surface differently.
         //
         // Zero is the ordinary value and stays silent; a non-zero one is the
-        // population that was being misread, and `type4_base_offset_nonzero`
+        // population that was being misread, and `backing_base_offset_nonzero`
         // counts how large that is. Read on a driven x86/Vulkan boot: **0**, so
         // no single-plane surface on that workload starts past its base and this
         // is contract fidelity rather than a live repair. It is also why the
@@ -1084,7 +1092,7 @@ fn synthesize_device_desc_from_type4(surf: &Type4Surface) -> Vec<u8> {
         // one the counter would have named.
         let base_offset = surf.planes[0].offset;
         if base_offset != 0 {
-            crate::runtime::drain::note_store_route("type4_base_offset_nonzero");
+            crate::runtime::drain::note_store_route("backing_base_offset_nonzero");
             st32(&mut device_desc[DEVICE_DESC_BASE_OFFSET..], base_offset);
         }
         if mtl != 0 {
@@ -1605,7 +1613,9 @@ pub fn resolve_sampler_state<M: HostMemory>(
     task_id: u32,
     sampler_ref: u32,
 ) -> Result<Arc<crate::model::TaskSamplerState>, SamplerResolveError> {
-    use crate::runtime::decode::resource::{decode_sampler_descriptor, OBJECT_TYPE_TYPE7};
+    use crate::runtime::decode::resource::{
+        decode_sampler_descriptor, OBJECT_TYPE_SERIALIZER_OBJECT,
+    };
 
     if let Some(sampler) = state.task_sampler_states.get(task_id, sampler_ref) {
         return Ok(sampler);
@@ -1613,7 +1623,7 @@ pub fn resolve_sampler_state<M: HostMemory>(
 
     let entry = lookup_list_entry(state, host, task_id, sampler_ref)
         .ok_or(SamplerResolveError::Rung(LadderRung::NoListEntry))?;
-    if entry.object_type != OBJECT_TYPE_TYPE7 {
+    if entry.object_type != OBJECT_TYPE_SERIALIZER_OBJECT {
         return Err(SamplerResolveError::Rung(LadderRung::WrongType {
             got: entry.object_type,
         }));
@@ -1644,13 +1654,15 @@ pub fn resolve_sampler_state<M: HostMemory>(
 
 /// Object tags constructed through the task's resource registry.
 ///
-/// Bit `n` names object type `n + 1`. The resource constructor accepts exactly
-/// types 1, 2, 3, 4, 5, 8, 9, 11, 12, 13, 14, and 15. Function (6), mutable
-/// serializer state (7), and type 10 have separate registries and lifetimes, so
-/// retaining their descriptors until `DeleteResource` would conflate distinct
-/// APIs. An immutable render pipeline constructed from a type-7 descriptor is
-/// retained separately in `DeviceState::task_render_pipeline_states`; the
-/// serializer bytes themselves remain outside this resource registry.
+/// Bit `n` names `APVObjectType` `n + 1`. The resource constructor accepts exactly 1, 2, 3, 4, 5,
+/// 8, 9, 11, 12, 13, 14, and 15 — every tag either rail's guest driver assigns to something with
+/// guest-owned storage: buffer, the two normal-texture tags, backing and ref texture on x86, the
+/// child/serializer texture, and on arm the mapper-ref texture, the dual-plane texture, the heap
+/// pair and the mapper-ref buffer. Function (6) and serializer objects (7) have separate registries
+/// and lifetimes, so retaining their descriptors until `DeleteResource` would conflate distinct
+/// APIs. An immutable render pipeline constructed from a serializer-object descriptor is retained
+/// separately in `DeviceState::task_render_pipeline_states`; the serializer bytes themselves remain
+/// outside this resource registry.
 const RESOURCE_CONSTRUCTOR_TYPE_MASK: u16 = 0x7d9f;
 
 fn object_type_is_resource(object_type: u8) -> bool {
@@ -1761,7 +1773,7 @@ pub fn resolve_resource<M: HostMemory>(
 /// found, and a descriptor cannot be read before the entry says where it is.
 ///
 /// `want` is a slice because several rails accept more than one tag —
-/// `OBJECT_TYPE_TEXTURE` and `OBJECT_TYPE_TEXTURE_VARIANT` are the standing
+/// `OBJECT_TYPE_TEXTURE` and `OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS` are the standing
 /// pair — and a single-tag caller passes a one-element slice rather than a
 /// second entry point that would drift from this one.
 ///
@@ -1814,7 +1826,7 @@ pub fn resolve_descriptor<M: HostMemory>(
     Ok((resource.entry, Arc::clone(&resource.descriptor)))
 }
 
-/// Why a type-1 buffer ref did not yield a backing span.
+/// Why a buffer ref did not yield a backing span.
 ///
 /// The three ways past [`resolve_descriptor`]'s rungs, which is the whole of
 /// what [`resolve_buffer_span`] can refuse for.
@@ -1829,10 +1841,10 @@ pub enum BufferSpanRefusal {
     NoBacking,
 }
 
-/// Resolve a type-1 buffer ref to its `(guest base address, allocation size)`.
+/// Resolve a buffer ref to its `(guest base address, allocation size)`.
 ///
 /// Three rails needed this and each wrote it out: `compute_exec`'s buffer-window
-/// read, `icb`'s type-1 bind, and `draw`'s vertex/fragment buffer load — which
+/// read, `icb`'s buffer bind, and `draw`'s vertex/fragment buffer load — which
 /// was found last, after this function already existed, and whose five refusals
 /// carried no `reason=` field at all, so none of them was in the log's ranking.
 /// They agreed on the four steps — resolve as
@@ -1885,10 +1897,10 @@ pub fn resolve_buffer_span_from_resource(
         .ok_or(BufferSpanRefusal::NoBacking)
 }
 
-/// Resolve object ref and, if type-11, latch mapping geometry + cache the entry.
+/// Resolve object ref and, if mapper-ref-texture, latch mapping geometry + cache the entry.
 ///
-/// Returns the mapping_id for type-11 textures, or None.
-pub fn resolve_type11_ref<M: HostMemory>(
+/// Returns the mapping_id for mapper-ref-textures, or None.
+pub fn resolve_mapper_ref_texture<M: HostMemory>(
     state: &mut DeviceState,
     host: &M,
     task_id: u32,
@@ -1897,18 +1909,18 @@ pub fn resolve_type11_ref<M: HostMemory>(
     let resource = match resolve_resource(state, host, task_id, ref_) {
         Ok(resource) => resource,
         Err(LadderRung::DescRead { .. }) => {
-            // Keep this failure scoped to a confirmed type-11 object. The
+            // Keep this failure scoped to a confirmed mapper-ref-texture object. The
             // second lookup is only on the failed-construction path; successful
             // binds retrieve the retained resource without a guest read.
             if let Some(entry) = lookup_list_entry(state, host, task_id, ref_)
-                .filter(|entry| entry.object_type == OBJECT_TYPE_IOSURFACE)
+                .filter(|entry| entry.object_type == OBJECT_TYPE_MAPPER_REF_TEXTURE)
             {
-                note_type11_fail(
+                note_mapper_ref_texture_fail(
                     task_id,
                     ref_,
-                    crate::observe::ladder_slug!("type11", desc_read),
+                    crate::observe::ladder_slug!("mapper_ref_texture", desc_read),
                     format!(
-                        "type11_resolve_fail reason=type11_desc_read task={task_id} ref={ref_} obj_type={} desc_gva={:#x} desc_len={}",
+                        "mapper_ref_texture_resolve_fail reason=mapper_ref_texture_desc_read task={task_id} ref={ref_} obj_type={} desc_gva={:#x} desc_len={}",
                         entry.object_type, entry.descriptor_gva, entry.descriptor_length
                     ),
                 );
@@ -1917,16 +1929,16 @@ pub fn resolve_type11_ref<M: HostMemory>(
         }
         Err(_) => return None,
     };
-    resolve_type11_resource(state, task_id, ref_, &resource)
+    resolve_mapper_ref_texture_resource(state, task_id, ref_, &resource)
 }
 
-/// Resolve an already-retained type-11 resource to its mapping.
+/// Resolve an already-retained mapper-ref-texture resource to its mapping.
 ///
 /// Draw preparation resolves each bound reference once and threads the
 /// resulting object through all of its consumers. Keeping this half separate
-/// prevents the type-11 branch from looking the same reference up again and
+/// prevents the mapper-ref-texture branch from looking the same reference up again and
 /// reparsing immutable construction bytes on every bind.
-pub fn resolve_type11_resource(
+pub fn resolve_mapper_ref_texture_resource(
     state: &mut DeviceState,
     task_id: u32,
     ref_: u32,
@@ -1934,12 +1946,12 @@ pub fn resolve_type11_resource(
 ) -> Option<u32> {
     let entry = resource.entry;
     let desc = &resource.descriptor;
-    if entry.object_type != OBJECT_TYPE_IOSURFACE {
+    if entry.object_type != OBJECT_TYPE_MAPPER_REF_TEXTURE {
         // Legitimate: this ref is a different object type, not a texture. Normal
-        // control flow (resolve_type11_refs skips it) — never a failure.
+        // control flow (resolve_mapper_ref_textures skips it) — never a failure.
         return None;
     }
-    if let Some(mapping_id) = resource.registered_type11_mapping() {
+    if let Some(mapping_id) = resource.registered_mapper_ref_texture_mapping() {
         return Some(mapping_id);
     }
     // Record the ref as live so the explicit delete path retires its associated
@@ -1953,13 +1965,19 @@ pub fn resolve_type11_resource(
             height,
             ..
         }) => {
-            if !texture::register_type11_geom(state, *mapping_id, *width, *height, *pixel_format) {
-                note_type11_fail(
+            if !texture::register_mapper_ref_texture_geom(
+                state,
+                *mapping_id,
+                *width,
+                *height,
+                *pixel_format,
+            ) {
+                note_mapper_ref_texture_fail(
                     task_id,
                     ref_,
-                    "type11_register",
+                    "mapper_ref_texture_register",
                     format!(
-                        "type11_resolve_fail reason=type11_register task={task_id} ref={ref_} desc_len={}",
+                        "mapper_ref_texture_resolve_fail reason=mapper_ref_texture_register task={task_id} ref={ref_} desc_len={}",
                         desc.len()
                     ),
                 );
@@ -1971,13 +1989,14 @@ pub fn resolve_type11_resource(
         // descriptors the total object decoder cannot name. This is a cold
         // refusal path; successfully constructed resources take the typed arm.
         Err(_) => {
-            if !texture::register_from_descriptor_bytes(state, OBJECT_TYPE_IOSURFACE, desc) {
-                note_type11_fail(
+            if !texture::register_from_descriptor_bytes(state, OBJECT_TYPE_MAPPER_REF_TEXTURE, desc)
+            {
+                note_mapper_ref_texture_fail(
                     task_id,
                     ref_,
-                    "type11_register",
+                    "mapper_ref_texture_register",
                     format!(
-                        "type11_resolve_fail reason=type11_register task={task_id} ref={ref_} desc_len={}",
+                        "mapper_ref_texture_resolve_fail reason=mapper_ref_texture_register task={task_id} ref={ref_} desc_len={}",
                         desc.len()
                     ),
                 );
@@ -1990,21 +2009,21 @@ pub fn resolve_type11_resource(
     if mapping_id == 0 {
         // Defensive for a compatibility decoder that ever accepts the sentinel
         // mapping id without registering it.
-        note_type11_fail(
+        note_mapper_ref_texture_fail(
             task_id,
             ref_,
-            "type11_mapping_zero",
+            "mapper_ref_texture_mapping_zero",
             format!(
-                "type11_resolve_fail reason=type11_mapping_zero task={task_id} ref={ref_} desc_len={}",
+                "mapper_ref_texture_resolve_fail reason=mapper_ref_texture_mapping_zero task={task_id} ref={ref_} desc_len={}",
                 desc.len()
             ),
         );
         return None;
     }
     state.texture_to_mapping.insert((task_id, ref_), mapping_id);
-    let mapping_id = resource.register_type11_mapping(mapping_id);
+    let mapping_id = resource.register_mapper_ref_texture_mapping(mapping_id);
     // Resolved: re-arm so a later genuine failure on this ref logs again.
-    clear_type11_fail(task_id, ref_);
+    clear_mapper_ref_texture_fail(task_id, ref_);
     Some(mapping_id)
 }
 
@@ -2047,7 +2066,7 @@ pub fn ensure_surface_for_texture_bind<M: HostMemory + crate::runtime::host::Hos
 /// Pure and separate from the emit so the composition is testable: the always-on
 /// sink has no in-memory capture, so a test can only reach this line by building
 /// it.
-fn type4_translate_fail_detail(
+fn backing_translate_fail_detail(
     surface_id: u32,
     task_id: u32,
     page: u64,
@@ -2056,31 +2075,31 @@ fn type4_translate_fail_detail(
     walk: &str,
 ) -> String {
     format!(
-        "type4_backing_fail reason=translate sid={surface_id} task={task_id} \
+        "backing_fail reason=translate sid={surface_id} task={task_id} \
          page={page}/{page_count} gva={gva:#x} walk=[{walk}] \
          (no translation in this task; not substituting the GVA)"
     )
 }
 
-/// Apply a decoded type-4 surface as page-table backing for `surface_id`.
+/// Apply a decoded backing record as page-table backing for `surface_id`.
 ///
-/// `backing_pfn` is a GPU-VA page (same source as type-2/3 textures). Translate
+/// `backing_pfn` is a GPU-VA page (same source as normal textures). Translate
 /// each consecutive GVA page through the task page table into GPA page entries
 /// the scanout path already understands.
-fn apply_type4_backing<M: HostMemory>(
+fn apply_backing<M: HostMemory>(
     state: &mut DeviceState,
     host: &M,
     task_id: u32,
     surface_id: u32,
-    surf: &Type4Surface,
+    surf: &BackingRecord,
 ) -> bool {
     if !crate::model::is_mapping_id(surface_id) {
-        defer_type4_fail(
+        defer_backing_fail(
             surface_id,
             "sid_zero",
             None,
             format!(
-                "type4_backing_fail reason=sid_zero sid={surface_id} task={task_id} \
+                "backing_fail reason=sid_zero sid={surface_id} task={task_id} \
                  (0 is the unbound-mapping sentinel; backing it would store pixels \
                  no attachment reader can address)"
             ),
@@ -2090,16 +2109,16 @@ fn apply_type4_backing<M: HostMemory>(
     let page_shift = state.page_shift;
     let page_size = page_size_of(page_shift);
     if page_size == 0 {
-        defer_type4_fail(
+        defer_backing_fail(
             surface_id,
             "page_size_zero",
             None,
-            format!("type4_backing_fail reason=page_size_zero sid={surface_id} task={task_id} page_shift={page_shift}"),
+            format!("backing_fail reason=page_size_zero sid={surface_id} task={task_id} page_shift={page_shift}"),
         );
         return false;
     }
     // The backing base this attempt is about. It identifies the refusal for
-    // `clear_type4_fail`, which is what lets a later clean attach on the *same*
+    // `clear_backing_fail`, which is what lets a later clean attach on the *same*
     // backing be recognised as a recovery — surface ids recycle, addresses do
     // not.
     let backing_base_gva = (surf.backing_pfn as u64) << page_shift;
@@ -2107,12 +2126,12 @@ fn apply_type4_backing<M: HostMemory>(
     // No host MiB budget: page count follows guest `surf.length` only.
     // Fail if zero or not host-addressable as a page-entry vector.
     if page_count == 0 || crate::runtime::draw::host_alloc_len(page_count).is_none() {
-        defer_type4_fail(
+        defer_backing_fail(
             surface_id,
             "page_count_oob",
             Some(backing_base_gva),
             format!(
-                "type4_backing_fail reason=page_count_oob sid={surface_id} task={task_id} len={:#x} page_count={page_count}",
+                "backing_fail reason=page_count_oob sid={surface_id} task={task_id} len={:#x} page_count={page_count}",
                 surf.length
             ),
         );
@@ -2121,11 +2140,11 @@ fn apply_type4_backing<M: HostMemory>(
     let task = match state.tasks.get(task_id) {
         Some(t) if t.active => t,
         _ => {
-            defer_type4_fail(
+            defer_backing_fail(
                 surface_id,
                 "task_inactive",
                 Some(backing_base_gva),
-                format!("type4_backing_fail reason=task_inactive sid={surface_id} task={task_id}"),
+                format!("backing_fail reason=task_inactive sid={surface_id} task={task_id}"),
             );
             return false;
         }
@@ -2153,8 +2172,8 @@ fn apply_type4_backing<M: HostMemory>(
     // code; the guess was standing in for an answer about to be available.
     //
     // Refusing also lets the task search do its job, which a guess ended.
-    // `apply_type4_backing` returning `true` stops the loop in
-    // `resolve_type4_surface_ex`, and task 0 is probed first, so a guess made
+    // `apply_backing` returning `true` stops the loop in
+    // `resolve_backing_ex`, and task 0 is probed first, so a guess made
     // task 0 claim surfaces it could not translate. That path is covered by
     // `the_task_search_reaches_the_owner_when_task_zero_cannot_translate`; it
     // has not been observed on the rig, where every attach resolves on task 0.
@@ -2163,12 +2182,12 @@ fn apply_type4_backing<M: HostMemory>(
     for i in 0..page_count {
         let gva = ((surf.backing_pfn as u64) + i) << page_shift;
         let Some(gpa) = gva_mem::translate_task_gva(host, task, gva, page_shift) else {
-            crate::runtime::drain::note_store_route("type4_translate_refused");
-            defer_type4_fail(
+            crate::runtime::drain::note_store_route("backing_translate_refused");
+            defer_backing_fail(
                 surface_id,
                 "translate",
                 Some(backing_base_gva),
-                type4_translate_fail_detail(
+                backing_translate_fail_detail(
                     surface_id,
                     task_id,
                     i,
@@ -2182,22 +2201,22 @@ fn apply_type4_backing<M: HostMemory>(
         gva_hits = gva_hits.saturating_add(1);
         let pfn = gpa >> page_shift;
         if pfn > u32::MAX as u64 {
-            defer_type4_fail(
+            defer_backing_fail(
                 surface_id,
                 "pfn_oob",
             Some(backing_base_gva),
-                format!("type4_backing_fail reason=pfn_oob sid={surface_id} task={task_id} page={i}/{page_count} gpa={gpa:#x} pfn={pfn:#x}"),
+                format!("backing_fail reason=pfn_oob sid={surface_id} task={task_id} page={i}/{page_count} gpa={gpa:#x} pfn={pfn:#x}"),
             );
             return false;
         }
         let entry = ((pfn as u32) << PAGE_ENTRY_PFN_SHIFT) | PAGE_ENTRY_VALID;
         // Sanity: entry_gpa must round-trip.
         if entry_gpa_shift(entry, page_shift) != Some(gpa & !(page_size - 1)) {
-            defer_type4_fail(
+            defer_backing_fail(
                 surface_id,
                 "entry_roundtrip",
             Some(backing_base_gva),
-                format!("type4_backing_fail reason=entry_roundtrip sid={surface_id} task={task_id} page={i}/{page_count} gpa={gpa:#x} entry={entry:#x}"),
+                format!("backing_fail reason=entry_roundtrip sid={surface_id} task={task_id} page={i}/{page_count} gpa={gpa:#x} entry={entry:#x}"),
             );
             return false;
         }
@@ -2230,7 +2249,7 @@ fn apply_type4_backing<M: HostMemory>(
         // the backing, so a refusal and a later resolve can be matched.
         //
         // Bring-up census (dims/fmt), not a drop — the genuine
-        // type-4 failures route through note_type4_fail with reason=. On the
+        // backing failures route through note_backing_fail with reason=. On the
         // always-on `off()` sink, not `fail()`: under surface recycling this
         // "first attach" re-fires per recycle (page_entries cleared by the
         // teardown), so on fail() it floods the curated real-error view (~4k
@@ -2243,28 +2262,30 @@ fn apply_type4_backing<M: HostMemory>(
         // later" can be a different surface wearing the same id.
         let gva0 = (surf.backing_pfn as u64) << page_shift;
         crate::observe::off(format!(
-            "type4 pages sid={surface_id} task={task_id} n={page_count} gva_hits={gva_hits} gva0={gva0:#x} gpa0={g0:#x} w={} h={} bpr={} len={:#x} fmt={:#x} planes={} multi={}",
+            "backing pages sid={surface_id} task={task_id} n={page_count} gva_hits={gva_hits} gva0={gva0:#x} gpa0={g0:#x} w={} h={} bpr={} len={:#x} fmt={:#x} planes={} multi={}",
             surf.width,
             surf.height,
             surf.bytes_per_row,
             surf.length,
             surf.pixel_format,
             surf.plane_count,
-            type4_is_multiplanar(surf) as u8
+            backing_is_multiplanar(surf) as u8
         ));
     }
 
     if !state.map_surface(surface_id) {
-        defer_type4_fail(
+        defer_backing_fail(
             surface_id,
             "map_surface",
             Some(backing_base_gva),
-            format!("type4_backing_fail reason=map_surface sid={surface_id} task={task_id} n={page_count}"),
+            format!(
+                "backing_fail reason=map_surface sid={surface_id} task={task_id} n={page_count}"
+            ),
         );
         return false;
     }
-    // Device desc from type-4 wire only (single- or multi-plane). No BGRA invent.
-    let device_desc = synthesize_device_desc_from_type4(surf);
+    // Device desc from backing wire only (single- or multi-plane). No BGRA invent.
+    let device_desc = synthesize_device_desc_from_backing(surf);
 
     let state_page_shift = state.page_shift;
     if let Some(m) = state.mappings.get_mut(&surface_id) {
@@ -2287,7 +2308,7 @@ fn apply_type4_backing<M: HostMemory>(
             // fail() view: per-recycle under animation churn it floods the
             // real-error view, at 793 lines in one measured boot.
             crate::observe::off(format!(
-                "type4_pages_refreshed sid={surface_id} task={task_id} n={} map_gen={}",
+                "backing_pages_refreshed sid={surface_id} task={task_id} n={} map_gen={}",
                 entries.len(),
                 m.map_generation
             ));
@@ -2299,7 +2320,7 @@ fn apply_type4_backing<M: HostMemory>(
             // had just called the SAME incarnation.
         }
         // The guest-physical footprint this incarnation authorises us to write.
-        // See `mapper::entry_gpa_span`; this is the type-4 adoption site, and it
+        // See `mapper::entry_gpa_span`; this is the backing adoption site, and it
         // is the one that carried every span in the x86 log.
         //
         // That reading used to be stated as "the page list arrives here, the
@@ -2323,7 +2344,7 @@ fn apply_type4_backing<M: HostMemory>(
                 crate::runtime::mapper::span_first_sight_key(surface_id, lo, hi, state_page_shift);
             if crate::observe::first_sight(crate::runtime::mapper::SPAN_SEEN_TYPE4, key) {
                 crate::observe::off(format!(
-                    "mapping_gpa_span mid={surface_id} gen={} pages={} src=type4 \
+                    "mapping_gpa_span mid={surface_id} gen={} pages={} src=backing \
                      lo={lo:#x} hi={:#x} pn_lo={:#x} pn_hi={:#x}",
                     m.map_generation,
                     entries.len(),
@@ -2342,7 +2363,7 @@ fn apply_type4_backing<M: HostMemory>(
         // and find out whether the entries still name the guest's memory —
         // without repeating the object search that found the surface. Written at
         // the assignment so the two cannot be updated independently.
-        m.type4_walk = Some(crate::model::Type4Walk {
+        m.backing_walk = Some(crate::model::BackingWalk {
             task_id,
             backing_pfn: surf.backing_pfn,
             map_generation: m.map_generation,
@@ -2378,34 +2399,30 @@ fn apply_type4_backing<M: HostMemory>(
     // Backing built cleanly — re-arm the fail latch so a later genuine failure
     // on this surface (flapping backing) is logged again, and report the earlier
     // refusal for *this* backing as the recovery it turned out to be.
-    clear_type4_fail(surface_id, backing_base_gva);
+    clear_backing_fail(surface_id, backing_base_gva);
     true
 }
 
-/// Resolve present `surface_id` to type-4 backing pages + geometry.
+/// Resolve present `surface_id` to backing pages + geometry.
 ///
-/// Scans active tasks: object-list slot `surface_id` must be type-4 (heap is
+/// Scans active tasks: object-list slot `surface_id` must be backing (heap is
 /// indexed by IOSurface surface ID). Returns true when pages were latched.
-pub fn resolve_type4_surface<M: HostMemory>(
+pub fn resolve_backing<M: HostMemory>(state: &mut DeviceState, host: &M, surface_id: u32) -> bool {
+    resolve_backing_ex(state, host, surface_id, false)
+}
+
+/// Like [`resolve_backing`] but always re-reads the object list / PT.
+pub fn resolve_backing_force<M: HostMemory>(
     state: &mut DeviceState,
     host: &M,
     surface_id: u32,
 ) -> bool {
-    resolve_type4_surface_ex(state, host, surface_id, false)
+    resolve_backing_ex(state, host, surface_id, true)
 }
 
-/// Like [`resolve_type4_surface`] but always re-reads the object list / PT.
-pub fn resolve_type4_surface_force<M: HostMemory>(
-    state: &mut DeviceState,
-    host: &M,
-    surface_id: u32,
-) -> bool {
-    resolve_type4_surface_ex(state, host, surface_id, true)
-}
-
-/// Latch the task that owns `surface_id` as its type-4 backing so the next
+/// Latch the task that owns `surface_id` as its backing so the next
 /// present-path scan tries it right after task 0.
-fn record_type4_owner(state: &mut DeviceState, surface_id: u32, task_id: u32) {
+fn record_backing_owner(state: &mut DeviceState, surface_id: u32, task_id: u32) {
     if let Some(m) = state.mappings.get_mut(&surface_id) {
         m.owner_task_hint = task_id;
     }
@@ -2422,7 +2439,7 @@ fn record_type4_owner(state: &mut DeviceState, surface_id: u32, task_id: u32) {
 /// naming pages that now back something else.
 ///
 /// Dropping the list is the whole action. It bumps `map_generation`, which is
-/// what retires the [`crate::model::Type4Walk`] latch and the resident/deferred
+/// what retires the [`crate::model::BackingWalk`] latch and the resident/deferred
 /// state keyed on that incarnation, and the next resolve re-walks the page table
 /// the guest has already rewritten.
 ///
@@ -2442,11 +2459,11 @@ fn record_type4_owner(state: &mut DeviceState, surface_id: u32, task_id: u32) {
 /// object is therefore resolved in the task's namespace; its integer must never
 /// be tried as a global mapping id first. Surface ids and resource refs overlap
 /// numerically. Treating a ref in task B as mapping `n` can retire the pages of
-/// an unrelated type-4 surface `n` owned by task A, after which a compositor
+/// an unrelated backing record `n` owned by task A, after which a compositor
 /// draw sees an unbound texture until that surface happens to be mapped again.
 ///
-/// A latched type-4 walk is the exact provenance of a direct surface mapping.
-/// Type-11 resources carry the task/ref-to-mapping association established at
+/// A latched backing walk is the exact provenance of a direct surface mapping.
+/// Mapper-ref-texture resources carry the task/ref-to-mapping association established at
 /// construction. Both routes require the packet's task; a bare integer match is
 /// not ownership.
 ///
@@ -2470,7 +2487,7 @@ pub fn replace_physical<H: HostMemory + crate::runtime::host::HostOps>(
         .get(&object_id)
         .and_then(|mapping| {
             mapping
-                .type4_walk
+                .backing_walk
                 .filter(|walk| walk.task_id == task_id)
                 .map(|_| object_id)
         })
@@ -2527,7 +2544,7 @@ pub fn replace_physical<H: HostMemory + crate::runtime::host::HostOps>(
 /// Say what a re-point named when no mapping belongs to the resource, and whether this
 /// device is holding anything else for it.
 ///
-/// A mapping is not the only place a resource's bytes can be cached. The type-2/3
+/// A mapping is not the only place a resource's bytes can be cached. The normal-texture
 /// rails key their host copies by object-list ref (`host_texture_surfaces`,
 /// `host_linear_textures`) rather than by mapping id, and neither carries a page
 /// list to notice a move — so "no mapping for this task-local resource" does
@@ -2630,13 +2647,17 @@ fn note_replace_physical_unmapped_after_invalidation<M: HostMemory>(
     }
 }
 
-/// The active tasks whose object list holds an `OBJECT_TYPE_SURFACE` at slot
+/// The active tasks whose object list holds an `OBJECT_TYPE_BACKING` at slot
 /// `surface_id` — every task the search could legitimately have stopped on.
 ///
 /// `lookup_list_entry` already refuses an inactive task, an out-of-range slot
 /// and an entry with no descriptor, so a task reaching the type test is one with
 /// a real object at that slot.
-fn type4_claimant_tasks<M: HostMemory>(state: &DeviceState, host: &M, surface_id: u32) -> Vec<u32> {
+fn backing_claimant_tasks<M: HostMemory>(
+    state: &DeviceState,
+    host: &M,
+    surface_id: u32,
+) -> Vec<u32> {
     // The live ids, not a fixed range. This walked `0..256` while the task table
     // was an array; `lookup_list_entry` refuses an inactive task before reading
     // anything, so the ids in between were never claimants and the answer is
@@ -2646,7 +2667,7 @@ fn type4_claimant_tasks<M: HostMemory>(state: &DeviceState, host: &M, surface_id
         .live_ids()
         .filter(|&task_id| {
             probe_list_entry(state, host, task_id, surface_id)
-                .is_some_and(|e| e.object_type == OBJECT_TYPE_SURFACE)
+                .is_some_and(|e| e.object_type == OBJECT_TYPE_BACKING)
         })
         .collect()
 }
@@ -2658,16 +2679,16 @@ fn type4_claimant_tasks<M: HostMemory>(state: &DeviceState, host: &M, surface_id
 /// nothing on the wire would say it chose wrong — there is no field to verify a
 /// candidate against. The object-list entry is `[type | desc_len]` plus
 /// `desc_gva` and carries no identity ([`decode_list_object_entry`]), and the
-/// type-4 descriptor is fully consumed: its only undecoded span is the three
+/// backing descriptor is fully consumed: its only undecoded span is the three
 /// bytes at `0x11`, which read zero on every distinct shape a driven boot
-/// produces (`type4_desc_shape … undecoded_nz=0`).
+/// produces (`backing_desc_shape … undecoded_nz=0`).
 ///
 /// So the question the wire cannot answer directly is answered by counting
 /// instead. A surface id only ever claimed by one task is a surface whose owner
 /// probe order cannot have gotten wrong, whatever order it used.
 ///
 /// The claim test is the object-list slot's type alone, not a descriptor read or
-/// a translation: a task that lists a type-4 surface at this slot is a task the
+/// a translation: a task that lists a backing record at this slot is a task the
 /// search could have stopped on. That keeps the sweep to one 12-byte guest read
 /// per active task, and it is taken once per surface id — whether a surface id
 /// is claimed twice is a property of the guest's allocation, not of this
@@ -2676,18 +2697,18 @@ fn type4_claimant_tasks<M: HostMemory>(state: &DeviceState, host: &M, surface_id
 /// `claims=1` is the healthy reading and stays on the quiet channel. More than
 /// one claimant is the case that makes the search's tie-break load-bearing, so
 /// that one is a failure line naming the tasks involved.
-fn note_type4_claimants<M: HostMemory>(
+fn note_backing_claimants<M: HostMemory>(
     state: &DeviceState,
     host: &M,
     surface_id: u32,
     winner: u32,
 ) {
-    if !crate::observe::first_sight("type4_claimants", surface_id as u64) {
+    if !crate::observe::first_sight("backing_claimants", surface_id as u64) {
         return;
     }
-    let claimants = type4_claimant_tasks(state, host, surface_id);
+    let claimants = backing_claimant_tasks(state, host, surface_id);
     let line = format!(
-        "type4_claimants sid={surface_id} winner={winner} claims={} tasks={claimants:?}",
+        "backing_claimants sid={surface_id} winner={winner} claims={} tasks={claimants:?}",
         claimants.len()
     );
     if claimants.len() > 1 {
@@ -2700,19 +2721,19 @@ fn note_type4_claimants<M: HostMemory>(
     }
 }
 
-/// The mapping format a type-4 backing latches: single-plane MTL only.
+/// The mapping format a backing latches: single-plane MTL only.
 ///
 /// Multi-plane and unknown-FourCC surfaces get `0`, and that zero is a decoded
 /// refusal rather than an absence — stage and paint must not invent BGRA, and
-/// type-11 selects planes through `device_desc` instead.
+/// mapper-ref-texture selects planes through `device_desc` instead.
 /// [`iosurface_pixel_format_to_mtl`] states the same rule for the conversion.
 ///
-/// Named rather than inlined at [`apply_type4_backing`] because
+/// Named rather than inlined at [`apply_backing`] because
 /// [`backing_matches_latched_geom`] has to compute the *same* value: it compares
 /// a freshly-read descriptor against `m.format`, which is whatever this returned
 /// last time.
-fn latched_mapping_format(surf: &Type4Surface) -> u16 {
-    if type4_is_multiplanar(surf) {
+fn latched_mapping_format(surf: &BackingRecord) -> u16 {
+    if backing_is_multiplanar(surf) {
         return 0;
     }
     iosurface_pixel_format_to_mtl(surf.pixel_format)
@@ -2721,13 +2742,13 @@ fn latched_mapping_format(surf: &Type4Surface) -> u16 {
 /// Whether the geometry already latched on this mapping is still the geometry
 /// the freshly-read descriptor declares.
 ///
-/// Both arms of [`resolve_type4_surface_ex`]'s freshness test ask this, and they
+/// Both arms of [`resolve_backing_ex`]'s freshness test ask this, and they
 /// used to ask it differently: the non-force arm compared width **and** height,
 /// the force arm compared width only. They are the same question — "may this
 /// resolve return without rebuilding" — and the force arm is the one that cannot
 /// afford to be looser, because `force_fresh` returns through
-/// [`win_type4_search`] *without* calling [`apply_type4_backing`], so neither
-/// `set_mapping_geom` nor `synthesize_device_desc_from_type4` runs. A height
+/// [`win_backing_search`] *without* calling [`apply_backing`], so neither
+/// `set_mapping_geom` nor `synthesize_device_desc_from_backing` runs. A height
 /// change that stays inside the same page count therefore left `m.height` and
 /// the whole device descriptor describing the previous incarnation, on the exact
 /// path `ensure_surface_for_present` calls to catch a wire geometry change.
@@ -2741,11 +2762,11 @@ fn latched_mapping_format(surf: &Type4Surface) -> u16 {
 /// surface as changed, and comparing the raw conversion would report every
 /// multi-plane surface as changed forever, since the latch deliberately discards
 /// it in favour of 0.
-fn backing_matches_latched_geom(m: &MappingEntry, surf: &Type4Surface) -> bool {
+fn backing_matches_latched_geom(m: &MappingEntry, surf: &BackingRecord) -> bool {
     m.width == surf.width && m.height == surf.height && m.format == latched_mapping_format(surf)
 }
 
-/// The order [`resolve_type4_surface_ex`] probes task object lists in: task 0,
+/// The order [`resolve_backing_ex`] probes task object lists in: task 0,
 /// then the cached owner hint, then every other task once.
 ///
 /// An iterator rather than a materialised list. The order is unchanged, but
@@ -2764,7 +2785,7 @@ fn backing_matches_latched_geom(m: &MappingEntry, surf: &Type4Surface) -> bool {
 /// liveness test per id per present. Task 0 leads whether or not it is live —
 /// see the caller for why the guest's kernel task is named rather than found —
 /// so it is filtered out of the tail rather than left to `live_ids` to omit.
-fn type4_probe_order(tasks: &TaskTable, hint: u32) -> Vec<u32> {
+fn backing_probe_order(tasks: &TaskTable, hint: u32) -> Vec<u32> {
     std::iter::once(0)
         .chain(Some(hint).filter(|&h| h != 0))
         .chain(tasks.live_ids().filter(move |&tid| tid != 0 && tid != hint))
@@ -2772,18 +2793,18 @@ fn type4_probe_order(tasks: &TaskTable, hint: u32) -> Vec<u32> {
 }
 
 /// Take `task_id` as the owner of `surface_id` and report the search's exposure.
-fn win_type4_search<M: HostMemory>(
+fn win_backing_search<M: HostMemory>(
     state: &mut DeviceState,
     host: &M,
     surface_id: u32,
     task_id: u32,
 ) -> bool {
-    record_type4_owner(state, surface_id, task_id);
-    note_type4_claimants(state, host, surface_id, task_id);
+    record_backing_owner(state, surface_id, task_id);
+    note_backing_claimants(state, host, surface_id, task_id);
     true
 }
 
-fn resolve_type4_surface_ex<M: HostMemory>(
+fn resolve_backing_ex<M: HostMemory>(
     state: &mut DeviceState,
     host: &M,
     surface_id: u32,
@@ -2797,15 +2818,15 @@ fn resolve_type4_surface_ex<M: HostMemory>(
     // all 256 slots), then the remaining tasks.
     //
     // Task 0 leads because the guest says so, not because it is where surfaces
-    // have happened to be. A type-5 view carries the owning task at
+    // have happened to be. A ref-texture view carries the owning task at
     // [`TYPE5_OWNER_TASK`] and it is the accelerator's kernel task, whose id is a
     // hardcoded 0 and whose slot the task-id allocator reserves before any client
-    // task exists. `note_type5_owner_task` fails loudly if that ever reads
+    // task exists. `note_ref_texture_owner_task` fails loudly if that ever reads
     // otherwise.
     //
     // The remaining 255 probes are not dead weight on that reading. They cost
     // nothing on the path that matters — every successful resolve measured has
-    // stopped on the first probe — and they are what makes `type4_claimants` able
+    // stopped on the first probe — and they are what makes `backing_claimants` able
     // to say a second task claims the id at all.
     //
     // Built as an iterator rather than a `Vec`. The order is the same one, but
@@ -2818,39 +2839,39 @@ fn resolve_type4_surface_ex<M: HostMemory>(
         .map(|m| m.owner_task_hint)
         .unwrap_or(0);
 
-    for task_id in type4_probe_order(&state.tasks, hint) {
+    for task_id in backing_probe_order(&state.tasks, hint) {
         // Count the guest-read cost of one active-task object-list probe.
         let Some(entry) = probe_list_entry(state, host, task_id, surface_id) else {
             continue;
         };
-        if entry.object_type != OBJECT_TYPE_SURFACE {
+        if entry.object_type != OBJECT_TYPE_BACKING {
             continue;
         }
         let Some(desc) = read_descriptor(state, host, task_id, &entry) else {
-            defer_type4_fail(
+            defer_backing_fail(
                 surface_id,
                 crate::observe::ladder_slug!("", desc_read),
                 None,
                 format!(
-                    "type4_backing_fail reason=desc_read sid={surface_id} task={task_id} desc_gva={:#x} desc_len={}",
+                    "backing_fail reason=desc_read sid={surface_id} task={task_id} desc_gva={:#x} desc_len={}",
                     entry.descriptor_gva, entry.descriptor_length
                 ),
             );
             continue;
         };
         let _ = state.insert_object(task_id, surface_id);
-        let Some(surf) = decode_type4_surface(&desc) else {
-            defer_type4_fail(
+        let Some(surf) = decode_backing(&desc) else {
+            defer_backing_fail(
                 surface_id,
                 crate::observe::ladder_slug!("", desc_decode),
                 None,
                 format!(
-                    "type4_backing_fail reason=desc_decode sid={surface_id} task={task_id} desc_len={} backing_pfn={:#x} length={:#x}",
+                    "backing_fail reason=desc_decode sid={surface_id} task={task_id} desc_len={} backing_pfn={:#x} length={:#x}",
                     desc.len(),
-                    reims_vgpu_wire::device_desc::type4_header(&desc)
+                    reims_vgpu_wire::device_desc::backing_header(&desc)
                         .map(|h| h.backing_pfn.get())
                         .unwrap_or(0),
-                    reims_vgpu_wire::device_desc::type4_header(&desc)
+                    reims_vgpu_wire::device_desc::backing_header(&desc)
                         .map(|h| h.length.get())
                         .unwrap_or(0)
                 ),
@@ -2874,7 +2895,7 @@ fn resolve_type4_surface_ex<M: HostMemory>(
             if same_geom {
                 // Same geom + non-empty pages: keep (guest double-buffer
                 // may still rewrite page *content* without changing pfn).
-                return win_type4_search(state, host, surface_id, task_id);
+                return win_backing_search(state, host, surface_id, task_id);
             }
         } else if let Some(m) = state.mappings.get(&surface_id) {
             // Force: keep the cached table only while the CURRENT task
@@ -2913,7 +2934,7 @@ fn resolve_type4_surface_ex<M: HostMemory>(
                         force_fresh = true;
                     } else {
                         crate::observe::fail(format!(
-                            "type4_pages_stale sid={surface_id} task={task_id} n={} gpa0={:#x} (task PT translation moved; rebuilding)",
+                            "backing_pages_stale sid={surface_id} task={task_id} n={} gpa0={:#x} (task PT translation moved; rebuilding)",
                             m.page_entries.len(),
                             entry_gpa_shift(m.page_entries[0], page_shift).unwrap_or(0)
                         ));
@@ -2922,21 +2943,21 @@ fn resolve_type4_surface_ex<M: HostMemory>(
             }
         }
         if force_fresh {
-            return win_type4_search(state, host, surface_id, task_id);
+            return win_backing_search(state, host, surface_id, task_id);
         }
-        if apply_type4_backing(state, host, task_id, surface_id, &surf) {
-            return win_type4_search(state, host, surface_id, task_id);
+        if apply_backing(state, host, task_id, surface_id, &surf) {
+            return win_backing_search(state, host, surface_id, task_id);
         }
     }
     // No task could back it. Only now is a probe's refusal a backing failure.
-    flush_type4_fail(surface_id);
+    flush_backing_fail(surface_id);
     false
 }
 
-/// Ensure surface backing for present: type-4 pages when needed, else keep arm
+/// Ensure surface backing for present: backing pages when needed, else keep arm
 /// MappingInternal path.
 ///
-/// Resolves type-4 once pages are empty; guest double-buffering uses distinct
+/// Resolves backing once pages are empty; guest double-buffering uses distinct
 /// surface_ids (content updates land in-place on an already-mapped pfn).
 pub fn ensure_surface_for_present<M: HostMemory + crate::runtime::host::HostOps>(
     state: &mut DeviceState,
@@ -2952,10 +2973,10 @@ pub fn ensure_surface_for_present<M: HostMemory + crate::runtime::host::HostOps>
         .map(|m| !m.mapped || m.page_entries.is_empty())
         .unwrap_or(true);
     if need {
-        let _ = resolve_type4_surface(state, host, surface_id);
+        let _ = resolve_backing(state, host, surface_id);
     } else {
         // Opportunistic refresh if wire geom changed (mode switch).
-        let _ = resolve_type4_surface_force(state, host, surface_id);
+        let _ = resolve_backing_force(state, host, surface_id);
     }
     // Arm/iosfc path: MappingInternal resolve when captured.
     let _ = crate::runtime::mapper::ensure_resolved_for_scanout(state, host, surface_id);

--- a/crates/reims-vgpu/src/runtime/objects/tests.rs
+++ b/crates/reims-vgpu/src/runtime/objects/tests.rs
@@ -1,42 +1,42 @@
-use reims_vgpu_wire::device_desc::Type4Builder;
+use reims_vgpu_wire::device_desc::BackingBuilder;
 
 use super::*;
 use crate::contract::endian::{ld32, st16, st32, st64};
 use crate::contract::gva::{DIRECTORY_DEPTH, DIRECTORY_ROOT_PFN};
 use crate::contract::iosurface_pages::DEVICE_DESC_PLANE_COUNT;
 use crate::model::{DeviceId, PAGE_SHIFT_ARM64E, PAGE_SHIFT_X86};
-use crate::runtime::decode::resource::TYPE7_OBJECT_SAMPLER;
+use crate::runtime::decode::resource::SERIALIZER_OBJECT_SAMPLER;
 use crate::runtime::host::FakeHost;
 
 #[test]
-fn type11_fail_latch_dedups_per_task_ref_and_rearms_on_clear() {
+fn mapper_ref_texture_fail_latch_dedups_per_task_ref_and_rearms_on_clear() {
     // Flood guard for the per-draw-per-ref resolve path: a genuinely-broken
-    // type-11 ref logs each reason once, isolates per (task,ref), and
+    // mapper-ref-texture ref logs each reason once, isolates per (task,ref), and
     // re-arms on resolve. Unique ids so this never races real refs across
     // the process-global latch.
     let (t, r, r2) = (0xAB01u32, 0xCD01u32, 0xCD02u32);
-    clear_type11_fail(t, r);
-    clear_type11_fail(t, r2);
+    clear_mapper_ref_texture_fail(t, r);
+    clear_mapper_ref_texture_fail(t, r2);
     let seen = |task: u32, rf: u32, reason: &'static str| {
-        type11_fail_latch()
+        mapper_ref_texture_fail_latch()
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .contains(&(task, rf, reason))
     };
-    note_type11_fail(t, r, "type11_register", "x".into());
-    assert!(seen(t, r, "type11_register"));
+    note_mapper_ref_texture_fail(t, r, "mapper_ref_texture_register", "x".into());
+    assert!(seen(t, r, "mapper_ref_texture_register"));
     // Distinct reason on the same ref tracked independently.
-    note_type11_fail(t, r, "type11_desc_read", "x".into());
-    assert!(seen(t, r, "type11_desc_read"));
+    note_mapper_ref_texture_fail(t, r, "mapper_ref_texture_desc_read", "x".into());
+    assert!(seen(t, r, "mapper_ref_texture_desc_read"));
     // A different ref is untouched.
-    assert!(!seen(t, r2, "type11_register"));
-    note_type11_fail(t, r2, "type11_register", "x".into());
+    assert!(!seen(t, r2, "mapper_ref_texture_register"));
+    note_mapper_ref_texture_fail(t, r2, "mapper_ref_texture_register", "x".into());
     // Clearing r re-arms only r, leaves r2.
-    clear_type11_fail(t, r);
-    assert!(!seen(t, r, "type11_register"));
-    assert!(!seen(t, r, "type11_desc_read"));
-    assert!(seen(t, r2, "type11_register"));
-    clear_type11_fail(t, r2);
+    clear_mapper_ref_texture_fail(t, r);
+    assert!(!seen(t, r, "mapper_ref_texture_register"));
+    assert!(!seen(t, r, "mapper_ref_texture_desc_read"));
+    assert!(seen(t, r2, "mapper_ref_texture_register"));
+    clear_mapper_ref_texture_fail(t, r2);
 }
 
 fn setup_task_with_list(host: &mut FakeHost, state: &mut DeviceState) {
@@ -70,7 +70,7 @@ fn setup_task_with_list(host: &mut FakeHost, state: &mut DeviceState) {
 }
 
 #[test]
-fn resolve_type11_from_list() {
+fn resolve_mapper_ref_texture_from_list() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
@@ -78,27 +78,27 @@ fn resolve_type11_from_list() {
     let e = lookup_list_entry(&state, &host, 1, 1).expect("list entry");
     assert_eq!(e.object_type, 11);
     assert_eq!(e.descriptor_gva, 0x40);
-    let mid = resolve_type11_ref(&mut state, &host, 1, 1).expect("type11");
+    let mid = resolve_mapper_ref_texture(&mut state, &host, 1, 1).expect("mapper_ref_texture");
     assert_eq!(mid, 9);
     let m = state.mappings.get(&9).unwrap();
     assert!(m.has_geom);
     assert_eq!((m.width, m.height, m.format), (64, 32, 0x50));
 }
 
-/// Registering a type-11 texture is construction, not bind-time repair.
+/// Registering a mapper-ref-texture is construction, not bind-time repair.
 ///
 /// Once the task owns the texture object, later binds retrieve that object and
 /// must not replay its serialized descriptor over mutable mapping state. A new
 /// descriptor can take effect only after the resource lifetime ends.
 #[test]
-fn a_retained_type11_texture_runs_construction_side_effects_once() {
+fn a_retained_mapper_ref_texture_runs_construction_side_effects_once() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
     let resource = resolve_resource(&state, &host, 1, 1).expect("construction");
 
     assert_eq!(
-        resolve_type11_resource(&mut state, 1, 1, &resource),
+        resolve_mapper_ref_texture_resource(&mut state, 1, 1, &resource),
         Some(9)
     );
     {
@@ -109,7 +109,7 @@ fn a_retained_type11_texture_runs_construction_side_effects_once() {
     }
 
     assert_eq!(
-        resolve_type11_resource(&mut state, 1, 1, &resource),
+        resolve_mapper_ref_texture_resource(&mut state, 1, 1, &resource),
         Some(9)
     );
     let mapping = &state.mappings[&9];
@@ -182,7 +182,7 @@ fn resources_keep_construction_input_until_explicit_delete() {
         )
     ));
     assert_eq!(
-        resolve_type11_resource(&mut state, 1, 1, &retained),
+        resolve_mapper_ref_texture_resource(&mut state, 1, 1, &retained),
         Some(9),
         "the retained typed object resolves after its construction bytes become unreadable"
     );
@@ -195,7 +195,7 @@ fn resources_keep_construction_input_until_explicit_delete() {
     assert!(!Arc::ptr_eq(&first, &replacement));
     assert_eq!(ld32(&replacement.descriptor), 10);
     assert_eq!(
-        resolve_type11_resource(&mut state, 1, 1, &replacement),
+        resolve_mapper_ref_texture_resource(&mut state, 1, 1, &replacement),
         Some(10),
         "the replacement lifetime runs its own construction side effects"
     );
@@ -230,39 +230,42 @@ fn the_resource_registry_accepts_exactly_the_resource_constructor_types() {
 /// must not retain its descriptor and hide a later update.
 #[test]
 fn non_resource_descriptors_are_read_again() {
-    use crate::runtime::decode::resource::OBJECT_TYPE_TYPE7;
+    use crate::runtime::decode::resource::OBJECT_TYPE_SERIALIZER_OBJECT;
 
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
     let data_gpa = 4u64 << PAGE_SHIFT_ARM64E;
     let mut entry = [0u8; 12];
-    st32(&mut entry, u32::from(OBJECT_TYPE_TYPE7) | (4u32 << 8));
+    st32(
+        &mut entry,
+        u32::from(OBJECT_TYPE_SERIALIZER_OBJECT) | (4u32 << 8),
+    );
     entry[4..].copy_from_slice(&0x80u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa + 24, &entry);
     let _ = host.write_gpa(data_gpa + 0x80, &1u32.to_le_bytes());
 
-    let (_, first) = resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_TYPE7])
+    let (_, first) = resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_SERIALIZER_OBJECT])
         .expect("first serializer descriptor");
     assert_eq!(ld32(&first), 1);
     assert!(state.task_resources.get(1, 2).is_none());
 
     let _ = host.write_gpa(data_gpa + 0x80, &2u32.to_le_bytes());
-    let (_, second) = resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_TYPE7])
+    let (_, second) = resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_SERIALIZER_OBJECT])
         .expect("updated serializer descriptor");
     assert_eq!(ld32(&second), 2);
     assert!(state.task_resources.get(1, 2).is_none());
 }
 
 fn put_sampler_object(host: &mut FakeHost, ref_: u32, descriptor_gva: u64, lod_min: f32) {
-    use crate::runtime::decode::resource::OBJECT_TYPE_TYPE7;
+    use crate::runtime::decode::resource::OBJECT_TYPE_SERIALIZER_OBJECT;
     use reims_vgpu_wire::ops::sampler::NEW_SAMPLER_TOTAL_LEN;
 
     let data_gpa = 4u64 << PAGE_SHIFT_ARM64E;
     let mut entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     st32(
         &mut entry,
-        u32::from(OBJECT_TYPE_TYPE7) | (NEW_SAMPLER_TOTAL_LEN << 8),
+        u32::from(OBJECT_TYPE_SERIALIZER_OBJECT) | (NEW_SAMPLER_TOTAL_LEN << 8),
     );
     st64(&mut entry[4..], descriptor_gva);
     let _ = host.write_gpa(
@@ -271,7 +274,7 @@ fn put_sampler_object(host: &mut FakeHost, ref_: u32, descriptor_gva: u64, lod_m
     );
 
     let mut descriptor = vec![0u8; NEW_SAMPLER_TOTAL_LEN as usize];
-    st32(&mut descriptor, TYPE7_OBJECT_SAMPLER);
+    st32(&mut descriptor, SERIALIZER_OBJECT_SAMPLER);
     st32(&mut descriptor[4..], NEW_SAMPLER_TOTAL_LEN);
     st32(&mut descriptor[8..], ref_);
     st32(&mut descriptor[12..], 0x8400_0000);
@@ -307,17 +310,20 @@ fn sampler_construction_is_retained_until_its_own_explicit_delete() {
 
 #[test]
 fn failed_sampler_construction_is_not_retained_and_can_retry() {
-    use crate::runtime::decode::resource::OBJECT_TYPE_TYPE7;
+    use crate::runtime::decode::resource::OBJECT_TYPE_SERIALIZER_OBJECT;
 
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
     let data_gpa = 4u64 << PAGE_SHIFT_ARM64E;
     let mut short_entry = [0u8; OBJECT_LIST_ENTRY_LEN];
-    st32(&mut short_entry, u32::from(OBJECT_TYPE_TYPE7) | (4 << 8));
+    st32(
+        &mut short_entry,
+        u32::from(OBJECT_TYPE_SERIALIZER_OBJECT) | (4 << 8),
+    );
     st64(&mut short_entry[4..], 0x80);
     let _ = host.write_gpa(data_gpa + 24, &short_entry);
-    let _ = host.write_gpa(data_gpa + 0x80, &TYPE7_OBJECT_SAMPLER.to_le_bytes());
+    let _ = host.write_gpa(data_gpa + 0x80, &SERIALIZER_OBJECT_SAMPLER.to_le_bytes());
 
     assert!(matches!(
         resolve_sampler_state(&state, &host, 1, 2),
@@ -343,7 +349,7 @@ fn task_teardown_retires_sampler_objects_without_touching_outstanding_owners() {
     assert_eq!(sampler.descriptor.lod_min_clamp, 2.0);
 }
 
-/// The type-4 decoder refuses a descriptor it cannot decode as declared, and
+/// The backing decoder refuses a descriptor it cannot decode as declared, and
 /// says which check refused.
 ///
 /// All three of these bounds are correct — IOSurface caps `getPlaneCount` at
@@ -357,22 +363,33 @@ fn task_teardown_retires_sampler_objects_without_touching_outstanding_owners() {
 /// the guest declared. Neither reads as a decode failure downstream — both are
 /// well-formed surfaces — so the loss appears as a layer that samples blank,
 /// which is what content that is genuinely empty also looks like. `None` reaches
-/// the caller's `type4_backing_fail reason=desc_decode`, which names the surface
+/// the caller's `backing_fail reason=desc_decode`, which names the surface
 /// id.
 ///
 /// Fails without the fix: both decodes return `Some`.
 #[test]
-fn the_type4_decoder_refuses_what_it_cannot_decode_and_reports_why() {
+fn the_backing_decoder_refuses_what_it_cannot_decode_and_reports_why() {
     // Twelve planes against IOSurface's own ceiling of eight.
-    let over_cap = Type4Builder::new(0x1000, 0x100, 0x4247_5241, 12).with_len(0x24); // 'BGRA'
-                                                                                     // A legal plane count whose records the blob does not reach: `with_len`
-                                                                                     // stops after plane 0, so planes 1..=3 are declared and unreachable.
-    let short_records = Type4Builder::new(0x1000, 0x100, 0x4247_5241, 4).with_len(0x24);
+    let over_cap = BackingBuilder::new(0x1000, 0x100, 0x4247_5241, 12).with_len(0x24); // 'BGRA'
+                                                                                       // A legal
+                                                                                       // plane count
+                                                                                       // whose
+                                                                                       // records the
+                                                                                       // blob does
+                                                                                       // not reach:
+                                                                                       // `with_len`
+                                                                                       // stops after
+                                                                                       // plane 0, so
+                                                                                       // planes 1..=3
+                                                                                       // are declared
+                                                                                       // and
+                                                                                       // unreachable.
+    let short_records = BackingBuilder::new(0x1000, 0x100, 0x4247_5241, 4).with_len(0x24);
 
-    reset_type4_decode_drops();
+    reset_backing_decode_drops();
     let cap = crate::observe::FailCapture::start();
     assert!(
-        decode_type4_surface(over_cap.bytes()).is_none(),
+        decode_backing(over_cap.bytes()).is_none(),
         "a plane count past IOSurface's own ceiling is a malformed descriptor, \
          and there is no correct prefix of it to publish"
     );
@@ -391,7 +408,7 @@ fn the_type4_decoder_refuses_what_it_cannot_decode_and_reports_why() {
     // every time; only the line is deduped.
     let cap2 = crate::observe::FailCapture::start();
     assert!(
-        decode_type4_surface(over_cap.bytes()).is_none(),
+        decode_backing(over_cap.bytes()).is_none(),
         "the latch must not turn the second refusal into an acceptance"
     );
     assert!(
@@ -403,10 +420,10 @@ fn the_type4_decoder_refuses_what_it_cannot_decode_and_reports_why() {
     );
 
     // A declared plane whose record the blob does not reach.
-    reset_type4_decode_drops();
+    reset_backing_decode_drops();
     let cap3 = crate::observe::FailCapture::start();
     assert!(
-        decode_type4_surface(short_records.bytes()).is_none(),
+        decode_backing(short_records.bytes()).is_none(),
         "a declared plane the blob does not reach must refuse the surface, \
          not publish a 0x0 plane in its slot"
     );
@@ -421,12 +438,12 @@ fn the_type4_decoder_refuses_what_it_cannot_decode_and_reports_why() {
     );
 
     // A surface larger than the 32-bit `allocSize` field can express.
-    reset_type4_decode_drops();
-    let big =
-        Type4Builder::new((u32::MAX as u64) + 1, 0x100, 0x4247_5241, 1).plane(0, 0, 64, 32, 256, 0);
-    let surf = decode_type4_surface(big.bytes()).expect("type4 decodes");
+    reset_backing_decode_drops();
+    let big = BackingBuilder::new((u32::MAX as u64) + 1, 0x100, 0x4247_5241, 1)
+        .plane(0, 0, 64, 32, 256, 0);
+    let surf = decode_backing(big.bytes()).expect("backing decodes");
     let cap4 = crate::observe::FailCapture::start();
-    let _ = synthesize_device_desc_from_type4(&surf);
+    let _ = synthesize_device_desc_from_backing(&surf);
     let sat = cap4
         .lines()
         .into_iter()
@@ -436,7 +453,7 @@ fn the_type4_decoder_refuses_what_it_cannot_decode_and_reports_why() {
 }
 
 #[test]
-fn decode_type4_plane0() {
+fn decode_backing_plane0() {
     let mut desc = vec![0u8; 0x30];
     st64(&mut desc[0..], 0x1000);
     st32(&mut desc[8..], 0x100); // backing pfn
@@ -446,13 +463,13 @@ fn decode_type4_plane0() {
     st32(&mut desc[0x18..], 64);
     st32(&mut desc[0x1c..], 32);
     st32(&mut desc[0x20..], 256); // bpr
-    let s = decode_type4_surface(&desc).expect("type4");
+    let s = decode_backing(&desc).expect("backing");
     assert_eq!(s.length, 0x1000);
     assert_eq!(s.backing_pfn, 0x100);
     assert_eq!((s.width, s.height, s.bytes_per_row), (64, 32, 256));
     assert_eq!(s.plane_count, 1);
     assert_eq!(s.planes[0].offset, 0);
-    assert!(!type4_is_multiplanar(&s));
+    assert!(!backing_is_multiplanar(&s));
     assert_eq!(
         iosurface_pixel_format_to_mtl(s.pixel_format),
         crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM
@@ -464,7 +481,7 @@ fn decode_type4_plane0() {
 /// The bug class: a guest game creates its render surface as a single-plane
 /// `kCVPixelFormatType_ARGB2101010LEPacked` IOSurface, this table answered 0 for
 /// it, and 0 out of this table is `draw::render_target`'s
-/// `rt_type4_base_format` refusal — so every draw of every frame failed and the
+/// `rt_backing_base_format` refusal — so every draw of every frame failed and the
 /// window was black. Two tables had to answer for that to stop, and a test on
 /// either one alone would have passed while the window stayed black, so this
 /// walks the whole chain the resolve walks.
@@ -478,10 +495,11 @@ fn an_l10r_surface_resolves_as_a_packed_ten_bit_colour_attachment() {
     use crate::contract::pixel_format as pf;
 
     const FOURCC_L10R: u32 = 0x6c31_3072;
-    let built = Type4Builder::new(0x384000, 0x100, FOURCC_L10R, 1).plane(0, 0, 1280, 720, 5120, 0);
-    let surf = decode_type4_surface(built.bytes()).expect("type4 decodes");
+    let built =
+        BackingBuilder::new(0x384000, 0x100, FOURCC_L10R, 1).plane(0, 0, 1280, 720, 5120, 0);
+    let surf = decode_backing(built.bytes()).expect("backing decodes");
     assert!(
-        !type4_is_multiplanar(&surf),
+        !backing_is_multiplanar(&surf),
         "a packed single-plane colour surface must not read as biplanar"
     );
 
@@ -531,14 +549,14 @@ fn fourcc_420f_not_bgra_and_multiplanar() {
 ///
 /// The converter used to return `pixel_format as u16` for anything at or
 /// below 0x200, deciding which encoding the field was in from how big the
-/// number was. Every caller passes a type-4 `pixelFormat` (+0x0c), which is
+/// number was. Every caller passes a backing `pixelFormat` (+0x0c), which is
 /// an IOSurface OSType and therefore never below `'    '` (0x20202020), so
 /// a small value arriving here is a bad read — and passing it through
 /// published a format the guest never named. Fail closed instead, which is
 /// what this function already does for every FourCC it does not know.
 #[test]
 fn a_small_value_is_not_read_as_an_mtl_ordinal() {
-    // 0x50 is MTLPixelFormatBGRA8Unorm. As a type-4 OSType it is nonsense,
+    // 0x50 is MTLPixelFormatBGRA8Unorm. As a backing OSType it is nonsense,
     // and the old magnitude test would have handed it back as a format.
     assert_eq!(iosurface_pixel_format_to_mtl(0x50), 0);
     assert_eq!(iosurface_pixel_format_to_mtl(0x200), 0);
@@ -551,7 +569,7 @@ fn a_small_value_is_not_read_as_an_mtl_ordinal() {
 }
 
 #[test]
-fn decode_type4_biplanar_420f_planes() {
+fn decode_backing_biplanar_420f_planes() {
     // Wire: plane0 Y 1024×1024 bpr=1024 bpe=1; plane1 UV 512×512 bpr=1024 bpe=2.
     // Live boot: fmt='420f' len=0x180000 plane0 bpr=1024.
     let mut desc = vec![0u8; 0x14 + 2 * 0x10];
@@ -569,8 +587,8 @@ fn decode_type4_biplanar_420f_planes() {
     st32(&mut desc[0x28..], 512);
     st32(&mut desc[0x2c..], 512);
     st32(&mut desc[0x30..], 1024 | (2 << 24));
-    let s = decode_type4_surface(&desc).expect("type4 420f");
-    assert!(type4_is_multiplanar(&s));
+    let s = decode_backing(&desc).expect("backing 420f");
+    assert!(backing_is_multiplanar(&s));
     assert_eq!(s.plane_count, 2);
     assert_eq!(
         (
@@ -589,7 +607,7 @@ fn decode_type4_biplanar_420f_planes() {
         ),
         (512, 512, 2)
     );
-    let dev = synthesize_device_desc_from_type4(&s);
+    let dev = synthesize_device_desc_from_backing(&s);
     assert_eq!(dev[DEVICE_DESC_PLANE_COUNT], 2);
     use crate::contract::iosurface_pages::{
         decode_device_surface, mapping_span_bound, sample_window_from_device_desc,
@@ -602,7 +620,7 @@ fn decode_type4_biplanar_420f_planes() {
     let surf = decode_device_surface(&dev).expect("device");
     assert_eq!(surf.plane_count, 2);
     assert_eq!(surf.alloc_size, 0x180000);
-    // Type-11 Y plane: R8 1024×1024 matches plane0 (contract geometry key).
+    // Mapper-ref-texture Y plane: R8 1024×1024 matches plane0 (contract geometry key).
     let y = sample_window_from_device_desc(
         Some(&dev),
         None,
@@ -650,7 +668,7 @@ fn decode_type4_biplanar_420f_planes() {
 /// through. Here the walk cannot resolve the backing GVA and the identity
 /// candidate *is* mapped RAM, so the old path would have accepted it.
 #[test]
-fn resolve_type4_refuses_to_substitute_the_gva_when_the_walk_fails() {
+fn resolve_backing_refuses_to_substitute_the_gva_when_the_walk_fails() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     state.page_shift = PAGE_SHIFT_X86;
@@ -688,7 +706,7 @@ fn resolve_type4_refuses_to_substitute_the_gva_when_the_walk_fails() {
     let _ = host.write_gpa(data_gpa + 0x80, &desc);
 
     assert!(
-        !resolve_type4_surface(&mut state, &host, 3),
+        !resolve_backing(&mut state, &host, 3),
         "an untranslatable backing must not resolve"
     );
     // The refusal happens before any mutation, so no fabricated entry is
@@ -701,7 +719,7 @@ fn resolve_type4_refuses_to_substitute_the_gva_when_the_walk_fails() {
     assert!(!fabricated, "refusal must not cache a fabricated backing");
 }
 
-/// `resolve_type4_surface_ex` probes task 0 first and returns on the first
+/// `resolve_backing_ex` probes task 0 first and returns on the first
 /// task whose backing applies. The identity guess made task 0 succeed for
 /// surfaces it could not translate, so the search stopped there and the
 /// owning task was never tried — the surface was then backed by an address
@@ -768,7 +786,7 @@ fn the_task_search_reaches_the_owner_when_task_zero_cannot_translate() {
     let _ = host.write_gpa(data_gpa + 0x80, &desc);
 
     assert!(
-        resolve_type4_surface(&mut state, &host, 3),
+        resolve_backing(&mut state, &host, 3),
         "the owning task can translate the backing, so the resolve must succeed"
     );
     let m = state.mappings.get(&3).unwrap();
@@ -784,14 +802,14 @@ fn the_task_search_reaches_the_owner_when_task_zero_cannot_translate() {
 /// The search stops on the first task that can back a surface, so whether
 /// that choice was ever a choice is the thing to count. Nothing on the wire
 /// can verify a candidate — the object-list entry carries no identity and
-/// the type-4 descriptor is fully decoded — so the claimant count is the
+/// the backing descriptor is fully decoded — so the claimant count is the
 /// only available reading of the search's exposure, and it has to
 /// distinguish "one task lists this id" from "two do".
 #[test]
 fn a_surface_id_claimed_by_two_tasks_is_counted_as_two() {
     // Two tasks, each with its own directory and root, both listing eight
-    // object slots at GVA 0. Task 0's list page holds a type-4 surface at
-    // slot 3; task 1's holds a type-5 there until the second half of the
+    // object slots at GVA 0. Task 0's list page holds a backing record at
+    // slot 3; task 1's holds a ref-texture there until the second half of the
     // test rewrites it.
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
@@ -834,7 +852,7 @@ fn a_surface_id_claimed_by_two_tasks_is_counted_as_two() {
     // and length, which is what `lookup_list_entry` requires before the type
     // is even looked at.
     let mut entry = [0u8; 12];
-    st32(&mut entry[0..], OBJECT_TYPE_SURFACE as u32 | (0x30u32 << 8));
+    st32(&mut entry[0..], OBJECT_TYPE_BACKING as u32 | (0x30u32 << 8));
     entry[4..12].copy_from_slice(&0x80u64.to_le_bytes());
     let _ = host.write_gpa(list0_gpa + 3 * 12, &entry);
 
@@ -849,26 +867,26 @@ fn a_surface_id_claimed_by_two_tasks_is_counted_as_two() {
     let _ = host.write_gpa(list1_gpa + 3 * 12, &other);
 
     assert_eq!(
-        type4_claimant_tasks(&state, &host, 3),
+        backing_claimant_tasks(&state, &host, 3),
         vec![0],
         "a populated slot of another object type is not a claim on this id"
     );
 
-    // Now task 1 lists a type-4 surface at the same slot. The id spaces are
+    // Now task 1 lists a backing record at the same slot. The id spaces are
     // per task, so this is a second, unrelated surface wearing the same id —
     // and the search would have to break the tie by probe order alone.
     let _ = host.write_gpa(list1_gpa + 3 * 12, &entry);
     assert_eq!(
-        type4_claimant_tasks(&state, &host, 3),
+        backing_claimant_tasks(&state, &host, 3),
         vec![0, 1],
-        "both tasks list a type-4 surface at slot 3, so both are claimants"
+        "both tasks list a backing record at slot 3, so both are claimants"
     );
 
     // An inactive task cannot be the one the search stops on, so it is not
     // counted either.
     state.tasks[1].active = false;
     assert_eq!(
-        type4_claimant_tasks(&state, &host, 3),
+        backing_claimant_tasks(&state, &host, 3),
         vec![0],
         "an inactive task is not a claimant"
     );
@@ -878,7 +896,7 @@ fn a_surface_id_claimed_by_two_tasks_is_counted_as_two() {
 /// translation of the backing GVA moved (same surface id, same geometry,
 /// new physical pages — the early-boot FB vs WindowServer reallocation).
 #[test]
-fn resolve_type4_force_rebuilds_when_task_translation_moves() {
+fn resolve_backing_force_rebuilds_when_task_translation_moves() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     state.page_shift = PAGE_SHIFT_X86;
@@ -903,7 +921,7 @@ fn resolve_type4_force_rebuilds_when_task_translation_moves() {
     let _ = host.write_gpa(root_gpa + 4, &d[..4]);
     state.define_task(1, 0x1000, 2);
     assert!(state.set_object_list(1, 0, 8));
-    // Type-4 entry at surface_id=3, descriptor at GVA 0x80.
+    // Backing entry at surface_id=3, descriptor at GVA 0x80.
     let mut entry = [0u8; 12];
     st32(&mut entry[0..], 4u32 | (0x30u32 << 8));
     entry[4..12].copy_from_slice(&0x80u64.to_le_bytes());
@@ -918,7 +936,7 @@ fn resolve_type4_force_rebuilds_when_task_translation_moves() {
     st32(&mut desc[0x20..], 64);
     let _ = host.write_gpa(data_gpa + 0x80, &desc);
 
-    assert!(resolve_type4_surface(&mut state, &host, 3));
+    assert!(resolve_backing(&mut state, &host, 3));
     {
         let m = state.mappings.get(&3).unwrap();
         assert_eq!(m.page_entries.len(), 1);
@@ -931,7 +949,7 @@ fn resolve_type4_force_rebuilds_when_task_translation_moves() {
     // Guest remaps GVA page 1 onto a new physical page (same id/geometry).
     st32(&mut d[..4], 6);
     let _ = host.write_gpa(root_gpa + 4, &d[..4]);
-    assert!(resolve_type4_surface_force(&mut state, &host, 3));
+    assert!(resolve_backing_force(&mut state, &host, 3));
     {
         let m = state.mappings.get(&3).unwrap();
         assert_eq!(
@@ -942,7 +960,7 @@ fn resolve_type4_force_rebuilds_when_task_translation_moves() {
         assert_eq!(m.map_generation, 2, "page move bumps map_generation");
     }
     // Unchanged translation: force keeps the table without a rebuild.
-    assert!(resolve_type4_surface_force(&mut state, &host, 3));
+    assert!(resolve_backing_force(&mut state, &host, 3));
     let m = state.mappings.get(&3).unwrap();
     assert_eq!(m.map_generation, 2);
     assert_eq!(
@@ -955,35 +973,35 @@ fn resolve_type4_force_rebuilds_when_task_translation_moves() {
 /// whose page-backing construction fails) must be fail-visible with a
 /// `reason=` slug, deduped per `(surface_id, reason)`, and re-armed when the
 /// surface next backs cleanly — never a silent `return false` that paints
-/// stale/black with no log. Locks the type-4 backing blind-spot closure.
+/// stale/black with no log. Locks the backing blind-spot closure.
 #[test]
-fn apply_type4_backing_fail_latches_reason_and_rearms() {
+fn apply_backing_fail_latches_reason_and_rearms() {
     let host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     state.page_shift = PAGE_SHIFT_X86;
-    // A surface_id other type-4 tests do not touch (they use 3).
+    // A surface_id other backing tests do not touch (they use 3).
     let sid = 11u32;
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
-    assert!(!type4_fail_latch()
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    assert!(!backing_fail_latch()
         .lock()
         .unwrap()
         .contains_key(&(sid, "task_inactive")));
     // Small valid length (page_count = 1) so the alloc-guard passes, then an
     // undefined/inactive task_id hits the `task_inactive` site — the drain
     // race where a decoded surface's owning task died before backing landed.
-    let surf = Type4Surface {
+    let surf = BackingRecord {
         length: 0x1000,
         backing_pfn: 0x20,
         pixel_format: 0,
         plane_count: 1,
-        planes: [Type4Plane::default(); TYPE4_PLANE_CAP],
+        planes: [BackingPlane::default(); TYPE4_PLANE_CAP],
         width: 16,
         height: 16,
         bytes_per_row: 64,
     };
-    assert!(!apply_type4_backing(&mut state, &host, 5, sid, &surf));
+    assert!(!apply_backing(&mut state, &host, 5, sid, &surf));
     assert!(
-        !type4_fail_latch()
+        !backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "task_inactive")),
@@ -993,34 +1011,34 @@ fn apply_type4_backing_fail_latches_reason_and_rearms() {
     );
     // The search running out of tasks is what turns the probe's reason into
     // a reported failure.
-    flush_type4_fail(sid);
+    flush_backing_fail(sid);
     assert!(
-        type4_fail_latch()
+        backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "task_inactive")),
         "an exhausted search must report the first probe's reason slug"
     );
     // A clean backing on the same surface re-arms the latch.
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
     assert!(
-        !type4_fail_latch()
+        !backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "task_inactive")),
-        "clear_type4_fail must re-arm so a later failure logs again"
+        "clear_backing_fail must re-arm so a later failure logs again"
     );
 }
 
 /// A refusal that the next attach resolves is reported as the recovery it is,
 /// and only when the backing that landed is the one the refusal named.
 ///
-/// `type4_backing_fail reason=translate` reads as lost guest work and usually is
+/// `backing_fail reason=translate` reads as lost guest work and usually is
 /// not: `st=zero-pfn` means the guest had not finished mapping when the
 /// per-present path walked it, and the refusal exists so the device asks again
 /// rather than substituting a guess. Every one of the six on a driven boot
 /// recovered, within 1-21 ms, and nothing in the log said so — see
-/// [`super::clear_type4_fail`].
+/// [`super::clear_backing_fail`].
 ///
 /// The match is on the **backing address**, never on `surface_id`: ids recycle
 /// within a boot and across geometries, so a clean attach on a recycled id must
@@ -1029,10 +1047,10 @@ fn apply_type4_backing_fail_latches_reason_and_rearms() {
 /// A refusal leaves the latch three ways, and all three are now countable.
 ///
 /// Recovered, superseded, or still there. The third is the only one that can be
-/// lost guest work, and before `type4_backing_superseded` and
-/// `type4_backing_outstanding` it was indistinguishable from the second: a
-/// driven boot with five `type4_backing_fail` lines and four
-/// `type4_backing_recovered` lines gave a reader no way to tell a refusal the
+/// lost guest work, and before `backing_superseded` and
+/// `backing_outstanding` it was indistinguishable from the second: a
+/// driven boot with five `backing_fail` lines and four
+/// `backing_recovered` lines gave a reader no way to tell a refusal the
 /// guest walked away from apart from one that never came back, short of
 /// hand-matching backing GVAs across the log. That is how this gap was found.
 ///
@@ -1040,33 +1058,28 @@ fn apply_type4_backing_fail_latches_reason_and_rearms() {
 /// every refusal that leaves the latch is accounted for by exactly one of the
 /// three, and the residue is the census line's `n`.
 #[test]
-fn every_type4_refusal_leaves_the_latch_recovered_superseded_or_counted() {
+fn every_backing_refusal_leaves_the_latch_recovered_superseded_or_counted() {
     use crate::runtime::drain::store_route_count;
 
     // Ids no other test in this module uses; the latch is process-global.
     let sid = 0x4d2u32;
     let gva = 0x4222000u64;
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
 
     // Superseded: refused at `gva`, backed somewhere else. Not a recovery, and
     // it used to be the silent one.
-    let before = store_route_count("type4_backing_superseded");
-    let recovered_before = store_route_count("type4_backing_recovered");
-    defer_type4_fail(
-        sid,
-        "translate",
-        Some(gva),
-        "type4_backing_fail probe".into(),
-    );
-    flush_type4_fail(sid);
-    clear_type4_fail(sid, gva + 0x1000);
+    let before = store_route_count("backing_superseded");
+    let recovered_before = store_route_count("backing_recovered");
+    defer_backing_fail(sid, "translate", Some(gva), "backing_fail probe".into());
+    flush_backing_fail(sid);
+    clear_backing_fail(sid, gva + 0x1000);
     assert_eq!(
-        store_route_count("type4_backing_superseded"),
+        store_route_count("backing_superseded"),
         before + 1,
         "a refusal dropped because the surface backed elsewhere must be counted"
     );
     assert_eq!(
-        store_route_count("type4_backing_recovered"),
+        store_route_count("backing_recovered"),
         recovered_before,
         "and must not be claimed as a recovery"
     );
@@ -1074,23 +1087,18 @@ fn every_type4_refusal_leaves_the_latch_recovered_superseded_or_counted() {
     // Recovered: refused at `gva`, backed at `gva`. Counts on the other route
     // and leaves the superseded count alone — the two must not double-count one
     // refusal, which is what would make the identity stop holding.
-    let before = store_route_count("type4_backing_superseded");
-    let recovered_before = store_route_count("type4_backing_recovered");
-    defer_type4_fail(
-        sid,
-        "translate",
-        Some(gva),
-        "type4_backing_fail probe".into(),
-    );
-    flush_type4_fail(sid);
-    clear_type4_fail(sid, gva);
+    let before = store_route_count("backing_superseded");
+    let recovered_before = store_route_count("backing_recovered");
+    defer_backing_fail(sid, "translate", Some(gva), "backing_fail probe".into());
+    flush_backing_fail(sid);
+    clear_backing_fail(sid, gva);
     assert_eq!(
-        store_route_count("type4_backing_recovered"),
+        store_route_count("backing_recovered"),
         recovered_before + 1,
         "an attach on the backing the refusal named is a recovery"
     );
     assert_eq!(
-        store_route_count("type4_backing_superseded"),
+        store_route_count("backing_superseded"),
         before,
         "and is not also a supersede"
     );
@@ -1105,7 +1113,7 @@ fn every_type4_refusal_leaves_the_latch_recovered_superseded_or_counted() {
 fn the_outstanding_census_names_the_oldest_refusal_and_is_otherwise_silent() {
     let sid = 0x4d3u32;
     let gva = 0x4333000u64;
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
 
     // Other tests in this module share the latch, so assert about *this* sid
     // rather than about emptiness — a bare `is_none()` would be order-dependent.
@@ -1114,20 +1122,15 @@ fn the_outstanding_census_names_the_oldest_refusal_and_is_otherwise_silent() {
             .is_some_and(|l| l.contains(&format!("sid={sid}")))
     };
     assert!(
-        !mine(&type4_backing_outstanding_census()),
+        !mine(&backing_outstanding_census()),
         "nothing is latched for this surface yet"
     );
 
-    defer_type4_fail(
-        sid,
-        "translate",
-        Some(gva),
-        "type4_backing_fail probe".into(),
-    );
-    flush_type4_fail(sid);
-    let line = type4_backing_outstanding_census().expect("a latched refusal must be censused");
+    defer_backing_fail(sid, "translate", Some(gva), "backing_fail probe".into());
+    flush_backing_fail(sid);
+    let line = backing_outstanding_census().expect("a latched refusal must be censused");
     assert!(
-        line.starts_with("type4_backing_outstanding n=") && line.contains("oldest_ms="),
+        line.starts_with("backing_outstanding n=") && line.contains("oldest_ms="),
         "the line must carry both the count and the age: {line}"
     );
     assert!(
@@ -1136,9 +1139,9 @@ fn the_outstanding_census_names_the_oldest_refusal_and_is_otherwise_silent() {
     );
 
     // Retiring it removes it from the census, by either route.
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
     assert!(
-        !mine(&type4_backing_outstanding_census()),
+        !mine(&backing_outstanding_census()),
         "a recovered refusal is no longer outstanding"
     );
 }
@@ -1150,24 +1153,24 @@ fn the_outstanding_census_names_the_oldest_refusal_and_is_otherwise_silent() {
 /// frame is losing guest work; a surface it asked for once and never again is
 /// one the guest stopped presenting. Both sit in the latch as `n=1`.
 ///
-/// The trap this pins: `note_type4_fail` refreshes its timestamp on a repeat, so
+/// The trap this pins: `note_backing_fail` refreshes its timestamp on a repeat, so
 /// `oldest_ms` alone reads **backwards** — a live retry holds it near zero and
 /// an abandoned refusal lets it grow with the clock. `attempts` is what makes
 /// the line state which of the two it is without anyone re-deriving that.
 #[test]
-fn a_retried_type4_refusal_counts_its_attempts_and_an_abandoned_one_does_not() {
+fn a_retried_backing_refusal_counts_its_attempts_and_an_abandoned_one_does_not() {
     let sid = 0x4d3u32;
     let gva = 0x4188000u64;
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
     let is_mine = |line: &Option<String>| {
         line.as_ref()
             .is_some_and(|l| l.contains(&format!("sid={sid} ")))
     };
 
     // Asked once and refused.
-    defer_type4_fail(sid, "translate", Some(gva), "first refusal".into());
-    flush_type4_fail(sid);
-    let line = type4_backing_outstanding_census().expect("a latched refusal is censused");
+    defer_backing_fail(sid, "translate", Some(gva), "first refusal".into());
+    flush_backing_fail(sid);
+    let line = backing_outstanding_census().expect("a latched refusal is censused");
     if is_mine(&Some(line.clone())) {
         assert!(
             line.contains("attempts=1"),
@@ -1183,10 +1186,10 @@ fn a_retried_type4_refusal_counts_its_attempts_and_an_abandoned_one_does_not() {
     // quiet — this is the per-present path and one line a frame would flood it
     // — so the count is the only thing saying the device is still trying.
     for _ in 0..4 {
-        defer_type4_fail(sid, "translate", Some(gva), "retry refusal".into());
-        flush_type4_fail(sid);
+        defer_backing_fail(sid, "translate", Some(gva), "retry refusal".into());
+        flush_backing_fail(sid);
     }
-    let line = type4_backing_outstanding_census().expect("still latched");
+    let line = backing_outstanding_census().expect("still latched");
     if is_mine(&Some(line.clone())) {
         assert!(
             line.contains("attempts=5"),
@@ -1194,15 +1197,15 @@ fn a_retried_type4_refusal_counts_its_attempts_and_an_abandoned_one_does_not() {
         );
     }
 
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
     assert!(
-        !is_mine(&type4_backing_outstanding_census()),
+        !is_mine(&backing_outstanding_census()),
         "the latch re-arms once the surface backs"
     );
 }
 
 #[test]
-fn a_type4_refusal_the_next_attach_resolves_is_reported_as_recovered() {
+fn a_backing_refusal_the_next_attach_resolves_is_reported_as_recovered() {
     fn log_mark() -> usize {
         crate::observe::redirect_logs_for_tests();
         std::fs::read_to_string(crate::observe::fail_log_path())
@@ -1217,31 +1220,26 @@ fn a_type4_refusal_the_next_attach_resolves_is_reported_as_recovered() {
     // A surface id no other test in this module uses.
     let sid = 0x4d1u32;
     let gva = 0x4112000u64;
-    clear_type4_fail(sid, gva);
+    clear_backing_fail(sid, gva);
 
     // A reported refusal naming this backing...
     let mark = log_mark();
-    defer_type4_fail(
-        sid,
-        "translate",
-        Some(gva),
-        "type4_backing_fail probe".into(),
-    );
-    flush_type4_fail(sid);
+    defer_backing_fail(sid, "translate", Some(gva), "backing_fail probe".into());
+    flush_backing_fail(sid);
     assert!(
-        log_since(mark).contains("type4_backing_fail probe"),
+        log_since(mark).contains("backing_fail probe"),
         "the exhausted search must report the probe's reason"
     );
 
     // ...that a later attach on a *different* backing must not claim.
     let mark = log_mark();
-    clear_type4_fail(sid, gva + 0x1000);
+    clear_backing_fail(sid, gva + 0x1000);
     assert!(
-        !log_since(mark).contains("type4_backing_recovered"),
+        !log_since(mark).contains("backing_recovered"),
         "a recycled surface id is not evidence that the earlier backing landed"
     );
     assert!(
-        !type4_fail_latch()
+        !backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "translate")),
@@ -1250,17 +1248,12 @@ fn a_type4_refusal_the_next_attach_resolves_is_reported_as_recovered() {
 
     // The same refusal, then an attach on the backing it named, is a recovery.
     let mark = log_mark();
-    defer_type4_fail(
-        sid,
-        "translate",
-        Some(gva),
-        "type4_backing_fail probe".into(),
-    );
-    flush_type4_fail(sid);
-    clear_type4_fail(sid, gva);
+    defer_backing_fail(sid, "translate", Some(gva), "backing_fail probe".into());
+    flush_backing_fail(sid);
+    clear_backing_fail(sid, gva);
     let log = log_since(mark);
     assert!(
-        log.contains("type4_backing_recovered")
+        log.contains("backing_recovered")
             && log.contains(&format!("sid={sid}"))
             && log.contains("reason=translate")
             && log.contains(&format!("gva={gva:#x}")),
@@ -1282,7 +1275,7 @@ fn a_type4_refusal_the_next_attach_resolves_is_reported_as_recovered() {
 /// too is what keeps this from passing vacuously: a fixture in which every
 /// walk fails would satisfy the refusal assertions on its own.
 #[test]
-fn a_refused_type4_walk_names_the_check_that_refused() {
+fn a_refused_backing_walk_names_the_check_that_refused() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
@@ -1308,7 +1301,7 @@ fn a_refused_type4_walk_names_the_check_that_refused() {
         "the refusal must name where in the walk it stopped, got {walk:?}"
     );
 
-    let line = type4_translate_fail_detail(202, 1, 0, 640, gva, &walk);
+    let line = backing_translate_fail_detail(202, 1, 0, 640, gva, &walk);
     assert!(line.contains("reason=translate"), "{line}");
     assert!(line.contains("sid=202"), "{line}");
     assert!(line.contains("page=0/640"), "{line}");
@@ -1395,7 +1388,7 @@ fn a_task_with_no_object_list_resolves_nothing_not_its_neighbours_list() {
     let mut entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     st32(
         &mut entry[0..],
-        (OBJECT_TYPE_SURFACE as u32) | (0x40u32 << 8),
+        (OBJECT_TYPE_BACKING as u32) | (0x40u32 << 8),
     );
     entry[4..12].copy_from_slice(&0xdead_0000u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa, &entry);
@@ -1431,7 +1424,7 @@ fn a_task_with_no_object_list_resolves_nothing_not_its_neighbours_list() {
 /// miss is reportable differs.
 ///
 /// This is the half a regression would break. `probe_list_entry` exists because
-/// `type4_probe_order` walks every live task asking who owns a surface, so it
+/// `backing_probe_order` walks every live task asking who owns a surface, so it
 /// misses on every task before the owner — 18 `gva_read_refused` lines per
 /// driven boot, all of them the search working. Quietening that is only correct
 /// while it still *answers* identically; a probe that skipped the liveness test,
@@ -1461,7 +1454,7 @@ fn the_probe_and_the_named_lookup_answer_identically() {
     let mut entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     st32(
         &mut entry[0..],
-        (OBJECT_TYPE_SURFACE as u32) | (0x40u32 << 8),
+        (OBJECT_TYPE_BACKING as u32) | (0x40u32 << 8),
     );
     entry[4..12].copy_from_slice(&0xdead_0000u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa, &entry);
@@ -1492,7 +1485,7 @@ fn the_probe_and_the_named_lookup_answer_identically() {
     assert_eq!(probe_list_entry(&state, &host, 5, 0), None);
 }
 
-fn setup_type4_candidate(
+fn setup_backing_candidate(
     host: &mut FakeHost,
     state: &mut DeviceState,
     surface_id: u32,
@@ -1517,7 +1510,7 @@ fn setup_type4_candidate(
     let mut entry = [0u8; OBJECT_LIST_ENTRY_LEN];
     st32(
         &mut entry[0..],
-        (OBJECT_TYPE_SURFACE as u32) | (desc_len << 8),
+        (OBJECT_TYPE_BACKING as u32) | (desc_len << 8),
     );
     entry[4..12].copy_from_slice(&desc_gva.to_le_bytes());
     let entry_gpa = data_gpa + surface_id as u64 * OBJECT_LIST_ENTRY_LEN as u64;
@@ -1525,56 +1518,56 @@ fn setup_type4_candidate(
     data_gpa
 }
 
-/// Once task-scan lookup finds an actual type-4 candidate, descriptor read
+/// Once task-scan lookup finds an actual backing candidate, descriptor read
 /// failure is no longer speculative: the surface has an owner but cannot get
 /// backing. It must be fail-visible with a stable reason slug.
 #[test]
-fn resolve_type4_candidate_logs_descriptor_read_failure() {
+fn resolve_backing_candidate_logs_descriptor_read_failure() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
     let sid = 17u32;
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
-    let _ = setup_type4_candidate(&mut host, &mut state, sid, 0x3000, 0x30);
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    let _ = setup_backing_candidate(&mut host, &mut state, sid, 0x3000, 0x30);
 
-    assert!(!resolve_type4_surface(&mut state, &host, sid));
+    assert!(!resolve_backing(&mut state, &host, sid));
     assert!(
-        type4_fail_latch()
+        backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "desc_read")),
         "surface-type candidate with unreadable descriptor must name desc_read"
     );
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
 }
 
-/// A readable but invalid type-4 descriptor used to fall through to the
+/// A readable but invalid backing descriptor used to fall through to the
 /// resolver tail with no site reason. Keep it fail-visible without logging
 /// absent/non-surface speculative probes.
 #[test]
-fn resolve_type4_candidate_logs_descriptor_decode_failure() {
+fn resolve_backing_candidate_logs_descriptor_decode_failure() {
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
     let sid = 18u32;
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
-    let data_gpa = setup_type4_candidate(&mut host, &mut state, sid, 0x80, 0x30);
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    let data_gpa = setup_backing_candidate(&mut host, &mut state, sid, 0x80, 0x30);
     let bad_desc = vec![0u8; 0x30];
     let _ = host.write_gpa(data_gpa + 0x80, &bad_desc);
 
-    assert!(!resolve_type4_surface(&mut state, &host, sid));
+    assert!(!resolve_backing(&mut state, &host, sid));
     assert!(
-        type4_fail_latch()
+        backing_fail_latch()
             .lock()
             .unwrap()
             .contains_key(&(sid, "desc_decode")),
         "surface-type candidate with invalid descriptor must name desc_decode"
     );
-    clear_type4_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
+    clear_backing_fail(sid, 0x20u64 << PAGE_SHIFT_X86);
 }
 
-/// Live wire bytes (boot 093019 `compute_stage_tex type5 … args_hex`):
+/// Live wire bytes (boot 093019 `compute_stage_tex ref_texture … args_hex`):
 /// R8 1024×1024 = Y plane view of a biplanar 1024×1024 surface.
 #[test]
-fn decode_type5_texture_view_live_r8_y_plane() {
+fn decode_ref_texture_view_live_r8_y_plane() {
     let mut desc = vec![0u8; 8];
     st32(&mut desc[TYPE5_SURFACE_ID..], 8);
     // args blob: kind 0x2f, len 0x30, own_ref 0x15, record R8 1024×1024 d=1.
@@ -1587,7 +1580,7 @@ fn decode_type5_texture_view_live_r8_y_plane() {
         0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x10, 0x00, // trailer (unconsumed)
     ];
     desc.extend_from_slice(&args);
-    let rec = decode_type5_texture_view(&desc).expect("live R8 record decodes");
+    let rec = decode_ref_texture_view(&desc).expect("live R8 record decodes");
     assert_eq!(rec.pixel_format, 0x0a);
     assert_eq!((rec.width, rec.height, rec.depth), (1024, 1024, 1));
     // Short record (no +0x20 field) defaults to plane 0.
@@ -1600,7 +1593,7 @@ fn decode_type5_texture_view_live_r8_y_plane() {
 /// record tag `0x62`, not the biplanar `0x42`. Same field layout — must
 /// decode, or the blit path drops the copy.
 #[test]
-fn decode_type5_texture_view_live_0x62_color_window_view() {
+fn decode_ref_texture_view_live_0x62_color_window_view() {
     // Exact leading 40 bytes observed, zero-padded to the 56-byte desc_len.
     let head: [u8; 40] = [
         0x22, 0x00, 0x00, 0x00, // surface_id = 34
@@ -1616,7 +1609,7 @@ fn decode_type5_texture_view_live_0x62_color_window_view() {
     ];
     let mut desc = head.to_vec();
     desc.resize(56, 0); // plane field (+0x20 in record) reads 0
-    let rec = decode_type5_texture_view(&desc).expect("0x62 color view must decode");
+    let rec = decode_ref_texture_view(&desc).expect("0x62 color view must decode");
     assert_eq!(rec.pixel_format, 0x51);
     assert_eq!((rec.width, rec.height, rec.depth), (1024, 768, 1));
     assert_eq!(rec.plane_index, 0);
@@ -1627,7 +1620,7 @@ fn decode_type5_texture_view_live_0x62_color_window_view() {
 /// `+0x20` — Y views carry 0, the RG8 chroma view 1, the same-geometry
 /// alpha view 2. Geometry cannot separate Y from alpha; this field does.
 #[test]
-fn decode_type5_texture_view_live_v0a8_alpha_plane_index() {
+fn decode_ref_texture_view_live_v0a8_alpha_plane_index() {
     let mut desc = vec![0u8; 8];
     st32(&mut desc[TYPE5_SURFACE_ID..], 0x6d);
     let args = [
@@ -1641,7 +1634,7 @@ fn decode_type5_texture_view_live_v0a8_alpha_plane_index() {
         0x02, 0x00, 0x00, 0x00, // IOSurface plane index = 2 (alpha)
     ];
     desc.extend_from_slice(&args);
-    let rec = decode_type5_texture_view(&desc).expect("live v0a8 alpha record decodes");
+    let rec = decode_ref_texture_view(&desc).expect("live v0a8 alpha record decodes");
     assert_eq!(rec.pixel_format, 0x0a);
     assert_eq!((rec.width, rec.height, rec.depth), (946, 350, 1));
     assert_eq!(rec.plane_index, 2);
@@ -1656,7 +1649,7 @@ fn decode_type5_texture_view_live_v0a8_alpha_plane_index() {
 /// point of having it. Pinning the offset against a descriptor whose *other*
 /// leading dword is non-zero is what makes an off-by-four visible.
 #[test]
-fn the_type5_owner_task_is_read_from_its_own_dword() {
+fn the_ref_texture_owner_task_is_read_from_its_own_dword() {
     let mut desc = [0u8; TYPE5_MIN_LEN];
     st32(&mut desc[TYPE5_SURFACE_ID..], 0xabcd);
     assert_eq!(
@@ -1678,11 +1671,11 @@ fn the_type5_owner_task_is_read_from_its_own_dword() {
 }
 
 #[test]
-fn decode_type5_texture_view_fail_closed() {
+fn decode_ref_texture_view_fail_closed() {
     // Short descriptor (no record).
     let mut short = vec![0u8; 8];
     st32(&mut short[TYPE5_SURFACE_ID..], 8);
-    assert!(decode_type5_texture_view(&short).is_none());
+    assert!(decode_ref_texture_view(&short).is_none());
     // Wrong record tag.
     let mut bad_tag = vec![0u8; 8];
     st32(&mut bad_tag[TYPE5_SURFACE_ID..], 8);
@@ -1690,7 +1683,7 @@ fn decode_type5_texture_view_fail_closed() {
     bad_tag.extend_from_slice(&[
         0x41, 0x01, 0x0a, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x01, 0, 0, 0,
     ]);
-    assert!(decode_type5_texture_view(&bad_tag).is_none());
+    assert!(decode_ref_texture_view(&bad_tag).is_none());
     // Non-2D (depth != 1) fails closed.
     let mut vol = vec![0u8; 8];
     st32(&mut vol[TYPE5_SURFACE_ID..], 8);
@@ -1698,7 +1691,7 @@ fn decode_type5_texture_view_fail_closed() {
     vol.extend_from_slice(&[
         0x42, 0x07, 0x50, 0x00, 0x40, 0, 0, 0, 0x40, 0, 0, 0, 0x40, 0, 0, 0,
     ]);
-    assert!(decode_type5_texture_view(&vol).is_none());
+    assert!(decode_ref_texture_view(&vol).is_none());
     // Zero width fails closed.
     let mut zw = vec![0u8; 8];
     st32(&mut zw[TYPE5_SURFACE_ID..], 8);
@@ -1706,11 +1699,11 @@ fn decode_type5_texture_view_fail_closed() {
     zw.extend_from_slice(&[
         0x42, 0x01, 0x0a, 0x00, 0, 0, 0, 0, 0x00, 0x04, 0, 0, 0x01, 0, 0, 0,
     ]);
-    assert!(decode_type5_texture_view(&zw).is_none());
+    assert!(decode_ref_texture_view(&zw).is_none());
 }
 
 /// The probe's notion of "undecoded" must be exactly the bytes
-/// `decode_type4_surface` skips, and it must distinguish two surfaces on
+/// `decode_backing` skips, and it must distinguish two surfaces on
 /// those bytes alone.
 ///
 /// This is the measurement that blocks the largest deletion in the present
@@ -1718,12 +1711,12 @@ fn decode_type5_texture_view_fail_closed() {
 /// swapchain buffer from a same-geometry offscreen tile, so membership is
 /// reconstructed by half a dozen downstream mechanisms. If the guest is
 /// telling us in the undecoded span, the probe has to be able to see it.
-/// The two arms of the type-4 freshness test must accept exactly the same
+/// The two arms of the backing freshness test must accept exactly the same
 /// backings, because only one of them rebuilds when it says no.
 ///
-/// The force arm returns through `win_type4_search` **without** calling
-/// `apply_type4_backing`, so `set_mapping_geom` and
-/// `synthesize_device_desc_from_type4` are both skipped. It used to compare
+/// The force arm returns through `win_backing_search` **without** calling
+/// `apply_backing`, so `set_mapping_geom` and
+/// `synthesize_device_desc_from_backing` are both skipped. It used to compare
 /// width alone while the non-force arm compared width and height, and
 /// `ensure_surface_for_present` calls the force arm precisely to catch a
 /// wire geometry change — so a height change that stayed inside the same
@@ -1736,7 +1729,7 @@ fn decode_type5_texture_view_fail_closed() {
 #[test]
 fn a_latched_backing_is_stale_when_any_of_geometry_or_format_moved() {
     use crate::contract::pixel_format::{MTL_FORMAT_BGRA8_UNORM, MTL_FORMAT_RGBA8_UNORM};
-    let surf = |w: u32, h: u32, fourcc: u32| Type4Surface {
+    let surf = |w: u32, h: u32, fourcc: u32| BackingRecord {
         length: 0x1000,
         backing_pfn: 1,
         pixel_format: fourcc,
@@ -1786,7 +1779,7 @@ fn a_latched_backing_is_stale_when_any_of_geometry_or_format_moved() {
 /// the failure a shared `latched_mapping_format` exists to make impossible.
 #[test]
 fn a_multiplane_backing_compares_equal_to_the_zero_it_latched() {
-    let mut surf = Type4Surface {
+    let mut surf = BackingRecord {
         length: 0x1000,
         backing_pfn: 1,
         pixel_format: 0x4247_5241, // 'BGRA' — a format the converter knows
@@ -1819,8 +1812,8 @@ fn a_multiplane_backing_compares_equal_to_the_zero_it_latched() {
 /// A single-plane surface must publish plane 0's offset, because both its
 /// consumers fold it in and one of them is the other pathway.
 ///
-/// `decode_type4_plane` reads four fields; the surface-level convenience
-/// copies on `Type4Surface` take three, and the synthesizer's single-plane
+/// `decode_backing_plane` reads four fields; the surface-level convenience
+/// copies on `BackingRecord` take three, and the synthesizer's single-plane
 /// arm used to publish only those three. A surface whose pixels start past
 /// the base of its allocation was then read and written at 0 — the
 /// multi-plane arm has always published each plane's offset, and
@@ -1832,7 +1825,7 @@ fn a_single_plane_backing_publishes_the_offset_its_pixels_start_at() {
     use crate::contract::pixel_format::MTL_FORMAT_BGRA8_UNORM;
     const BASE: u32 = 0x800;
     let (w, h, bpr) = (8u32, 4u32, 32u32);
-    let mut surf = Type4Surface {
+    let mut surf = BackingRecord {
         length: 0x4000,
         backing_pfn: 1,
         pixel_format: 0x4247_5241, // 'BGRA'
@@ -1842,7 +1835,7 @@ fn a_single_plane_backing_publishes_the_offset_its_pixels_start_at() {
         height: h,
         bytes_per_row: bpr,
     };
-    surf.planes[0] = Type4Plane {
+    surf.planes[0] = BackingPlane {
         offset: BASE,
         width: w,
         height: h,
@@ -1850,11 +1843,11 @@ fn a_single_plane_backing_publishes_the_offset_its_pixels_start_at() {
         bytes_per_element: 4,
     };
     assert!(
-        !type4_is_multiplanar(&surf),
+        !backing_is_multiplanar(&surf),
         "the single-plane arm is the one under test"
     );
 
-    let desc = synthesize_device_desc_from_type4(&surf);
+    let desc = synthesize_device_desc_from_backing(&surf);
     let decoded = decode_device_surface(&desc).expect("device descriptor");
     assert_eq!(
         decoded.plane_count, 0,
@@ -1876,7 +1869,7 @@ fn a_single_plane_backing_publishes_the_offset_its_pixels_start_at() {
 
     // Zero stays zero — the ordinary case must not gain an offset.
     surf.planes[0].offset = 0;
-    let zero = synthesize_device_desc_from_type4(&surf);
+    let zero = synthesize_device_desc_from_backing(&surf);
     assert_eq!(decode_device_surface(&zero).expect("desc").base_offset, 0);
 }
 
@@ -1930,7 +1923,7 @@ fn the_device_descriptor_format_word_survives_both_of_its_encodings() {
     assert_eq!(device_desc_format_to_mtl(0), 0);
 }
 
-/// The type-4 probe order must visit task 0 first, the hint next, and every
+/// The backing probe order must visit task 0 first, the hint next, and every
 /// **live** task exactly once.
 ///
 /// It is the thing that makes the search terminate on the first probe for
@@ -1946,7 +1939,7 @@ fn the_device_descriptor_format_word_survives_both_of_its_encodings() {
 /// and is why a length assertion against a number would silently stop meaning
 /// anything.
 #[test]
-fn the_type4_probe_order_visits_task_zero_first_and_every_live_task_once() {
+fn the_backing_probe_order_visits_task_zero_first_and_every_live_task_once() {
     use std::collections::HashSet;
 
     let mut state = DeviceState::new(DeviceId(1), crate::model::PAGE_SHIFT_X86);
@@ -1958,7 +1951,7 @@ fn the_type4_probe_order_visits_task_zero_first_and_every_live_task_once() {
     }
 
     for hint in [0u32, 1, 7, 70_000] {
-        let order = type4_probe_order(&state.tasks, hint);
+        let order = backing_probe_order(&state.tasks, hint);
         assert_eq!(order[0], 0, "task 0 leads for hint {hint}");
         if hint != 0 {
             assert_eq!(order[1], hint, "the hint is probed second");
@@ -1978,7 +1971,7 @@ fn the_type4_probe_order_visits_task_zero_first_and_every_live_task_once() {
     // A dead task is not probed. It never could be — the probe's own liveness
     // test refused it — so yielding it only ever cost a guest read's worth of
     // work per present.
-    let order = type4_probe_order(&state.tasks, 0);
+    let order = backing_probe_order(&state.tasks, 0);
     assert!(
         !order.contains(&9),
         "an id nothing defined must not be probed: {order:?}"
@@ -1986,27 +1979,27 @@ fn the_type4_probe_order_visits_task_zero_first_and_every_live_task_once() {
 
     // A hint naming no live task adds a probe that the liveness test at the
     // probe then refuses, and must not lose a live one or duplicate task 0.
-    let order = type4_probe_order(&state.tasks, u32::MAX);
+    let order = backing_probe_order(&state.tasks, u32::MAX);
     let seen: HashSet<u32> = order.iter().copied().collect();
     assert_eq!(seen.len(), order.len(), "{order:?}");
     assert!(live.iter().all(|t| seen.contains(t)), "{order:?}");
 }
 
 #[test]
-fn undecoded_type4_span_is_exactly_what_the_decoder_skips() {
+fn undecoded_backing_span_is_exactly_what_the_decoder_skips() {
     // One plane: the decoder consumes 0x14..0x24, so the tail starts there.
-    let built = Type4Builder::new(0x800000, 0x1234, 0x4247_5241, 1) // 'BGRA'
+    let built = BackingBuilder::new(0x800000, 0x1234, 0x4247_5241, 1) // 'BGRA'
         .plane(0, 0, 1920, 1080, 1920 * 4, 0)
         .with_len(0x40);
     let a = built.bytes().to_vec();
 
     // Every decoded field can change without moving the undecoded span.
-    let b = Type4Builder::new(0x900000, 0x9999, 0x4c31_3062, 1)
+    let b = BackingBuilder::new(0x900000, 0x9999, 0x4c31_3062, 1)
         .plane(0, 0, 1280, 720, 1280 * 4, 0)
         .with_len(0x40);
     assert_eq!(
-        undecoded_type4_surface_bytes(&a),
-        undecoded_type4_surface_bytes(b.bytes()),
+        undecoded_backing_bytes(&a),
+        undecoded_backing_bytes(b.bytes()),
         "changing only decoded fields must not look like a new shape"
     );
 
@@ -2016,8 +2009,8 @@ fn undecoded_type4_span_is_exactly_what_the_decoder_skips() {
         let mut c = a.clone();
         c[probe] ^= 0xff;
         assert_ne!(
-            undecoded_type4_surface_bytes(&a),
-            undecoded_type4_surface_bytes(&c),
+            undecoded_backing_bytes(&a),
+            undecoded_backing_bytes(&c),
             "byte {probe:#x} is undecoded and must be visible to the probe"
         );
     }
@@ -2030,25 +2023,25 @@ fn undecoded_type4_span_is_exactly_what_the_decoder_skips() {
         let mut c = a.clone();
         c[probe] ^= 0xff;
         assert_eq!(
-            undecoded_type4_surface_bytes(&a),
-            undecoded_type4_surface_bytes(&c),
+            undecoded_backing_bytes(&a),
+            undecoded_backing_bytes(&c),
             "byte {probe:#x} is decoded and must stay out of the span"
         );
     }
 
     // A second plane moves the boundary: 0x24..0x34 becomes decoded.
-    let two = Type4Builder::new(0x800000, 0x1234, 0x4247_5241, 2)
+    let two = BackingBuilder::new(0x800000, 0x1234, 0x4247_5241, 2)
         .plane(0, 0, 1920, 1080, 1920 * 4, 0)
         .with_len(0x40);
     assert_eq!(
-        undecoded_type4_surface_bytes(two.bytes()).len(),
-        undecoded_type4_surface_bytes(&a).len() - TYPE4_PLANE_STRIDE,
+        undecoded_backing_bytes(two.bytes()).len(),
+        undecoded_backing_bytes(&a).len() - TYPE4_PLANE_STRIDE,
         "the span shrinks by exactly one plane record"
     );
 
     // A record too short to decode reports nothing rather than a partial
     // span that would compare unequal against every real one.
-    assert!(undecoded_type4_surface_bytes(&a[..TYPE4_MIN_LEN - 1]).is_empty());
+    assert!(undecoded_backing_bytes(&a[..TYPE4_MIN_LEN - 1]).is_empty());
 }
 
 /// The shared ladder asks its three questions in the only order they can be
@@ -2062,16 +2055,16 @@ fn undecoded_type4_span_is_exactly_what_the_decoder_skips() {
 /// branches removes.
 #[test]
 fn the_shared_ladder_names_the_rung_that_refused() {
-    use crate::runtime::decode::resource::{OBJECT_TYPE_BUFFER, OBJECT_TYPE_IOSURFACE};
+    use crate::runtime::decode::resource::{OBJECT_TYPE_BUFFER, OBJECT_TYPE_MAPPER_REF_TEXTURE};
 
     let mut host = FakeHost::new();
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
     setup_task_with_list(&mut host, &mut state);
 
-    // Ref 1 is a type-11 entry whose descriptor is mapped: all three rungs pass.
-    let (entry, bytes) =
-        resolve_descriptor(&state, &host, 1, 1, &[OBJECT_TYPE_IOSURFACE]).expect("all rungs pass");
-    assert_eq!(entry.object_type, OBJECT_TYPE_IOSURFACE);
+    // Ref 1 is a mapper-ref-texture entry whose descriptor is mapped: all three rungs pass.
+    let (entry, bytes) = resolve_descriptor(&state, &host, 1, 1, &[OBJECT_TYPE_MAPPER_REF_TEXTURE])
+        .expect("all rungs pass");
+    assert_eq!(entry.object_type, OBJECT_TYPE_MAPPER_REF_TEXTURE);
     assert!(!bytes.is_empty(), "the descriptor bytes come back with it");
 
     // Same ref, asked for as a buffer: the tag it found travels with the
@@ -2080,7 +2073,7 @@ fn the_shared_ladder_names_the_rung_that_refused() {
     assert_eq!(
         resolve_descriptor(&state, &host, 1, 1, &[OBJECT_TYPE_BUFFER]),
         Err(LadderRung::WrongType {
-            got: OBJECT_TYPE_IOSURFACE
+            got: OBJECT_TYPE_MAPPER_REF_TEXTURE
         })
     );
 
@@ -2099,14 +2092,14 @@ fn the_shared_ladder_names_the_rung_that_refused() {
     let mut entry = [0u8; 12];
     st32(
         &mut entry[0..],
-        u32::from(OBJECT_TYPE_IOSURFACE) | (0x20u32 << 8),
+        u32::from(OBJECT_TYPE_MAPPER_REF_TEXTURE) | (0x20u32 << 8),
     );
     entry[4..12].copy_from_slice(&0xdead_0000u64.to_le_bytes());
     let _ = host.write_gpa(data_gpa + 24, &entry);
     // The declared length travels with the rung: the entry above says 0x20
     // bytes, and by the time a rail reports this the entry is gone.
     assert_eq!(
-        resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_IOSURFACE]),
+        resolve_descriptor(&state, &host, 1, 2, &[OBJECT_TYPE_MAPPER_REF_TEXTURE]),
         Err(LadderRung::DescRead { declared_len: 0x20 })
     );
 }
@@ -2198,8 +2191,8 @@ fn a_repoint_drops_the_ref_keyed_host_copies_of_the_object() {
 /// mapping id is a different namespace even when the integers happen to be
 /// equal.
 ///
-/// This is the compositor failure class: task 0 owns type-4 surface 1 while
-/// task 1 owns type-11 resource 1, which resolves to mapping 9. Re-pointing the
+/// This is the compositor failure class: task 0 owns backing record 1 while
+/// task 1 owns mapper-ref-texture resource 1, which resolves to mapping 9. Re-pointing the
 /// latter must retire mapping 9 and leave task 0's surface intact. The old
 /// global-id-first route did the opposite.
 #[test]
@@ -2208,21 +2201,24 @@ fn a_repoint_resolves_the_resource_in_its_task_before_touching_a_mapping() {
     let mut host = FakeHost::new();
     setup_task_with_list(&mut host, &mut state);
 
-    assert_eq!(resolve_type11_ref(&mut state, &host, 1, 1), Some(9));
+    assert_eq!(resolve_mapper_ref_texture(&mut state, &host, 1, 1), Some(9));
 
     assert!(state.map_surface(1));
     {
         let surface = state.mappings.get_mut(&1).expect("surface mapping");
         surface.mapped = true;
         surface.page_entries = vec![0x1234_5001];
-        surface.type4_walk = Some(crate::model::Type4Walk {
+        surface.backing_walk = Some(crate::model::BackingWalk {
             task_id: 0,
             backing_pfn: 0x20,
             map_generation: surface.map_generation,
         });
     }
     {
-        let resource = state.mappings.get_mut(&9).expect("type-11 mapping");
+        let resource = state
+            .mappings
+            .get_mut(&9)
+            .expect("mapper-ref-texture mapping");
         resource.mapped = true;
         resource.page_entries = vec![0x6789_a001];
     }
@@ -2236,15 +2232,15 @@ fn a_repoint_resolves_the_resource_in_its_task_before_touching_a_mapping() {
     );
     assert!(
         state.mappings[&9].page_entries.is_empty(),
-        "the task-local type-11 association names the mapping to invalidate"
+        "the task-local mapper-ref-texture association names the mapping to invalidate"
     );
 }
 
-/// A direct type-4 resource is routed by the task provenance latched with its
+/// A direct backing resource is routed by the task provenance latched with its
 /// page walk, so tightening the namespace must not suppress genuine surface
 /// re-points.
 #[test]
-fn a_repoint_retires_a_type4_mapping_owned_by_the_packet_task() {
+fn a_repoint_retires_a_backing_mapping_owned_by_the_packet_task() {
     let mut state = DeviceState::new(DeviceId(1), PAGE_SHIFT_X86);
     let mut host = FakeHost::new();
     assert!(state.map_surface(7));
@@ -2252,7 +2248,7 @@ fn a_repoint_retires_a_type4_mapping_owned_by_the_packet_task() {
         let surface = state.mappings.get_mut(&7).expect("surface mapping");
         surface.mapped = true;
         surface.page_entries = vec![0x1234_5001];
-        surface.type4_walk = Some(crate::model::Type4Walk {
+        surface.backing_walk = Some(crate::model::BackingWalk {
             task_id: 3,
             backing_pfn: 0x20,
             map_generation: surface.map_generation,
@@ -2266,7 +2262,7 @@ fn a_repoint_retires_a_type4_mapping_owned_by_the_packet_task() {
     assert_ne!(state.mappings[&7].map_generation, prior_generation);
     assert_ne!(
         state.mappings[&7]
-            .type4_walk
+            .backing_walk
             .expect("the old walk remains only as provenance")
             .map_generation,
         state.mappings[&7].map_generation,

--- a/crates/reims-vgpu/src/runtime/pipeline_resolve.rs
+++ b/crates/reims-vgpu/src/runtime/pipeline_resolve.rs
@@ -11,11 +11,11 @@
 //! namespace. Resource-list deletion belongs to a separate reference space and
 //! cannot retire a pipeline merely because its integer collides.
 //!
-//! The broad type-7 serializer object is not itself a retained resource: other
-//! type-7 subtypes are mutable serializer state. A render pipeline *constructed
+//! The broad serializer-object serializer object is not itself a retained resource: other
+//! serializer-object subtypes are mutable serializer state. A render pipeline *constructed
 //! from* that serializer is a distinct, immutable object with the explicit
 //! lifetime above. Keeping pipelines in their own typed registry preserves that
-//! distinction instead of either retaining every type-7 descriptor or re-reading
+//! distinction instead of either retaining every serializer-object descriptor or re-reading
 //! pipeline construction input on every draw.
 //!
 //! This used to be an insertion-bounded process-global memo. Every hit re-read

--- a/crates/reims-vgpu/src/runtime/present_identity.rs
+++ b/crates/reims-vgpu/src/runtime/present_identity.rs
@@ -1,4 +1,4 @@
-//! The resident identity a type-11 guest surface renders into.
+//! The resident identity a mapper-ref-texture guest surface renders into.
 //!
 //! A compatible surface resident is a Vulkan image imported over the guest
 //! allocation itself. Rendering, attachment LOAD, Store synchronization, and

--- a/crates/reims-vgpu/src/runtime/render_writeback/mod.rs
+++ b/crates/reims-vgpu/src/runtime/render_writeback/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! [`crate::runtime::writeback_debt`] is the rail this doc spent four sections
 //! designing and one section burying, built in the one shape the four guest
-//! panics do not rule out: type-11 mappings are resolved at payment, while a
+//! panics do not rule out: mapper-ref-texture mappings are resolved at payment, while a
 //! live GVA resource retains the physical-page identity of its transfer
 //! backing without retaining raw host pointers. Read that
 //! module's doc first if you are here about deferral; what follows is the
@@ -25,7 +25,7 @@
 //! in the ways below.
 //!
 //! Twelve driven macos-13 sustained-animation boots, six an arm: **90 % of
-//! type-11 Stores are superseded before anything reads their pages**, `store_us`
+//! mapper-ref-texture Stores are superseded before anything reads their pages**, `store_us`
 //! falls 0.89 against 9.56 us a chain, `draw_us` 14.62 against 26.52, and five
 //! of six on-arm boots present at 105.8-109.2 Hz against a 77.2-78.6 Hz
 //! baseline. GVA targets use the same ownership rule now; their debt is keyed by
@@ -100,7 +100,7 @@
 //! `registry_mark_ready` clears that stamp on every draw that renders into the
 //! resident, so `resident_content_epoch(identity) == m.surface_content_epoch` at
 //! the top of a Store means nothing has changed the pixels since the last one.
-//! It is the same comparison the type-11 attachment LOAD already elides its CPU
+//! It is the same comparison the mapper-ref-texture attachment LOAD already elides its CPU
 //! seed on, read from the writing side.
 //!
 //! **It is zero, and not nearly zero.** A census partitioning every
@@ -343,7 +343,7 @@
 //!
 //!   Read that against [`SettleSite::ScanoutPaint`] and not against the slug it
 //!   used to share. `scanout::paint_mapping` has two callers — the console, and
-//!   `read_mapping_bgra8`, which is a draw materialising a sampled type-11
+//!   `read_mapping_bgra8`, which is a draw materialising a sampled mapper-ref-texture
 //!   texture — and until the sampled arm got [`SettleSite::SampledMappingRead`]
 //!   they charged one route. A macos-11 Safari-torture leg read 985 waits and
 //!   1.42 s on it, which is three orders of magnitude off the console's rate and
@@ -677,12 +677,12 @@ settle_sites! {
     /// times in a whole boot", and that is true of the console. It was not true
     /// of this *slug*, because `paint_mapping` has two callers and both charged
     /// it: the console's `scanout_copy_mapping`, and `read_mapping_bgra8`, which
-    /// is sampled type-11 bind materialisation on a draw. A macos-11
+    /// is sampled mapper-ref-texture bind materialisation on a draw. A macos-11
     /// Safari-torture leg read 985 waits and 1.42 s here, which is the second
     /// caller, and the doc's six-a-boot reading was being applied to a number
     /// three orders of magnitude off it. The sampled arm names itself below.
     ScanoutPaint => "settle_scanout_paint",
-    /// `scanout::read_mapping_bgra8` — a draw materialising a sampled type-11
+    /// `scanout::read_mapping_bgra8` — a draw materialising a sampled mapper-ref-texture
     /// texture out of a mapping's guest pages.
     ///
     /// Shares `paint_mapping`'s leaf with the console above and nothing else:
@@ -696,7 +696,7 @@ settle_sites! {
     CompletionStamp => "settle_completion_stamp",
     /// `drain::drain_main_fifo` — the root packet's completion stamp.
     RootStamp => "settle_root_stamp",
-    /// `mapping_write::write_bgra8_inner` — the copying type-11 Store.
+    /// `mapping_write::write_bgra8_inner` — the copying mapper-ref-texture Store.
     MappingBgra8Write => "settle_mapping_bgra8_write",
     /// `mapping_write::write_rgba8_image_changed`.
     MappingRgba8Write => "settle_mapping_rgba8_write",

--- a/crates/reims-vgpu/src/runtime/render_writeback/vulkan.rs
+++ b/crates/reims-vgpu/src/runtime/render_writeback/vulkan.rs
@@ -10,7 +10,7 @@
 //! every entry point here takes a
 //! [`crate::backend::vulkan::engine::TargetIdentity`], and a rail that holds no
 //! residents has nothing to name. The three destinations are the three
-//! namespaces the guest renders into — a type-11 mapping, a guest-backed
+//! namespaces the guest renders into — a mapper-ref-texture mapping, a guest-backed
 //! surface, and a raw GVA plane — and each is reached only from that rail's own
 //! draw, blit or compute path.
 //!
@@ -614,7 +614,7 @@ fn land_gva_frame_bytes<M: HostMemory + HostOps>(
     Ok(extent)
 }
 
-/// Copy `identity`'s pixels into the guest pages behind a type-2/3 render
+/// Copy `identity`'s pixels into the guest pages behind a normal-texture render
 /// target's `target_gva`, with no host copy of the frame at any point.
 ///
 /// The GVA twin of [`store_render_frame`]'s first arm, and worth diffing
@@ -894,7 +894,7 @@ pub(crate) fn copy_resident_into_gva_plane<M: HostMemory + HostOps>(
     // `store_render_frame` performs in `finish`.
     crate::backend::vulkan::engine::note_resident_content_copied_out(identity);
     // Arm the GVA write witness over the pages this Store just published, the
-    // twin of `mapper::stamp_guest_write_gen` on the type-11 rail. It is what
+    // twin of `mapper::stamp_guest_write_gen` on the mapper-ref-texture rail. It is what
     // lets a later reader ask whether these pages still hold this frame without
     // reading them — see `crate::runtime::gva_store_witness`.
     //

--- a/crates/reims-vgpu/src/runtime/sampled_phase.rs
+++ b/crates/reims-vgpu/src/runtime/sampled_phase.rs
@@ -53,7 +53,7 @@
 //! |---|---|---|---|---|
 //! | `Resolve` | 15498 | 72.1 | the attachment-alias branch and `resolve_sampled_source`, per texture bind | the sampled content cache and the gather witness |
 //! | [`Part::Reflect`] | 2556 | 11.9 | the AIR constexpr static-sampler walk and, in this measurement, the residual SPIR-V sampler-interface scan | carrying the reflected interface with each `m2v_cache` variant |
-//! | [`Part::Lookup`] | 1526 | 7.1 | `lookup_list_entry` + `resolve_texture_view`, per texture bind | caching the guest object-list walk and the type-8 view descriptor read |
+//! | [`Part::Lookup`] | 1526 | 7.1 | `lookup_list_entry` + `resolve_texture_view`, per texture bind | caching the guest object-list walk and the texture-view descriptor read |
 //! | [`Part::Samplers`] | 1263 | 5.9 | `load_vulkan_sampler` over the record's own sampler binds | the task-scoped retained sampler registry |
 //!
 //! The sampler registry is now the contract rather than a prospective cache:
@@ -130,7 +130,7 @@ use crate::observe::phase_clock::{charge_ns, to_us};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Part {
     /// The per-bind guest reads: `objects::lookup_list_entry` for the texture's
-    /// object-list entry, and `resolve_texture_view` for a type-8 view's
+    /// object-list entry, and `resolve_texture_view` for a texture-view's
     /// channel remap.
     Lookup = 0,
     /// The fragment attachment-alias branch: the `req.colors` probe, plus
@@ -139,7 +139,7 @@ pub enum Part {
     /// `to_vec` of the prior record's seed for a Load one — so this is where a
     /// draw sampling the target it is drawing into pays for the copy.
     ResolveAlias = 1,
-    /// `resolve_sampled_source`: the type-11 rung ladder and the linear guest
+    /// `resolve_sampled_source`: the mapper-ref-texture rung ladder and the linear guest
     /// rungs, for every bind the alias branch above did not claim.
     ResolveSource = 2,
     /// `load_vulkan_sampler` over the record's vertex and fragment sampler

--- a/crates/reims-vgpu/src/runtime/scanout/mod.rs
+++ b/crates/reims-vgpu/src/runtime/scanout/mod.rs
@@ -6,8 +6,8 @@
 //! otherwise we fall back to the programmed EFI framebuffer or clear.
 //!
 //! Early-boot / present policy (archive apple-pv-gpu + live Monterey + PGDisplay):
-//! - Front formats: archive prefers type-11 **RGBA16Float** (0x73); live Monterey
-//!   boot logo/progress also stores full-screen type-11 **BGRA8** / **RGBA8**
+//! - Front formats: archive prefers mapper-ref-texture **RGBA16Float** (0x73); live Monterey
+//!   boot logo/progress also stores full-screen mapper-ref-texture **BGRA8** / **RGBA8**
 //!   before the first DisplaySwap — paint those formats too pre-boundary.
 //! - Geometry barrier (archive same_geom): first early paint establishes console
 //!   size from the **guest surface** (mapper geom / job size); later pre-boundary
@@ -36,10 +36,10 @@ use crate::contract::pixel_format::{
 use crate::model::{scanout_extent_ok, DeviceState, EFI_BOOT_HEIGHT, EFI_BOOT_WIDTH};
 use crate::runtime::host::HostMemory;
 
-/// Type-11 color formats that may be the compositor front before DisplaySwap.
+/// Mapper-ref-texture color formats that may be the compositor front before DisplaySwap.
 ///
 /// Archive `front_buffer` is RGBA16Float only; live Monterey also draws the
-/// early boot logo into BGRA8/RGBA8 type-11 full-frame targets. Not a size list.
+/// early boot logo into BGRA8/RGBA8 mapper-ref-texture full-frame targets. Not a size list.
 #[inline]
 fn is_front_buffer_format(fmt: u16) -> bool {
     matches!(
@@ -61,11 +61,11 @@ pub enum ScanoutCopyResult {
 
 /// Read mapping pages into `dst` without updating present/paint generation.
 ///
-/// Used by draw bind materialization (sampled type-11 textures). Returns true
+/// Used by draw bind materialization (sampled mapper-ref-textures). Returns true
 /// when geometry and page table produced a full image.
 ///
 /// Backend-agnostic on purpose: it resolves and scatters guest pages and
-/// touches no engine, and the Metal arm's `load_type11_mapping_rgba` needs it
+/// touches no engine, and the Metal arm's `load_mapper_ref_texture_mapping_rgba` needs it
 /// for the same reason the Vulkan arm does.
 pub fn read_mapping_bgra8<M: HostMemory + crate::runtime::host::HostOps>(
     state: &mut DeviceState,
@@ -154,7 +154,7 @@ pub fn capture_present_frame(
         return false;
     }
     // "These are different pixels", which `generation` cannot say for a lazy
-    // type-11 Store: it leaves the frame in the engine resident and writes no
+    // mapper-ref-texture Store: it leaves the frame in the engine resident and writes no
     // guest page, so `content_generation` holds still while the pixels move.
     // Read from the entry here rather than threaded in, because the caller
     // resolved `generation` from that same entry and a second parameter is a
@@ -257,7 +257,7 @@ pub fn capture_present_frame(
     //
     // The proxies need the finished frame's BYTES; they do not need those bytes
     // to be in guest pages. This reads the resident and nothing else: no
-    // `flush_intersecting`. Nothing is owed — a type-11 render Store lands its
+    // `flush_intersecting`. Nothing is owed — a mapper-ref-texture render Store lands its
     // own guest-page writeback (`mapping_write::write_rgba8_image_changed`), and
     // the deferred rails that remain (compute storage, linear, GVA) are keyed on
     // resources this capture does not touch and flush on a genuine guest read
@@ -294,7 +294,7 @@ pub fn capture_present_frame(
         state.present.capture_scratch = buf;
         return false;
     }
-    // Capture provenance, and there are only two sources to name: the type-4
+    // Capture provenance, and there are only two sources to name: the backing
     // surface_cache hit, or the resident. Reaching here with `!from_host_cache`
     // means `Backend::try_capture_from_resident` returned true above, and it returns true
     // and there is no third source. This used to read a `last_paint_src`
@@ -345,7 +345,7 @@ pub fn capture_present_frame(
     state.present.frame_content_epoch = content_epoch;
     state.present.frame_valid = true;
     // Force the next host paint to blit +0x188. Early pre-boundary paints may
-    // have latched painted_mapping/generation (live type-11 paint_mapping or
+    // have latched painted_mapping/generation (live mapper-ref-texture paint_mapping or
     // paint_efi_console) to the same mid+gen; with encode_pending=false that made
     // copy_to_bgra8 return Unchanged and left the QEMU console on frozen EFI
     // while +0x188 held logo+pill (live serial-20260715-054015:
@@ -772,7 +772,7 @@ impl crate::observe::Decline for ConsoleEfiRowRefused {
 ///
 /// Bare, three of them were claimed by another rail: `unmapped` and `short_view`
 /// were also `import_present`'s words for different checks, and `no_mapping` was
-/// also the type-5 loader's — so `grep reason=unmapped` returned a mix of the
+/// also the ref-texture loader's — so `grep reason=unmapped` returned a mix of the
 /// capture rail and the import rail and could not be read. The `capture_` prefix
 /// is the same fix the slate reasons and the MRT proxies took.
 ///
@@ -800,7 +800,7 @@ enum CaptureDecline {
     BppUnknown { format: u16 },
     /// The pixel format has no known tight row size.
     TightRowUnknown { format: u16 },
-    /// No type-11 sample window could be derived.
+    /// No mapper-ref-texture sample window could be derived.
     NoSampleWindow,
     /// The descriptor's row stride is narrower than a tight row.
     BprBelowTight { bpr: u64, tight: u32 },
@@ -925,7 +925,7 @@ fn paint_mapping<M: HostMemory + crate::runtime::host::HostOps>(
         width,
         height,
     } = dst;
-    use crate::runtime::mapping_write::type11_sample_window;
+    use crate::runtime::mapping_write::mapper_ref_texture_sample_window;
 
     // Every `false` return here shows as a black/stale console; log the specific
     // reason so the "why is it black" class is diagnosable (scanout audit Rank-3).
@@ -963,7 +963,7 @@ fn paint_mapping<M: HostMemory + crate::runtime::host::HostOps>(
     if m.page_entries.is_empty() {
         return fail(CaptureDecline::NoPages);
     }
-    // Geometry must be latched (same rule as write_bgra8 / archive scanout_type11).
+    // Geometry must be latched (same rule as write_bgra8 / archive scanout_mapper_ref_texture).
     if !m.has_geom || m.width == 0 || m.height == 0 {
         return fail(CaptureDecline::NoGeom);
     }
@@ -988,7 +988,8 @@ fn paint_mapping<M: HostMemory + crate::runtime::host::HostOps>(
         return fail(CaptureDecline::TightRowUnknown { format });
     };
     // Same sample window as writeback (device descriptor base/bpr when present).
-    let Some((base_off, bpr_u32, span_end)) = type11_sample_window(m, mw, mh, format) else {
+    let Some((base_off, bpr_u32, span_end)) = mapper_ref_texture_sample_window(m, mw, mh, format)
+    else {
         return fail(CaptureDecline::NoSampleWindow);
     };
     let bpr = bpr_u32 as usize;
@@ -1128,14 +1129,14 @@ pub fn present_dims(state: &DeviceState, mapping_id: u32) -> (u32, u32) {
     (0, 0)
 }
 
-/// After a successful type-11 color writeback: maybe latch front mapping / paint.
+/// After a successful mapper-ref-texture color writeback: maybe latch front mapping / paint.
 ///
 /// Contract:
 /// - **PGDisplay**: present names one surface; mode size = that surface's geom
 ///   (`modeChangeHandler` sizeInPixels). We never invent host mode sizes.
 /// - **Archive same_geom**: paint pre-boundary only when console unset or job
 ///   W×H equals established console (strips/other RTs do not resize the window).
-/// - **Live Monterey**: early logo also lands in BGRA8/RGBA8 type-11 (not only
+/// - **Live Monterey**: early logo also lands in BGRA8/RGBA8 mapper-ref-texture (not only
 ///   0x73); accept those formats pre-boundary. Post-boundary paint is DisplaySwap
 ///   only — writebacks must not rename `present_mapping` after `frame_flush_seen`.
 pub fn note_front_buffer_writeback<M: HostMemory + crate::runtime::host::HostOps>(
@@ -1205,7 +1206,7 @@ pub fn note_front_buffer_writeback<M: HostMemory + crate::runtime::host::HostOps
     }
 
     // HostAction size = mapper registry geom when known (archive
-    // scanout_type11_mapping / PG sizeInPixels from the named surface).
+    // scanout_mapper_ref_texture_mapping / PG sizeInPixels from the named surface).
     let (paint_w, paint_h) = if has_geom {
         (map_w, map_h)
     } else {
@@ -1433,7 +1434,9 @@ impl SampledFieldWindow {
         })?;
         let bpp = pixel_format::bytes_per_pixel(format)?;
         let (base_off, bpr, _) = state.mappings.get(&mapping_id).and_then(|m| {
-            crate::runtime::mapping_write::type11_sample_window(m, width, height, format)
+            crate::runtime::mapping_write::mapper_ref_texture_sample_window(
+                m, width, height, format,
+            )
         })?;
         Some(Self {
             width,
@@ -1618,7 +1621,9 @@ pub fn note_present_field_witness<M: HostMemory>(
             m.format
         };
         (
-            crate::runtime::mapping_write::type11_sample_window(m, width, height, format),
+            crate::runtime::mapping_write::mapper_ref_texture_sample_window(
+                m, width, height, format,
+            ),
             format,
             m.map_generation,
             m.surface_content_epoch,

--- a/crates/reims-vgpu/src/runtime/scanout/tests.rs
+++ b/crates/reims-vgpu/src/runtime/scanout/tests.rs
@@ -44,7 +44,7 @@ const ALL_CAPTURE: &[CaptureDecline] = &[
 /// Every capture reason names the rail that wrote it.
 ///
 /// Bare, three of these belonged to other rails too — `unmapped` and
-/// `short_view` to the guest-page import path and `no_mapping` to the type-5
+/// `short_view` to the guest-page import path and `no_mapping` to the ref-texture
 /// loader — so a `grep reason=unmapped` over one boot returned a mix of
 /// subsystems. The prefix is what makes that grep answerable.
 #[test]

--- a/crates/reims-vgpu/src/runtime/spirv_bind.rs
+++ b/crates/reims-vgpu/src/runtime/spirv_bind.rs
@@ -2975,7 +2975,7 @@ pub enum ReflectedComputeTexture {
     Absent,
     /// A single-layer, non-multisampled 2D texture, carrying its
     /// sampled-vs-storage class. This is the only shape the compute rail can
-    /// stage: a binding comes from one type-11 plane window or one linear GVA
+    /// stage: a binding comes from one mapper-ref-texture plane window or one linear GVA
     /// level, both flat `width × height` rectangles.
     Plain2d(ImageAccess),
     /// A single-layer multisampled 2D texture the kernel reads

--- a/crates/reims-vgpu/src/runtime/surface_cache/mod.rs
+++ b/crates/reims-vgpu/src/runtime/surface_cache/mod.rs
@@ -1,14 +1,14 @@
 //! Host surface cache for Linux/Vulkan discrete-GPU present (kb tahoe-x86 §8.5).
 //!
 //! On Apple Metal hosts, GPU Stores land in guest IOSurface pages (unified
-//! memory). On this Linux product rail guest type-4 pages are **not** filled by
+//! memory). On this Linux product rail guest backing pages are **not** filled by
 //! the host GPU until encode writeback; historical product painted from a
 //! **host render-cache** keyed by surface_id. This module is that cache.
 //!
 //! Namespace split (2026-07-13 live x86):
-//! - [`store`] / [`get`] — **type-4 surface_id / mapping_id** only (`host_surfaces`)
-//! - [`store_texture`] / [`get_texture`] — type-2/3 color targets by task/object ref
-//! - [`store_gva_owned`] / [`get_gva`] — type-2/3 by target GVA (survives ref rebinding)
+//! - [`store`] / [`get`] — **backing record_id / mapping_id** only (`host_surfaces`)
+//! - [`store_texture`] / [`get_texture`] — normal-texture color targets by task/object ref
+//! - [`store_gva_owned`] / [`get_gva`] — normal-texture by target GVA (survives ref rebinding)
 //!
 //! Never put texture_ref into `host_surfaces`: list ids collide with mids and
 //! recycled refs return stale full-frame blacks as multi-bind samples.
@@ -83,12 +83,12 @@ fn get_from_with_gen<'a, K: Ord>(
     Some((&e.bgra[..need], e.host_gen))
 }
 
-/// Insert/replace host-cache pixels for `surface_id` (type-4 present id).
+/// Insert/replace host-cache pixels for `surface_id` (backing present id).
 pub fn store(state: &mut DeviceState, surface_id: u32, width: u32, height: u32, bgra: Vec<u8>) {
     store_shared(state, surface_id, width, height, std::sync::Arc::new(bgra));
 }
 
-/// [`store`] for a frame already held behind an `Arc` — the type-11 render Store
+/// [`store`] for a frame already held behind an `Arc` — the mapper-ref-texture render Store
 /// arms its deferred window with the same allocation, so the frame is stored
 /// once and referenced twice.
 pub fn store_shared(
@@ -200,7 +200,7 @@ pub fn get(state: &DeviceState, surface_id: u32, width: u32, height: u32) -> Opt
 /// `(surface_id, generation)` pair is a statement that the bytes have not moved,
 /// which is what lets the sampled cache skip re-hashing a frame it already holds.
 ///
-/// The caller is the type-11 sampled ladder's host-cache rung, which without
+/// The caller is the mapper-ref-texture sampled ladder's host-cache rung, which without
 /// this had no identity to offer and drove every bind through the content
 /// digest: 116 lookups a second over 201 MB, hashed twice each. It takes the
 /// frame as a handle rather than a slice because it hands the bytes to the
@@ -219,7 +219,7 @@ pub fn get_shared_with_gen(
     Some((get_shared(state, surface_id, width, height)?, host_gen))
 }
 
-/// Cede this mapping's cached frame to the engine resident a deferred type-11
+/// Cede this mapping's cached frame to the engine resident a deferred mapper-ref-texture
 /// render Store just pinned: the entry keeps its geometry and its `host_gen`
 /// lineage, and holds no bytes.
 ///
@@ -227,7 +227,7 @@ pub fn get_shared_with_gen(
 /// what enforces it — so every reader that goes through [`get`] or [`get_shared`]
 /// misses and falls through to the source that does hold the frame:
 /// [`crate::runtime::scanout::capture_present_frame`] to
-/// `try_capture_from_resident`, and the type-11 LOAD seed to the surface's own
+/// `try_capture_from_resident`, and the mapper-ref-texture LOAD seed to the surface's own
 /// guest pages, which lands this window first. Nothing has to be taught about a
 /// new state.
 ///
@@ -278,7 +278,7 @@ pub fn forget(state: &mut DeviceState, surface_id: u32) {
 /// [`cede_surface_to_resident`] leaves behind: present at exactly this geometry
 /// and carrying no bytes.
 ///
-/// Read by the type-11 LOAD seed's decline classifier so a ceded entry is named
+/// Read by the mapper-ref-texture LOAD seed's decline classifier so a ceded entry is named
 /// as such instead of being reported as a stale-geometry hit — `get`'s miss is
 /// the same either way, and the two have different fixes.
 pub fn surface_ceded_to_resident(
@@ -321,7 +321,7 @@ pub fn get_shared(
     })
 }
 
-/// Type-2/3 encode cache by task-local texture object ref (not surface_id).
+/// normal-texture encode cache by task-local texture object ref (not surface_id).
 ///
 /// `source_gva` is the address the producing Store rendered into, kept so
 /// [`texture_source_gva`] can tell a later serve whether this entry's pixels
@@ -474,7 +474,7 @@ impl LinearWindow {
     }
 }
 
-/// Store tight raw compute content for a type-2/3 texture object.
+/// Store tight raw compute content for a normal-texture object.
 ///
 /// This is the discrete GPU-private body. It deliberately survives
 /// MapMemory2/UnmapMemory; the guest GVA pages are only a pageable alias.
@@ -760,10 +760,10 @@ const fn page_mask(page_shift: u32) -> u64 {
     !((1u64 << page_shift) - 1)
 }
 
-/// Store a type-2/3 encode in the GVA-keyed cache, with the decoded object
+/// Store a normal-texture encode in the GVA-keyed cache, with the decoded object
 /// identity that produced it.
 ///
-/// Type-2/type-3 wrappers are the same linear texture storage family when the
+/// Texture/generate-mipmaps texture wrappers are the same linear texture storage family when the
 /// GVA and geometry match; unrelated nonzero object-type transitions still
 /// identify a different resource class.
 ///

--- a/crates/reims-vgpu/src/runtime/texture.rs
+++ b/crates/reims-vgpu/src/runtime/texture.rs
@@ -1,6 +1,6 @@
-//! Type-11 / texture geometry registration onto the IOSurface mapping table.
+//! Mapper-ref-texture / texture geometry registration onto the IOSurface mapping table.
 //!
-//! Archive: `apple_pv_gpu_register_type11_texture` latches width/height/format
+//! Archive: `apple_pv_gpu_register_mapper_ref_texture` latches width/height/format
 //! on the mapping when a texture descriptor is resolved. Device-desc geom
 //! (mapper path) and texture-path geom share [`DeviceState::set_mapping_geom`].
 
@@ -8,8 +8,8 @@ use crate::contract::iosurface_pages::decode_texture_descriptor;
 use crate::model::{is_mapping_id, DeviceState};
 use crate::runtime::decode::resource::{decode_descriptor, Descriptor};
 
-/// Register geometry from a decoded type-11 / IOSurface texture descriptor.
-pub fn register_type11_geom(
+/// Register geometry from a decoded mapper-ref-texture / IOSurface texture descriptor.
+pub fn register_mapper_ref_texture_geom(
     state: &mut DeviceState,
     mapping_id: u32,
     width: u32,
@@ -27,7 +27,7 @@ pub fn register_type11_geom(
     state.set_mapping_geom(mapping_id, width, height, format)
 }
 
-/// Decode descriptor bytes and, if type-11, latch mapping geometry.
+/// Decode descriptor bytes and, if mapper-ref-texture, latch mapping geometry.
 pub fn register_from_descriptor_bytes(
     state: &mut DeviceState,
     object_type: u8,
@@ -39,7 +39,13 @@ pub fn register_from_descriptor_bytes(
         // `bytes.len() < TYPE11_DESC_MIN_LEN`, so a copy of it one call above
         // could only ever disagree with the arm it is guarding.
         match decode_texture_descriptor(desc) {
-            Ok(t) => register_type11_geom(state, t.mapping_id, t.width, t.height, t.pixel_format),
+            Ok(t) => register_mapper_ref_texture_geom(
+                state,
+                t.mapping_id,
+                t.width,
+                t.height,
+                t.pixel_format,
+            ),
             Err(_) => false,
         }
     };
@@ -50,20 +56,20 @@ pub fn register_from_descriptor_bytes(
             height,
             pixel_format,
             ..
-        }) => register_type11_geom(state, mapping_id, width, height, pixel_format),
+        }) => register_mapper_ref_texture_geom(state, mapping_id, width, height, pixel_format),
         // A buffer, a function, a pipeline: not a refusal. This is called for
-        // every object type and only type-11 carries mapping geometry, so the
+        // every object type and only mapper-ref-texture carries mapping geometry, so the
         // decoder answering "that is a different object" is the normal case and
         // must stay out of the log.
         Ok(_) => headerless(state),
         Err(e) => {
             let recovered = headerless(state);
             if !recovered {
-                // Both forms refused, so a type-11 registration was genuinely
+                // Both forms refused, so a mapper-ref-texture registration was genuinely
                 // dropped. `_ => false` used to give this the same silence as
                 // the `Ok(_)` arm above, which is the collapse: a malformed
                 // descriptor and a buffer object looked identical.
-                crate::observe::Emit::decline("type11_register", &e)
+                crate::observe::Emit::decline("mapper_ref_texture_register", &e)
                     .field("obj_type", object_type)
                     .field("len", desc.len())
                     .fail_once(object_type as u64);
@@ -82,9 +88,9 @@ mod tests {
     use crate::model::{DeviceId, PAGE_SHIFT_ARM64E};
 
     #[test]
-    fn type11_geom_and_generation() {
+    fn mapper_ref_texture_geom_and_generation() {
         let mut s = DeviceState::new(DeviceId(1), PAGE_SHIFT_ARM64E);
-        assert!(register_type11_geom(&mut s, 5, 640, 480, 0x50));
+        assert!(register_mapper_ref_texture_geom(&mut s, 5, 640, 480, 0x50));
         let m = s.mappings.get(&5).unwrap();
         assert!(m.has_geom);
         assert_eq!((m.width, m.height, m.format), (640, 480, 0x50));

--- a/crates/reims-vgpu/src/runtime/writeback_debt.rs
+++ b/crates/reims-vgpu/src/runtime/writeback_debt.rs
@@ -9,7 +9,7 @@
 //!
 //! # A resource owns its transfer backing
 //!
-//! Type-11 debts carry a mapping id, geometry, and map generation. GVA debts
+//! Mapper-ref-texture debts carry a mapping id, geometry, and map generation. GVA debts
 //! carry the task-local texture reference, GVA declaration, geometry, format,
 //! and resource generation. The live GVA resource separately retains the
 //! ordered physical pages of its transfer backing. Ordinary task unmap changes
@@ -42,7 +42,7 @@
 //! invalidation, task retirement, and generation movement release the same
 //! ownership without inventing a guest write.
 //!
-//! [`MAX_DEBTS`] bounds only anonymous type-11 surface debts. GVA resource
+//! [`MAX_DEBTS`] bounds only anonymous mapper-ref-texture surface debts. GVA resource
 //! lifetime is explicit — resource discard/delete and task teardown — so an
 //! unrelated capacity limit must not invent an early synchronization point.
 
@@ -119,7 +119,7 @@ pub(crate) fn test_resident_identity(
     NoResidentIdentity
 }
 
-/// A frame owed to one type-11 mapping's guest pages.
+/// A frame owed to one mapper-ref-texture mapping's guest pages.
 ///
 /// Values only, and no memory. See the module doc: the rail this replaces held
 /// resolved host pointers and corrupted the guest's page tables with them. A
@@ -1758,7 +1758,7 @@ fn pay_gva<M: HostMemory + HostOps>(
 
 /// [`pay`] on an arm with no Vulkan engine to owe a frame to.
 ///
-/// Unreachable rather than merely unused: the only arm site is the type-11
+/// Unreachable rather than merely unused: the only arm site is the mapper-ref-texture
 /// surface Store in `draw::vulkan`, so the ledger is empty on this arm and both
 /// callers return at their emptiness check before reaching here. It exists so
 /// the reader-side helpers can be one set of functions on both arms instead of

--- a/crates/reims-vgpu/tests/vk_engine_parity.rs
+++ b/crates/reims-vgpu/tests/vk_engine_parity.rs
@@ -153,7 +153,7 @@ fn near(got: u8, want: u8) -> bool {
 ///
 /// The engine picks the attachment format from the resolved target — a
 /// `TargetIdentity::Surface` resident is the format its mapping declared, which
-/// is `SURFACE_TEST_FORMAT` for every identity in this file, so a type-11
+/// is `SURFACE_TEST_FORMAT` for every identity in this file, so a mapper-ref-texture
 /// composite Store's readback lands in guest scanout order with no CPU pass — and reports
 /// which it used in `DrawOutput::pixels_bgra`. These cases assert *colour*, not
 /// byte layout, so they normalize here from the reported order rather than
@@ -1193,7 +1193,7 @@ fn sampled_upload_happens_once_across_more_draws_than_the_ring_is_deep() {
     }
 }
 
-/// A resident type-11 sample stays on the GPU: no source readback, staging
+/// A resident mapper-ref-texture sample stays on the GPU: no source readback, staging
 /// upload, or temporary sampled image. The tracked layout must still permit a
 /// later LoadFromTarget draw on the source identity.
 #[test]
@@ -1796,7 +1796,7 @@ fn every_admitted_resident_survives_past_the_retired_slot_cap() {
 /// and reads back in it **without the caller asking**, and says so; a pooled
 /// target does not.
 ///
-/// This is the contract the type-11 composite Store rests on. That Store's
+/// This is the contract the mapper-ref-texture composite Store rests on. That Store's
 /// consumers are all defined in BGRA — `mapping_write::write_bgra8`,
 /// `surface_cache`, the deferred window the flush reads — so when the attachment
 /// is BGRA the readback lands ready to use, and when it is not the runtime pays a
@@ -2412,7 +2412,7 @@ fn sampled_bgra8_bytes_upload_matches_rgba8_semantic_color() {
     );
 }
 
-/// **L3's proof.** A decoded type-8 view swizzle must be performed by the image
+/// **L3's proof.** A decoded texture-view swizzle must be performed by the image
 /// view's component mapping, on the GPU, at sample time — not by rewriting
 /// texels, which would force every swizzled texture onto the CPU upload path
 /// and cost it the zero-copy crossing.
@@ -2722,7 +2722,7 @@ fn an_alpha_only_write_mask_leaves_the_colour_channels_alone() {
 /// A `SeedOrder::Bgra8` seed must land the same semantic pixels as the
 /// equivalent `SeedOrder::Rgba8` seed.
 ///
-/// This is the type-11 composite Load. `surface_cache` holds guest scanout order
+/// This is the mapper-ref-texture composite Load. `surface_cache` holds guest scanout order
 /// while the pooled target is RGBA, so the runtime used to allocate, copy and
 /// swizzle a whole framebuffer per seeded draw purely to restate pixels it
 /// already had — at the 28-111 Stores/s `store_routes` measures. Naming the
@@ -2980,7 +2980,7 @@ fn chain_load_from_target_byte_parity_vs_cpu_seed() {
     );
 }
 
-/// The type-11 composite Store's shape: `LoadFromTarget` on a resident that the
+/// The mapper-ref-texture composite Store's shape: `LoadFromTarget` on a resident that the
 /// *previous* pass read back, rather than one it left GPU-only.
 ///
 /// Every other `LoadFromTarget` case in this suite sets `skip_readback = true`
@@ -3087,7 +3087,7 @@ fn load_from_target_after_a_readback_matches_the_cpu_seed_chain() {
     );
 }
 
-/// Resident GVA chain (type-2/3 rail): a 3-record chain keeps intermediate
+/// Resident GVA chain (normal-texture rail): a 3-record chain keeps intermediate
 /// content on the engine target — exactly one readback (the final contract
 /// Store), zero CPU seed uploads, two post-submit wait skips — and the final
 /// pixels byte-match the CPU round-trip chain (readback → LoadSeed re-upload

--- a/crates/reims-vgpu/tests/wire_fixtures_reach_the_decoders.rs
+++ b/crates/reims-vgpu/tests/wire_fixtures_reach_the_decoders.rs
@@ -182,7 +182,7 @@ fn blit_verdict(bytes: &[u8]) -> Reading {
 /// as a class. Two are worth their own line:
 ///
 /// * `0x0c`, the IOSurface-backed texture. `decode_iosurface_texture_descriptor`
-///   looks like its record reader and is not: that function reads the **type-11
+///   looks like its record reader and is not: that function reads the **mapper-ref-texture
 ///   object-list descriptor**, a structure the kernel and IOSurface write,
 ///   whose live blobs run `0x38`/`0x58` bytes against this record's 48. Its own
 ///   doc says so and says it does not run on the x86 pathway at all. Feeding a
@@ -317,9 +317,9 @@ fn serializer_verdict(bytes: &[u8], opcode: u32) -> Reading {
         // The indirect-command-buffer creation. This device does have a reader
         // for it, and the gap map hid that for as long as the map was keyed on
         // how a record *arrives*: `decode_icb_descriptor` is reached by object
-        // type through the type-7 object list rather than by opcode off the
+        // type through the object list as a serializer object rather than by opcode off the
         // command stream, so the 88 bytes never met their decoder here even
-        // though the decoder existed. They are the same bytes — the type-7 tag
+        // though the decoder existed. They are the same bytes — the serializer-object tag
         // is the opcode and the declared length is the record length, which is
         // what the decoder itself checks first.
         0x36 => shape(resource::decode_icb_descriptor(bytes), "serializer_icb"),
@@ -352,7 +352,7 @@ fn serializer_verdict(bytes: &[u8], opcode: u32) -> Reading {
         }
         // The IOSurface-backed texture and its `TextureDescriptor2` form. Only
         // the embedded descriptor is signed, for the reason in `body` above:
-        // what reaches this device for an IOSurface texture is the type-11
+        // what reaches this device for an IOSurface texture is the mapper-ref-texture
         // object-list descriptor, a different structure entirely.
         0x0c => body(bytes, narrow, false),
         0x39 => body(bytes, wide, true),

--- a/scripts/runtime-dead/README.md
+++ b/scripts/runtime-dead/README.md
@@ -250,7 +250,7 @@ reaches it, and each named the guest action that would take it:
 
 | file | why it is zero | the guest action that takes it |
 |---|---|---|
-| `runtime/icb/mod.rs` | already priced, five boots behind it | indirect command buffers, type-7 tag `0x36` |
+| `runtime/icb/mod.rs` | already priced, five boots behind it | indirect command buffers, serializer-object tag `0x36` |
 | `runtime/heap_query.rs` | Vulkan host has no Metal device, so it answers `NoMetalDevice` | `CmdHeapTextureSizeAndAlign`, child-FIFO config op `0x40` — `[MTLDevice heapTextureSizeAndAlignForDescriptor:]` |
 | `runtime/mipmap.rs` | a window drag creates no multi-mip textures | blit opcode `0x133 generateMipmaps` |
 | `runtime/plan/event_sync.rs` | pure planning behind `fence_exec`; same reason | Metal events and encoder fences, segment type 3 and the blit/compute/render fence fields |

--- a/scripts/vibrancy-latch-probe/drag-load.py
+++ b/scripts/vibrancy-latch-probe/drag-load.py
@@ -17,7 +17,7 @@ sequence of teleports.
 
 Both stressors run, because they are different ones. The drag is the reported
 trigger. The resize and the second app opening and closing are what a previous
-session measured as the thing that moves `type4_pages_stale` off zero — surface
+session measured as the thing that moves `backing_pages_stale` off zero — surface
 *reallocation*, which a window that only moves never does.
 
 Usage:

--- a/scripts/vibrancy-latch-probe/vibrancy-latch-probe.sh
+++ b/scripts/vibrancy-latch-probe/vibrancy-latch-probe.sh
@@ -176,7 +176,7 @@ LOAD_OFF=$(stat -c %s "$FAILLOG")
 # with no trust to arrange. `drag-load.py` drives that, and keeps the resize and
 # second-app churn alongside it because those are a different stressor: surface
 # *reallocation*, which a window that only moves never does, and which a previous
-# session measured as the thing that moves `type4_pages_stale` off zero.
+# session measured as the thing that moves `backing_pages_stale` off zero.
 "$REPO_ROOT/scripts/vibrancy-latch-probe/drag-load.py" \
   --seconds "$LOAD_SECONDS" --guest "$GUEST" --app Safari --qmp "$QMP_SOCK" \
   >"$WORK/load.count" 2>"$WORK/load.err" &


### PR DESCRIPTION
The codebase called the guest's object-list tags `type-4`, `type-5`, `type-11` and `TYPE7` in about 1400 places, which is what you write while the contract is still being recovered. It is recovered, so this names them.

The tag is Apple's `APVObjectType`, from the mangled symbol of the one writer, `AppleParavirtResourceHeap::addObject(APVObjectType, unsigned int, unsigned int, void const*)`. Every constant reaching that call was read out of the guest's own driver — extracted from the provisioned 13.6 image this project boots — and cross-checked against the tag the device side dispatches on in `PGResourceManager::createObject`, on both 13.6 and the current host. So: 1 buffer, 2 and 3 texture, 4 backing, 5 ref texture, 6 function, 7 serializer object, 8 texture view, 11 mapper-ref texture.

Two findings the names now carry:

The rails use disjoint halves of one tag space, because the guests load different drivers — an x86 guest `AppleParavirtGPU`, an arm64 guest `AppleParavirtGPUIOGPUFamily`. That is why 4 and 5 never appear on arm and 11 never on x86, and why neither absence is a decode gap. The old comments called this "the x86 type-4 present path" without saying why it was x86's.

Tag 3 is not a "variant" of 2. Both are one `APVObjectTexture` landing on `PGSinglePlaneTextureResource`; the host sets that resource's `_generateMipmaps` exactly when the tag is 3, and then reads one 36-byte level record instead of the count the descriptor's leading 14-bit field states. A 3 is a texture whose base level the guest describes and whose chain the host generates — identical in Ventura and on the current host.

`OBJECT_TYPE_TEXTURE_VARIANT` becomes `OBJECT_TYPE_TEXTURE_GENERATE_MIPMAPS`, `OBJECT_TYPE_TYPE7` becomes `OBJECT_TYPE_SERIALIZER_OBJECT`, and the tag table plus its provenance lands in the owner, `runtime::decode::resource`. The serializer-object subtypes get the same treatment: the host requires tag 7 and then dispatches on the descriptor's first dword, which confirms the sampler, depth-stencil and pipeline values this crate already had and names the two it has no reader for.

Identifiers, observability slugs, doc comments and test names all move together; slugs renamed here are renamed in the probe scripts that grep them. Pure rename: no decode, no dispatch and no wire constant changed.

Verified: fmt, clippy and `cargo doc` clean of new findings on the workspace; 1333 lib tests, and the full `--all-targets` suite serially on both the default Metal rail and `backend-vulkan` (2181 + integration, 0 failed); the `backend-metal,backend-vulkan` both-rails configuration still checks. No VM or conformance run: nothing here can change guest-visible behaviour.
