### PR TITLE
Upgrade to latest metal2vulkan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "metal2vulkan"
 version = "0.1.0"
-source = "git+https://github.com/steelbrain/metal2vulkan.git?rev=47009b2693757b8d51b907bff37ce4fa4793293f#47009b2693757b8d51b907bff37ce4fa4793293f"
+source = "git+https://github.com/steelbrain/metal2vulkan.git?rev=42a7998514681fea7e955d789e084344b8fcbb51#42a7998514681fea7e955d789e084344b8fcbb51"
 dependencies = [
  "spirv",
  "wait-timeout",

--- a/crates/reims-vgpu/Cargo.toml
+++ b/crates/reims-vgpu/Cargo.toml
@@ -68,7 +68,7 @@ reims-vgpu-contract = { path = "../reims-vgpu-contract" }
 reims-vgpu-observe = { path = "../reims-vgpu-observe" }
 ash = { version = "0.38", optional = true }
 # Always available for Linux MTLB→AIR→SPIR-V (encode path + probes).
-metal2vulkan = { git = "https://github.com/steelbrain/metal2vulkan.git", rev = "47009b2693757b8d51b907bff37ce4fa4793293f" }
+metal2vulkan = { git = "https://github.com/steelbrain/metal2vulkan.git", rev = "42a7998514681fea7e955d789e084344b8fcbb51" }
 winit = { version = "0.30", optional = true }
 ash-window = { version = "0.13", optional = true }
 raw-window-handle = { version = "0.6", optional = true }


### PR DESCRIPTION
Forty commits upstream. The ones this device can see are in reflection and emission: bindings no instruction reads are no longer shipped, a read that never samples no longer carries a sampler, each reflected resource is named once, the address table is read off the module rather than predicted, and a handful of emission decisions stop following hash-map iteration order, so a translation is now byte-stable across runs. The rest is internal — one dominator core instead of three, a revision-keyed structurizer cache, and typed declines where a phase used to report only its first contract break.

Our consumed surface is unchanged. Checked on all three arms (Metal, Vulkan, both), 1341 lib tests and every integration suite serially, including the MoltenVK engine suites that bind reflected static samplers and storage buffers. No live guest or conformance run yet.